### PR TITLE
Add CHANGELOG.md (Keep a Changelog)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to **svy** are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+`svy` adheres to [Semantic Versioning](https://semver.org/). Entries are written
+for readers — *what changed and why it matters* — not raw commit logs. Add each
+change under `[Unreleased]` in the same PR that makes it; on release, rename
+`[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
+
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+
+<!-- Also available when needed: ### Deprecated, ### Removed, ### Security -->
+
+## [0.18.2] — 2026-05-20
+
+First release tracked in this changelog. For the history prior to 0.18.2, see the
+[Git tags](https://github.com/samplics-org/svy/tags) and
+[GitHub Releases](https://github.com/samplics-org/svy/releases).
+
+<!-- Optional: backfill a few notable 0.18.2 highlights here. -->
+
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.18.2...HEAD
+[0.18.2]: https://github.com/samplics-org/svy/releases/tag/svy-v0.18.2


### PR DESCRIPTION
Adds a per-package `CHANGELOG.md` at the repo root as the source of truth for release highlights — updated in the same PR as each change, feeding PyPI + GitHub Releases. A unified "What's new" page in the docs will later render/aggregate the three libraries' changelogs (source stays with the code; docs holds only the rendered view). Anchored at the current version.