### PR TITLE
Add .mailmap to canonicalize author name

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Mamadou S Diallo <msdiallo@samplics.org> <msdiallo@samplics.org>


### PR DESCRIPTION
Adds a `.mailmap` so all commits under `msdiallo@samplics.org` display as **Mamadou S Diallo**, harmonizing a single merge commit that was authored as "Mamadou Saliou DIALLO". Non-destructive: no history rewrite, no SHA changes — git (`log`/`blame`/`shortlog`) and GitHub's contributor graph both honor `.mailmap`.