### PR TITLE
ci: run svy tests on every PR (required-check prerequisite)

### DIFF
--- a/.github/workflows/svy-tests.yml
+++ b/.github/workflows/svy-tests.yml
@@ -7,13 +7,11 @@ on:
       - "pyproject.toml"
       - "uv.lock"
       - ".github/workflows/svy-tests.yml"
+  # No path filter on PRs: these jobs are required status checks on main,
+  # so they must report on every PR (a path-filtered required check would
+  # leave non-matching PRs stuck waiting forever).
   pull_request:
     branches: [main]
-    paths:
-      - "packages/svy/**"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/workflows/svy-tests.yml"
 concurrency:
   group: ci-${{ github.ref }}-${{ github.workflow }}
   cancel-in-progress: true


### PR DESCRIPTION
Removes the path filter from the `pull_request` trigger in svy-tests.yml (push trigger keeps its filters). Prerequisite for making `Test svy (py3.11–3.14)` required status checks on `main`: a path-filtered required check would deadlock PRs that don't touch `packages/svy/**`. The suite is fast enough to run on every PR.