### PR TITLE
perf: estimation speedup — safe caches, benchmarks, Taylor kernel fast paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,11 @@ presentations/*/
 roadmap/
 roadmap.md
 specs/
-benchmarks/
+# Benchmark scripts are local-only by default (many depend on the gitignored WB
+# CSVs), but the self-contained Phase-A harness is tracked so it — and its
+# recorded baseline — travel with the branch to CI and other machines.
+**/benchmarks/*
+!packages/svy/benchmarks/bench_kernel.py
 examples/
 svy-old
 testwheels

--- a/makefile
+++ b/makefile
@@ -93,6 +93,28 @@ test-svy-rs:
 	@echo "▶ Testing svy-rs..."
 	cd $(PKG_SVY_RS) && uv run pytest
 
+# ====== Benchmarks & native Rust tests ======
+# The svy-rs crate builds the Python extension by default (pyo3/extension-module).
+# Host-native `cargo test`/`cargo bench` must drop that feature (--no-default-
+# features) so the binary links normally, and point pyo3 at the venv interpreter.
+.PHONY: test-svy-rs-cargo bench-svy-rs bench-svy bench
+PYO3_PYTHON := $(CURDIR)/.venv/bin/python
+
+test-svy-rs-cargo:
+	@echo "▶ Rust unit tests (svy-rs, host build)..."
+	cd $(PKG_SVY_RS) && PYO3_PYTHON=$(PYO3_PYTHON) cargo test --lib --no-default-features
+
+bench-svy-rs:
+	@echo "▶ Criterion kernel benches (svy-rs)..."
+	cd $(PKG_SVY_RS) && PYO3_PYTHON=$(PYO3_PYTHON) cargo bench --no-default-features
+
+bench-svy:
+	@echo "▶ Python end-to-end + direct-kernel benches..."
+	cd $(PKG_SVY) && uv run python benchmarks/bench_kernel.py
+
+bench: bench-svy-rs bench-svy
+	@echo "All benchmarks complete."
+
 # ====== svy (pure Python — the one we publish from this repo) ======
 .PHONY: build-svy
 build-svy:

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -46,6 +46,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -272,6 +284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -325,6 +343,58 @@ dependencies = [
  "chrono",
  "phf",
 ]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "compact_str"
@@ -388,6 +458,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1377,10 +1483,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "iter-read"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1770,7 +1896,7 @@ dependencies = [
  "http-body-util",
  "humantime",
  "hyper",
- "itertools",
+ "itertools 0.14.0",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
@@ -1794,6 +1920,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
@@ -1929,6 +2061,34 @@ checksum = "3daf8e3d4b712abe1d690838f6e29fb76b76ea19589c4afa39ec30e12f62af71"
 dependencies = [
  "array-init-cursor",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
 ]
 
 [[package]]
@@ -3339,6 +3499,7 @@ version = "0.9.0"
 dependencies = [
  "ahash",
  "approx",
+ "criterion",
  "faer",
  "ndarray",
  "numpy",
@@ -3468,6 +3629,16 @@ checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -717,9 +717,9 @@ dependencies = [
 
 [[package]]
 name = "ethnum"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca81e6b4777c89fd810c25a4be2b1bd93ea034fbe58e6a75216a34c6b82c539b"
+checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
 
 [[package]]
 name = "event-listener"

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -3507,6 +3507,7 @@ dependencies = [
  "pyo3",
  "pyo3-polars",
  "rayon",
+ "rustc-hash",
  "thiserror 2.0.17",
 ]
 

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -28,6 +28,7 @@ ahash = "0.8"
 numpy = "0.26"
 ndarray = { version = "0.16", features = ["rayon"] }
 rayon = "1.12"
+rustc-hash = "2.1"
 thiserror = "2.0"
 approx = "0.5.1"
 

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -8,10 +8,19 @@ homepage = "https://gitlab.com/samplics/svy"
 
 [lib]
 name = "_internal"
-crate-type = ["cdylib"]
+# cdylib: the Python extension module (what maturin builds into the wheel).
+# rlib:   lets `cargo test`/`cargo bench` and the criterion benches link the
+#         crate as an ordinary Rust library.
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.26", features = ["abi3-py311", "extension-module", "generate-import-lib"] }
+# `extension-module` is intentionally NOT listed here — it is pulled in only
+# through this crate's own `extension-module` feature (default-on, and also
+# passed explicitly by maturin via pyproject.toml). Keeping it off the direct
+# dependency lets host builds drop it with `--no-default-features`, so
+# `cargo test`/`cargo bench` link a normal binary instead of failing on
+# undefined libpython symbols. See the [features] section below.
+pyo3 = { version = "0.26", features = ["abi3-py311", "generate-import-lib"] }
 pyo3-polars = { version = "0.25", features = ["derive"] }
 polars = { version = "0.52", default-features = false, features = ["dtype-categorical"] }
 faer = "0.24"
@@ -25,3 +34,16 @@ approx = "0.5.1"
 [features]
 extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
+
+[dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
+
+# Criterion micro-benchmarks for the estimation kernel. Run WITHOUT the
+# extension-module feature so the bench binary links as a normal executable:
+#   PYO3_PYTHON=../../.venv/bin/python cargo bench --no-default-features
+# (see `make bench-svy-rs`). Measures the individual functions Phase B/C touch
+# — string vs integer design indexing, fused point estimates, variance passes —
+# in isolation, free of Python/PyO3 marshalling noise.
+[[bench]]
+name = "kernel_bench"
+harness = false

--- a/packages/svy-rs/benches/kernel_bench.rs
+++ b/packages/svy-rs/benches/kernel_bench.rs
@@ -1,0 +1,170 @@
+// benches/kernel_bench.rs
+//
+// Criterion micro-benchmarks for the Taylor estimation kernel, measured on
+// native polars `ChunkedArray`s with NO Python/PyO3 boundary. This isolates the
+// exact functions the PERF_PLAN Phase B/C optimizations touch, so a change to
+// (say) the design-indexing hash or the point-estimate summation loop can be
+// proven in nanoseconds-per-element instead of being lost in end-to-end noise.
+//
+// Run (host build, extension-module off so it links as a normal binary):
+//   PYO3_PYTHON=../../.venv/bin/python cargo bench --no-default-features
+// or `make bench-svy-rs` from the repo root.
+//
+// Design shape mirrors the WB workload used in the Python harness and the
+// PERF_PLAN baseline table: ~20 strata, ~50 PSUs per stratum. Inputs are
+// single-chunk and null-free (the common post-`prepare_data` case).
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use polars::prelude::*;
+
+use _internal::estimation::taylor::{
+    index_categorical, index_categorical_pair, point_estimate_mean, scores_mean, srs_variance_mean,
+    taylor_variance,
+};
+
+const N_STRATA: usize = 20;
+const PSU_PER_STRATUM: usize = 50;
+const SIZES: [usize; 2] = [100_000, 1_000_000];
+
+// ── Deterministic input builders (no RNG → stable across runs) ──────────────
+
+fn make_y(n: usize) -> Float64Chunked {
+    let v: Vec<f64> = (0..n).map(|i| 100.0 + (i % 1000) as f64 * 0.1).collect();
+    Float64Chunked::from_slice("y".into(), &v)
+}
+
+fn make_w(n: usize) -> Float64Chunked {
+    let v: Vec<f64> = (0..n).map(|i| 0.5 + (i % 7) as f64 * 0.25).collect();
+    Float64Chunked::from_slice("w".into(), &v)
+}
+
+fn make_strata(n: usize, long: bool) -> StringChunked {
+    let owned: Vec<String> = (0..n)
+        .map(|i| {
+            let s = i % N_STRATA;
+            if long {
+                format!("stratum_region_{s}")
+            } else {
+                s.to_string()
+            }
+        })
+        .collect();
+    let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+    StringChunked::from_slice("s".into(), &refs)
+}
+
+fn make_psu(n: usize, long: bool) -> StringChunked {
+    let owned: Vec<String> = (0..n)
+        .map(|i| {
+            let p = i % PSU_PER_STRATUM;
+            if long {
+                format!("enumeration_area_{p}")
+            } else {
+                p.to_string()
+            }
+        })
+        .collect();
+    let refs: Vec<&str> = owned.iter().map(String::as_str).collect();
+    StringChunked::from_slice("p".into(), &refs)
+}
+
+// ── Design indexing (Phase B FxHashMap / Phase C integer codes target) ──────
+
+fn bench_index_categorical(c: &mut Criterion) {
+    let mut g = c.benchmark_group("index_categorical");
+    g.sample_size(20);
+    for &n in &SIZES {
+        for &long in &[false, true] {
+            let strata = make_strata(n, long);
+            let id = format!("{n}/{}", if long { "long" } else { "short" });
+            g.throughput(Throughput::Elements(n as u64));
+            g.bench_function(BenchmarkId::from_parameter(id), |b| {
+                b.iter(|| black_box(index_categorical(black_box(&strata))));
+            });
+        }
+    }
+    g.finish();
+}
+
+fn bench_index_categorical_pair(c: &mut Criterion) {
+    let mut g = c.benchmark_group("index_categorical_pair");
+    g.sample_size(20);
+    for &n in &SIZES {
+        for &long in &[false, true] {
+            let strata = make_strata(n, long);
+            let psu = make_psu(n, long);
+            let id = format!("{n}/{}", if long { "long" } else { "short" });
+            g.throughput(Throughput::Elements(n as u64));
+            g.bench_function(BenchmarkId::from_parameter(id), |b| {
+                b.iter(|| black_box(index_categorical_pair(black_box(&strata), black_box(&psu))));
+            });
+        }
+    }
+    g.finish();
+}
+
+// ── Point estimates & scores (Phase B fused no-null loop target) ────────────
+
+fn bench_point_estimates(c: &mut Criterion) {
+    let mut g = c.benchmark_group("point_estimate_mean");
+    g.sample_size(20);
+    for &n in &SIZES {
+        let y = make_y(n);
+        let w = make_w(n);
+        g.throughput(Throughput::Elements(n as u64));
+        g.bench_function(BenchmarkId::new("point", n), |b| {
+            b.iter(|| black_box(point_estimate_mean(black_box(&y), black_box(&w)).unwrap()));
+        });
+        g.bench_function(BenchmarkId::new("scores", n), |b| {
+            b.iter(|| black_box(scores_mean(black_box(&y), black_box(&w)).unwrap()));
+        });
+        g.bench_function(BenchmarkId::new("srs_variance", n), |b| {
+            b.iter(|| black_box(srs_variance_mean(black_box(&y), black_box(&w)).unwrap()));
+        });
+    }
+    g.finish();
+}
+
+// ── Full variance pass (indexing + stratum accumulation end-to-kernel) ──────
+
+fn bench_taylor_variance(c: &mut Criterion) {
+    let mut g = c.benchmark_group("taylor_variance_mean_strat_cluster");
+    g.sample_size(20);
+    for &n in &SIZES {
+        let y = make_y(n);
+        let w = make_w(n);
+        let scores = scores_mean(&y, &w).unwrap();
+        for &long in &[false, true] {
+            let strata = make_strata(n, long);
+            let psu = make_psu(n, long);
+            let id = format!("{n}/{}", if long { "long" } else { "short" });
+            g.throughput(Throughput::Elements(n as u64));
+            g.bench_function(BenchmarkId::from_parameter(id), |b| {
+                b.iter(|| {
+                    black_box(
+                        taylor_variance(
+                            black_box(&scores),
+                            Some(&strata),
+                            Some(&psu),
+                            None,
+                            None,
+                            None,
+                            None,
+                        )
+                        .unwrap(),
+                    )
+                });
+            });
+        }
+    }
+    g.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_index_categorical,
+    bench_index_categorical_pair,
+    bench_point_estimates,
+    bench_taylor_variance,
+);
+criterion_main!(benches);

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -1,7 +1,7 @@
 // src/estimation/taylor.rs
 
 use polars::prelude::*;
-use std::collections::HashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 // ============================================================================
 // Enums & Config
@@ -47,20 +47,52 @@ impl SvyQuantileMethod {
 // Point Estimates
 // ============================================================================
 
+/// Contiguous, null-free slices of two columns, if available.
+///
+/// After `prepare_data` the y/weight columns are typically single-chunk and
+/// null-free, so this is the common case. When it holds, callers take a
+/// branch-free fused loop over `&[f64]` instead of iterating `Option<f64>` and
+/// checking the validity bitmap per element. Returns `None` (→ Option-iterator
+/// fallback with identical semantics) when either column is chunked or has any
+/// null; `cont_slice()` returns `Err` in those cases rather than panicking.
+#[inline]
+fn cont_pair<'a>(a: &'a Float64Chunked, b: &'a Float64Chunked) -> Option<(&'a [f64], &'a [f64])> {
+    if a.null_count() == 0 && b.null_count() == 0 {
+        if let (Ok(sa), Ok(sb)) = (a.cont_slice(), b.cont_slice()) {
+            return Some((sa, sb));
+        }
+    }
+    None
+}
+
 pub fn point_estimate_mean(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult<f64> {
-    let sum_wy: f64 = y
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(yi, wi)| Some(yi? * wi?))
-        .sum();
-    let sum_w: f64 = y
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(yi, wi)| {
-            yi?;
-            wi
-        })
-        .sum();
+    // Fast path: single fused pass over contiguous null-free slices. Summation
+    // order is unchanged (sequential 0..n; f64 add is not auto-vectorized
+    // without fast-math), so the result is bit-identical to the fallback.
+    let (sum_wy, sum_w) = if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        let mut sum_w = 0.0f64;
+        for i in 0..ys.len() {
+            sum_wy += ys[i] * ws[i];
+            sum_w += ws[i];
+        }
+        (sum_wy, sum_w)
+    } else {
+        let sum_wy: f64 = y
+            .iter()
+            .zip(weights.iter())
+            .filter_map(|(yi, wi)| Some(yi? * wi?))
+            .sum();
+        let sum_w: f64 = y
+            .iter()
+            .zip(weights.iter())
+            .filter_map(|(yi, wi)| {
+                yi?;
+                wi
+            })
+            .sum();
+        (sum_wy, sum_w)
+    };
 
     if sum_w == 0.0 {
         return Err(PolarsError::ComputeError("Sum of weights is zero".into()));
@@ -94,6 +126,13 @@ pub fn point_estimate_mean_domain(
 }
 
 pub fn point_estimate_total(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult<f64> {
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        for i in 0..ys.len() {
+            sum_wy += ys[i] * ws[i];
+        }
+        return Ok(sum_wy);
+    }
     Ok(y.iter()
         .zip(weights.iter())
         .filter_map(|(yi, wi)| Some(yi? * wi?))
@@ -117,16 +156,32 @@ pub fn point_estimate_ratio(
     x: &Float64Chunked,
     weights: &Float64Chunked,
 ) -> PolarsResult<f64> {
-    let sum_wy: f64 = y
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(yi, wi)| Some(yi? * wi?))
-        .sum();
-    let sum_wx: f64 = x
-        .iter()
-        .zip(weights.iter())
-        .filter_map(|(xi, wi)| Some(xi? * wi?))
-        .sum();
+    // Fast path only when y, x and w are all contiguous and null-free.
+    let fast = match (cont_pair(y, weights), x.null_count() == 0) {
+        (Some((ys, ws)), true) => x.cont_slice().ok().map(|xs| (ys, ws, xs)),
+        _ => None,
+    };
+    let (sum_wy, sum_wx) = if let Some((ys, ws, xs)) = fast {
+        let mut sum_wy = 0.0f64;
+        let mut sum_wx = 0.0f64;
+        for i in 0..ys.len() {
+            sum_wy += ys[i] * ws[i];
+            sum_wx += xs[i] * ws[i];
+        }
+        (sum_wy, sum_wx)
+    } else {
+        let sum_wy: f64 = y
+            .iter()
+            .zip(weights.iter())
+            .filter_map(|(yi, wi)| Some(yi? * wi?))
+            .sum();
+        let sum_wx: f64 = x
+            .iter()
+            .zip(weights.iter())
+            .filter_map(|(xi, wi)| Some(xi? * wi?))
+            .sum();
+        (sum_wy, sum_wx)
+    };
 
     if sum_wx == 0.0 {
         return Err(PolarsError::ComputeError(
@@ -331,19 +386,36 @@ pub fn weighted_quantile_chunked(
 // ============================================================================
 
 pub fn scores_mean(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult<Float64Chunked> {
-    // Single pass: accumulate sum_wy, sum_w and collect (y,w) pairs simultaneously.
-    // Avoids the 3 separate iterations that the previous point_estimate_mean + sum_w + score
-    // build pattern required.
+    // Fast path: contiguous null-free slices → two branch-free passes and a
+    // plain Vec<f64> output, skipping the Vec<Option<(f64,f64)>> the fallback
+    // must allocate. Summation order is unchanged, so results are bit-identical.
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        let mut sum_w = 0.0f64;
+        for i in 0..ys.len() {
+            sum_wy += ys[i] * ws[i];
+            sum_w += ws[i];
+        }
+        if sum_w == 0.0 {
+            return Err(PolarsError::ComputeError("Sum of weights is zero".into()));
+        }
+        let est = sum_wy / sum_w;
+        let scores: Vec<f64> = (0..ys.len()).map(|i| (ws[i] / sum_w) * (ys[i] - est)).collect();
+        return Ok(Float64Chunked::from_slice("scores".into(), &scores));
+    }
+
+    // Fallback: single pass accumulating sums while collecting (y,w) pairs so
+    // null positions are preserved in the output.
     let n = y.len();
     let mut sum_wy = 0.0f64;
-    let mut sum_w  = 0.0f64;
+    let mut sum_w = 0.0f64;
     let mut pairs: Vec<Option<(f64, f64)>> = Vec::with_capacity(n);
 
     for (yi, wi) in y.iter().zip(weights.iter()) {
         match (yi, wi) {
             (Some(yv), Some(wv)) => {
                 sum_wy += yv * wv;
-                sum_w  += wv;
+                sum_w += wv;
                 pairs.push(Some((yv, wv)));
             }
             _ => pairs.push(None),
@@ -596,7 +668,11 @@ pub fn scores_median_domain(
 
 #[doc(hidden)] // internal; exposed only so criterion benches can measure it
 pub fn index_categorical(col: &StringChunked) -> (Vec<u32>, u32) {
-    let mut map: HashMap<&str, u32> = HashMap::new();
+    // FxHashMap (non-cryptographic) instead of the default SipHash map: a pure
+    // hot-path speedup. Codes are assigned in first-appearance order via
+    // `next_idx`, independent of the map's internal order, so the output is
+    // byte-for-byte identical to the SipHash version.
+    let mut map: FxHashMap<&str, u32> = FxHashMap::default();
     let mut next_idx = 0u32;
     let indices: Vec<u32> = col
         .iter()
@@ -618,7 +694,9 @@ pub fn index_categorical(col: &StringChunked) -> (Vec<u32>, u32) {
 /// survey package and glm.rs, which key PSUs on (stratum, psu).
 #[doc(hidden)] // internal; exposed only so criterion benches can measure it
 pub fn index_categorical_pair(a: &StringChunked, b: &StringChunked) -> (Vec<u32>, u32) {
-    let mut map: HashMap<(&str, &str), u32> = HashMap::new();
+    // FxHashMap: see index_categorical — codes are first-appearance order, so
+    // the map's hash function does not affect the output.
+    let mut map: FxHashMap<(&str, &str), u32> = FxHashMap::default();
     let mut next_idx = 0u32;
     let indices: Vec<u32> = a
         .iter()
@@ -636,7 +714,8 @@ pub fn index_categorical_pair(a: &StringChunked, b: &StringChunked) -> (Vec<u32>
 }
 
 fn reindex_within_subset(raw: &[u32]) -> (Vec<u32>, u32) {
-    let mut map: HashMap<u32, u32> = HashMap::new();
+    // FxHashMap: codes assigned in first-appearance order, hash-independent.
+    let mut map: FxHashMap<u32, u32> = FxHashMap::default();
     let mut next_idx = 0u32;
     let indices: Vec<u32> = raw
         .iter()
@@ -1122,11 +1201,13 @@ pub fn degrees_of_freedom(
         }
         // No strata, with PSU: df = n_unique_active_psus - 1
         let psu_col = psu.unwrap();
-        let mut seen = std::collections::HashSet::new();
+        // Borrow &str into the set instead of allocating a String per row; df is
+        // an order-independent unique count, so the result is unchanged.
+        let mut seen: FxHashSet<&str> = FxHashSet::default();
         for (opt_p, &act) in psu_col.iter().zip(active.iter()) {
             if act {
                 if let Some(p) = opt_p {
-                    seen.insert(p.to_string());
+                    seen.insert(p);
                 }
             }
         }
@@ -1138,16 +1219,13 @@ pub fn degrees_of_freedom(
     match psu {
         Some(psu_col) => {
             // Stratified + clustered: df = sum_h(n_active_psus_h - 1)
-            // Count unique active PSUs per stratum
-            let mut stratum_psus: HashMap<String, std::collections::HashSet<String>> =
-                HashMap::new();
+            // Count unique active PSUs per stratum. Keys/values borrow &str from
+            // the columns (no per-row String alloc); counts are order-independent.
+            let mut stratum_psus: FxHashMap<&str, FxHashSet<&str>> = FxHashMap::default();
             for ((opt_s, opt_p), &act) in strata_col.iter().zip(psu_col.iter()).zip(active.iter()) {
                 if act {
                     if let (Some(s), Some(p)) = (opt_s, opt_p) {
-                        stratum_psus
-                            .entry(s.to_string())
-                            .or_default()
-                            .insert(p.to_string());
+                        stratum_psus.entry(s).or_default().insert(p);
                     }
                 }
             }
@@ -1159,11 +1237,11 @@ pub fn degrees_of_freedom(
         }
         None => {
             // Stratified, no PSU: df = sum_h(n_active_h - 1)
-            let mut stratum_counts: HashMap<String, u32> = HashMap::new();
+            let mut stratum_counts: FxHashMap<&str, u32> = FxHashMap::default();
             for (opt_s, &act) in strata_col.iter().zip(active.iter()) {
                 if act {
                     if let Some(s) = opt_s {
-                        *stratum_counts.entry(s.to_string()).or_insert(0) += 1;
+                        *stratum_counts.entry(s).or_insert(0) += 1;
                     }
                 }
             }
@@ -1278,7 +1356,23 @@ fn weighted_s2(y: &[f64], wn: &[f64]) -> f64 {
 }
 
 pub fn srs_variance_mean(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult<f64> {
-    // Only use observations where both y and w are non-null
+    // Fast path: contiguous null-free slices are used directly, skipping the
+    // yv/wv copies the fallback builds. Same accumulation order → bit-identical.
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let n = ys.len() as f64;
+        if n < 2.0 {
+            return Ok(f64::NAN);
+        }
+        let sum_w: f64 = ws.iter().sum();
+        if sum_w <= 0.0 {
+            return Ok(f64::NAN);
+        }
+        let wn: Vec<f64> = ws.iter().map(|w| w / sum_w).collect();
+        let s2_y = weighted_s2(ys, &wn);
+        return Ok((s2_y / n) * (1.0 - (n / sum_w)));
+    }
+
+    // Fallback: only use observations where both y and w are non-null.
     let mut yv = Vec::new();
     let mut wv = Vec::new();
     for (yi, wi) in y.into_iter().zip(weights.into_iter()) {

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -594,7 +594,8 @@ pub fn scores_median_domain(
 // Variance Helpers (Indexing & Math)
 // ============================================================================
 
-fn index_categorical(col: &StringChunked) -> (Vec<u32>, u32) {
+#[doc(hidden)] // internal; exposed only so criterion benches can measure it
+pub fn index_categorical(col: &StringChunked) -> (Vec<u32>, u32) {
     let mut map: HashMap<&str, u32> = HashMap::new();
     let mut next_idx = 0u32;
     let indices: Vec<u32> = col
@@ -615,7 +616,8 @@ fn index_categorical(col: &StringChunked) -> (Vec<u32>, u32) {
 /// so PSU labels reused across strata (e.g. psu "1" in every stratum, as in
 /// NHANES/DHS-style data) are treated as distinct PSUs. This matches R's
 /// survey package and glm.rs, which key PSUs on (stratum, psu).
-fn index_categorical_pair(a: &StringChunked, b: &StringChunked) -> (Vec<u32>, u32) {
+#[doc(hidden)] // internal; exposed only so criterion benches can measure it
+pub fn index_categorical_pair(a: &StringChunked, b: &StringChunked) -> (Vec<u32>, u32) {
     let mut map: HashMap<(&str, &str), u32> = HashMap::new();
     let mut next_idx = 0u32;
     let indices: Vec<u32> = a

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -26,6 +26,20 @@ use crate::estimation::taylor::{
     weighted_median, weighted_median_domain,
 };
 
+/// Convert the incoming Python DataFrame and ensure one chunk per column.
+///
+/// After `prepare_data` the frame is usually already single-chunk, but scaled or
+/// concatenated inputs can arrive fragmented. A single rechunk here (one copy)
+/// lets every downstream kernel take its contiguous `cont_slice` fast path
+/// instead of the per-element chunked-iterator fallback.
+fn into_contiguous(data: PyDataFrame) -> DataFrame {
+    let mut df: DataFrame = data.into();
+    if df.first_col_n_chunks() > 1 {
+        df.as_single_chunk_par();
+    }
+    df
+}
+
 // ============================================================================
 // Mean
 // ============================================================================
@@ -45,7 +59,7 @@ pub fn taylor_mean(
     by_col: Option<String>,
     singleton_method: Option<String>,
 ) -> PyResult<PyDataFrame> {
-    let df: DataFrame = data.into();
+    let df = into_contiguous(data);
 
     if by_col.is_none() {
         let result = compute_mean_ungrouped(
@@ -165,7 +179,7 @@ pub fn taylor_total(
     by_col: Option<String>,
     singleton_method: Option<String>,
 ) -> PyResult<PyDataFrame> {
-    let df: DataFrame = data.into();
+    let df = into_contiguous(data);
     if by_col.is_none() {
         let result = compute_total_ungrouped(
             &df, &value_col, &weight_col,
@@ -284,7 +298,7 @@ pub fn taylor_ratio(
     by_col: Option<String>,
     singleton_method: Option<String>,
 ) -> PyResult<PyDataFrame> {
-    let df: DataFrame = data.into();
+    let df = into_contiguous(data);
     if by_col.is_none() {
         let result = compute_ratio_ungrouped(
             &df, &numerator_col, &denominator_col, &weight_col,
@@ -404,7 +418,7 @@ pub fn taylor_prop(
     by_col: Option<String>,
     singleton_method: Option<String>,
 ) -> PyResult<PyDataFrame> {
-    let df: DataFrame = data.into();
+    let df = into_contiguous(data);
     if by_col.is_none() {
         let result = compute_prop_ungrouped(
             &df, &value_col, &weight_col,
@@ -574,7 +588,7 @@ pub fn taylor_median(
     singleton_method: Option<String>,
     quantile_method: Option<String>,
 ) -> PyResult<PyDataFrame> {
-    let df: DataFrame = data.into();
+    let df = into_contiguous(data);
     let q_method = quantile_method
         .as_deref()
         .map(SvyQuantileMethod::from_str)

--- a/packages/svy-rs/src/lib.rs
+++ b/packages/svy-rs/src/lib.rs
@@ -2,7 +2,11 @@
 use pyo3::prelude::*;
 
 mod categorical;
-mod estimation;
+// `pub` so the criterion benches in benches/ (a separate crate that links this
+// one as an rlib) can reach the kernel functions. The crate's real public
+// surface is the `_internal` PyModule below; these Rust-level items are only
+// consumed by benches and integration tests.
+pub mod estimation;
 mod regression;
 mod rng;
 mod sampling;

--- a/packages/svy/benchmarks/bench_kernel.py
+++ b/packages/svy/benchmarks/bench_kernel.py
@@ -1,0 +1,203 @@
+"""Self-contained estimation benchmark harness (PERF_PLAN Phase A).
+
+Two layers, one script:
+
+  * end-to-end  — ms/call for mean/total/ratio/by/domain/replication/tabulate,
+    at a small and a large row count, through the full Python + PyO3 + Rust
+    stack. This is the number a user actually feels.
+  * direct-kernel — calls `_internal.taylor_mean` straight, isolating the Rust
+    kernel + marshalling from Python prep: no-design vs short-label vs
+    long-label vs a deliberately fragmented (32-chunk) frame.
+
+Unlike the older profile_estimation.py / bench_estimation.py, this generates
+its own synthetic survey data (no dependency on the gitignored WB CSVs), so it
+runs anywhere and in CI. The design shape matches the PERF_PLAN baseline:
+~20 strata (geo1 x urbrur), ~50 PSUs/stratum.
+
+Each case prints a machine-readable line so before/after diffs are scriptable:
+
+    BENCH\t<label>\t<rows>\t<ms>
+
+Usage:
+    uv run python benchmarks/bench_kernel.py                 # 32k + 1M
+    uv run python benchmarks/bench_kernel.py --rows 32000    # one size
+    uv run python benchmarks/bench_kernel.py --reps 9 --reps-large 5
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import numpy as np
+import polars as pl
+
+from svy_rs import _internal
+
+import svy
+
+from svy import Design, RepWeights, Sample
+
+
+N_STRATA = 20  # geo1 (10) x urbrur (2)
+PSU_PER_STRATUM = 50
+
+
+# ── Synthetic data ──────────────────────────────────────────────────────────
+
+
+def gen_data(n_rows: int, *, n_reps: int = 0, seed: int = 42) -> pl.DataFrame:
+    """A survey-shaped frame: 2-column stratum, clustered PSUs, weight, y, x,
+    a low-cardinality `by` variable, a domain source, and optional replicate
+    weights. Deterministic for a given (n_rows, seed)."""
+    rng = np.random.default_rng(seed)
+    s = rng.integers(0, N_STRATA, n_rows)  # stratum index
+    p = rng.integers(0, PSU_PER_STRATUM, n_rows)  # PSU within stratum (reused labels)
+
+    cols = {
+        "_s": s,
+        "_p": p,
+        "hhweight": rng.uniform(0.5, 3.0, n_rows),
+        "tot_exp": np.clip(rng.normal(1000.0, 300.0, n_rows), 0.0, None),
+        "hhsize": rng.integers(1, 9, n_rows).astype(float),
+        "sex": rng.integers(1, 3, n_rows),  # by: 2 levels
+        "region": rng.integers(0, 5, n_rows),  # domain source: 5 levels
+    }
+    # Replicate weights: shape only (values need not be statistically valid to
+    # exercise the replicate matrix pass).
+    for k in range(n_reps):
+        cols[f"rep_{k + 1}"] = cols["hhweight"] * rng.gamma(2.0, 0.5, n_rows)
+
+    df = pl.DataFrame(cols).with_columns(
+        ("geo" + (pl.col("_s") // 2).cast(pl.String)).alias("geo1"),  # 10 distinct
+        (pl.col("_s") % 2).cast(pl.String).alias("urbrur"),  # 2 distinct
+        ("ea" + pl.col("_p").cast(pl.String)).alias("ea"),  # 50, nested in stratum
+        pl.col("sex").cast(pl.String),
+    )
+    return df.drop("_s", "_p").rechunk()  # single chunk: chunking is a controlled variable
+
+
+# ── Timing ──────────────────────────────────────────────────────────────────
+
+
+def best_ms(fn, reps: int) -> float:
+    """Warm once, then return best-of-`reps` wall-clock in milliseconds."""
+    fn()
+    best = float("inf")
+    for _ in range(reps):
+        t0 = time.perf_counter()
+        fn()
+        best = min(best, time.perf_counter() - t0)
+    return best * 1000.0
+
+
+def emit(label: str, rows: int, ms: float) -> None:
+    print(f"BENCH\t{label}\t{rows}\t{ms:.3f}")
+
+
+# ── End-to-end cases (full Python + PyO3 + Rust) ────────────────────────────
+
+
+def run_end_to_end(n_rows: int, reps: int, n_reps: int) -> None:
+    df = gen_data(n_rows, n_reps=n_reps)
+
+    design = Design(stratum=("geo1", "urbrur"), psu="ea", wgt="hhweight")
+    sample = Sample(data=df, design=design)
+    est = sample.estimation
+
+    cases = {
+        "mean/strat+cluster": lambda: est.mean(y="tot_exp"),
+        "total/strat+cluster": lambda: est.total(y="tot_exp"),
+        "ratio/strat+cluster": lambda: est.ratio(y="tot_exp", x="hhsize"),
+        "mean/by=sex": lambda: est.mean(y="tot_exp", by="sex"),
+        "mean/domain(region==0)": lambda: est.mean(y="tot_exp", where=svy.col("region") == 0),
+    }
+    for label, fn in cases.items():
+        emit(label, n_rows, best_ms(fn, reps))
+
+    # Replication path (matrix pass scales differently from Taylor).
+    if n_reps > 0:
+        rep_design = Design(
+            stratum=("geo1", "urbrur"),
+            psu="ea",
+            wgt="hhweight",
+            rep_wgts=RepWeights(
+                method=svy.EstimationMethod.BOOTSTRAP, prefix="rep_", n_reps=n_reps
+            ),
+        )
+        rep_sample = Sample(data=df, design=rep_design)
+        rep_est = rep_sample.estimation
+        emit(
+            f"mean/replication(R={n_reps})",
+            n_rows,
+            best_ms(lambda: rep_est.mean(y="tot_exp", method="replication"), reps),
+        )
+
+    # One tabulate case (categorical path).
+    emit(
+        "tabulate/sex",
+        n_rows,
+        best_ms(lambda: sample.categorical.tabulate("sex"), reps),
+    )
+
+
+# ── Direct-kernel probe (isolates Rust kernel + marshalling) ────────────────
+
+
+def run_direct_kernel(n_rows: int, reps: int) -> None:
+    rng = np.random.default_rng(7)
+    strata_i = rng.integers(0, N_STRATA, n_rows)
+    psu_i = rng.integers(0, PSU_PER_STRATUM, n_rows)
+    y = rng.normal(100.0, 20.0, n_rows)
+    w = rng.uniform(0.5, 2.0, n_rows)
+
+    base = pl.DataFrame({"y": y, "w": w}).rechunk()
+    df_short = base.with_columns(
+        pl.Series("s", strata_i.astype("U3")),
+        pl.Series("p", psu_i.astype("U3")),
+    ).rechunk()
+    df_long = base.with_columns(
+        pl.Series("s", np.char.add("stratum_region_", strata_i.astype("U3"))),
+        pl.Series("p", np.char.add("enumeration_area_", psu_i.astype("U4"))),
+    ).rechunk()
+    # Deliberately fragmented input (32 chunks) to measure the chunking penalty.
+    n32 = n_rows // 32 or 1
+    df_chunked = pl.concat([df_short.slice(i * n32, n32) for i in range(32)], rechunk=False)
+
+    def call(df, s, p):
+        return lambda: _internal.taylor_mean(df, "y", "w", s, p, None, None, None, None, None)
+
+    emit("kernel/no-design", n_rows, best_ms(call(base, None, None), reps))
+    emit("kernel/short-labels", n_rows, best_ms(call(df_short, "s", "p"), reps))
+    emit("kernel/long-labels", n_rows, best_ms(call(df_long, "s", "p"), reps))
+    emit("kernel/short-32chunks", n_rows, best_ms(call(df_chunked, "s", "p"), reps))
+
+
+# ── Driver ──────────────────────────────────────────────────────────────────
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "--rows",
+        type=int,
+        nargs="+",
+        default=[32_000, 1_000_000],
+        help="row counts to benchmark (default: 32000 1000000)",
+    )
+    ap.add_argument("--reps", type=int, default=9, help="best-of-N reps at small sizes")
+    ap.add_argument("--reps-large", type=int, default=5, help="best-of-N reps at >=1M rows")
+    ap.add_argument("--n-reps", type=int, default=40, help="replicate weights for the rep path")
+    args = ap.parse_args()
+
+    print(f"svy {svy.__version__}  |  columns tab-separated: BENCH<TAB>label<TAB>rows<TAB>ms\n")
+    for n_rows in args.rows:
+        reps = args.reps_large if n_rows >= 1_000_000 else args.reps
+        print(f"# ── {n_rows:,} rows (best of {reps}) ──")
+        run_end_to_end(n_rows, reps, args.n_reps)
+        run_direct_kernel(n_rows, reps)
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -42,7 +42,10 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 # Cache for design.specified_fields() keyed on id(design).
-# Stores (design_obj, fields) so we can detect if a new object reuses the same id.
+# Stores (design_obj, data_version, fields). The held design_obj reference
+# catches CPython id-reuse (a new design reusing a freed id), and the
+# data_version — globally unique per Sample mutation — catches the case where
+# the same design object persists while the underlying data columns change.
 _design_fields_cache: dict[int, tuple] = {}
 
 # Internal column name for the materialized where-clause boolean mask.
@@ -286,12 +289,13 @@ def prepare_data(
         needed.extend(extra_cols)
     needed.extend(extract_where_cols(where))
     key = id(design)
+    data_version = getattr(sample, "_data_version", None)
     cached = _design_fields_cache.get(key)
-    if cached is None or cached[0] is not design:
+    if cached is None or cached[0] is not design or cached[1] != data_version:
         fields = design.specified_fields(data_columns=local_data.columns)
-        _design_fields_cache[key] = (design, fields)
+        _design_fields_cache[key] = (design, data_version, fields)
     else:
-        fields = cached[1]
+        fields = cached[2]
     needed.extend(fields)
     # Include singleton variance/exclude columns if present in data
     _sr_pre = getattr(sample, "_singleton_result", None)

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import itertools
 import logging
 
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, Self, Sequence, cast
@@ -53,6 +54,20 @@ log = logging.getLogger(__name__)
 INTEGER_DTYPES = {pl.Int8, pl.Int16, pl.Int32, pl.Int64, pl.UInt8, pl.UInt16, pl.UInt32, pl.UInt64}
 FLOAT_DTYPES = {pl.Float32, pl.Float64}
 
+# Globally monotonic data-version counter. Every Sample (and every fork or
+# in-place mutation of one) draws a fresh value, so a version stamp is unique
+# across ALL Sample instances for the process lifetime. Caches that key on the
+# data version (estimation design caches, prepared-fields cache, and the
+# Phase-C design code columns) can therefore never serve a stale cross-object
+# hit — a mismatch always means "rebuild". This replaces the previous
+# ``id(df)``-based cache keys, which CPython id-reuse could alias after an
+# in-place mutation freed and reallocated the underlying frame.
+_DATA_VERSION_COUNTER = itertools.count(1)
+
+
+def _next_data_version() -> int:
+    return next(_DATA_VERSION_COUNTER)
+
 
 class Sample:
     """A sample class for survey data."""
@@ -72,6 +87,7 @@ class Sample:
     # ════════════════════════════════════════════════════════════════════════
     __slots__ = (
         "_data",
+        "_data_version",
         "_fpc",
         "_design",
         "_metadata",
@@ -141,6 +157,7 @@ class Sample:
 
         self._warnings: WarningStore = WarningStore()
         self._data = local_data
+        self._data_version = _next_data_version()
 
         # Initialize MetadataStore (replaces _labels)
         self._metadata = MetadataStore(catalog=catalog)
@@ -153,6 +170,20 @@ class Sample:
 
         self._check_for_singletons()
         self._validate_design()
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        # Any rebind of the data or design invalidates every version-keyed
+        # cache (estimation design caches, the prepared-fields cache, and the
+        # Phase-C design code columns). Enforcing the bump here — rather than at
+        # each of the ~40 call sites in wrangling/weighting/selection — makes
+        # the invariant impossible to miss for current and future code. Only
+        # *writes* are intercepted; reads of ``self._data`` remain direct slot
+        # access with zero overhead. Forks that must diverge deterministically
+        # (see ``_replace_data``) reassign ``_data_version`` explicitly after
+        # copying, so this hook's copy-time ordering does not matter there.
+        object.__setattr__(self, name, value)
+        if name == "_data" or name == "_design":
+            object.__setattr__(self, "_data_version", _next_data_version())
 
     def __hash__(self) -> int:
         _d = (
@@ -720,6 +751,11 @@ class Sample:
         the original (and vice versa).
         """
         new = copy.copy(self)
+        # This assignment runs *after* copy.copy completes, so ``__setattr__``
+        # deterministically stamps the fork with a fresh, globally-unique data
+        # version. That matters: a fork carries different (or independently
+        # mutable) data, and without a distinct version a cache populated by
+        # the parent could be served to the fork through a shared design object.
         new._data = data
         new._metadata = copy.deepcopy(self._metadata)
         new._internal_design = copy.deepcopy(self._internal_design)

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -57,7 +57,7 @@ class Estimation:
 
     def _get_factorized_design(self) -> dict[str, Any]:
         if self._design_cache is not None:
-            if self._design_cache["_data_id"] == id(self._sample._data):
+            if self._design_cache["_data_version"] == self._sample._data_version:
                 return self._design_cache
             self._design_cache = None
 
@@ -70,7 +70,7 @@ class Estimation:
         design = self._sample._design
 
         cache: dict[str, Any] = {
-            "_data_id": id(self._sample._data),
+            "_data_version": self._sample._data_version,
             "stratum": None,
             "psu": None,
             "ssu": None,
@@ -137,7 +137,7 @@ class Estimation:
 
     def _get_polars_design_info(self) -> dict[str, Any]:
         if self._polars_cache is not None:
-            if self._polars_cache["_data_id"] == id(self._sample._data):
+            if self._polars_cache["_data_version"] == self._sample._data_version:
                 return self._polars_cache
             self._polars_cache = None
 
@@ -239,7 +239,7 @@ class Estimation:
             )
 
         self._polars_cache = {
-            "_data_id": id(self._sample._data),
+            "_data_version": self._sample._data_version,
             "data": data,
             "strata_col": strata_col,
             "psu_col": psu_col,

--- a/packages/svy/src/svy/wrangling/_helpers.py
+++ b/packages/svy/src/svy/wrangling/_helpers.py
@@ -83,6 +83,9 @@ def _resolve_target(sample: "Sample", new_data: pl.DataFrame, *, inplace: bool) 
         If False, return a new sample via :func:`_fork`.
     """
     if inplace:
+        # Rebinding _data triggers Sample.__setattr__, which bumps the data
+        # version and invalidates version-keyed caches. (The fork path is
+        # versioned via _replace_data.)
         sample._data = new_data
         return sample
     return _fork(sample, new_data)
@@ -232,6 +235,8 @@ def _rebuild_concat_columns(target: "Sample") -> None:
         "ssu": f"ssu{_INTERNAL_CONCAT_SUFFIX}" if ssu_cols else None,
         "suffix": _INTERNAL_CONCAT_SUFFIX,
     }
+    # The two ``target._data = ...`` rebinds above each trip Sample.__setattr__,
+    # which bumps the data version — no explicit invalidation needed here.
 
 
 def _rebuild_concat_if_touched(

--- a/packages/svy/tests/svy/core/test_data_version_cache.py
+++ b/packages/svy/tests/svy/core/test_data_version_cache.py
@@ -1,0 +1,138 @@
+# tests/svy/core/test_data_version_cache.py
+"""
+Regression tests for the Sample data-version counter and the caches keyed on
+it (estimation design caches + the prepared-fields cache).
+
+Background: the estimation design caches used to be keyed on ``id(sample._data)``
+without holding a reference to the frame. After an in-place mutation freed and
+reallocated the underlying DataFrame, CPython id-reuse could make a stale cache
+entry *look* current and serve design arrays for the old data — a silent wrong
+result. The fix is a globally-monotonic ``_data_version`` stamp that changes on
+every rebind of ``_data``/``_design`` (enforced in ``Sample.__setattr__``); every
+version-keyed cache compares against it and rebuilds on mismatch.
+
+These tests pin the invariant "the version changes whenever data or design
+changes, and a held estimation facade never serves a stale cached result."
+"""
+
+import polars as pl
+import pytest
+
+import svy
+
+
+@pytest.fixture
+def df():
+    return pl.DataFrame(
+        {
+            "stratum": ["a", "a", "b", "b", "a", "b"],
+            "psu": ["1", "1", "2", "2", "3", "3"],
+            "w": [1.0, 2.0, 1.5, 0.5, 1.0, 2.0],
+            "w2": [2.0, 1.0, 0.5, 1.5, 2.0, 1.0],
+            "y": [10.0, 12.0, 20.0, 22.0, 11.0, 21.0],
+        }
+    )
+
+
+@pytest.fixture
+def sample(df):
+    design = svy.Design(stratum="stratum", psu="psu", wgt="w")
+    return svy.Sample(df, design)
+
+
+# ── Basic invariants ────────────────────────────────────────────────────────
+
+
+def test_version_is_int_and_present(sample):
+    assert isinstance(sample._data_version, int)
+
+
+def test_distinct_samples_have_distinct_versions(df):
+    d = svy.Design(stratum="stratum", psu="psu", wgt="w")
+    s1 = svy.Sample(df, d)
+    s2 = svy.Sample(df, d)
+    assert s1._data_version != s2._data_version
+
+
+# ── Mutation bumps the version ──────────────────────────────────────────────
+
+
+def test_set_data_bumps_version(sample, df):
+    v0 = sample._data_version
+    sample.set_data(df)
+    assert sample._data_version != v0
+
+
+def test_update_data_bumps_version(sample, df):
+    v0 = sample._data_version
+    sample.update_data(df)
+    assert sample._data_version != v0
+
+
+def test_update_design_bumps_version(sample):
+    v0 = sample._data_version
+    sample.update_design(wgt="w2")
+    assert sample._data_version != v0
+
+
+def test_inplace_wrangling_bumps_version(sample):
+    v0 = sample._data_version
+    sample.wrangling.filter_records(svy.col("stratum") == "a", inplace=True)
+    assert sample._data_version != v0
+
+
+def test_non_inplace_wrangling_fork_has_distinct_version(sample):
+    v0 = sample._data_version
+    forked = sample.wrangling.filter_records(svy.col("stratum") == "a", inplace=False)
+    assert forked._data_version != v0
+    # Original is untouched → its version is unchanged.
+    assert sample._data_version == v0
+
+
+def test_use_weight_fork_has_distinct_version(sample):
+    forked = sample.use_weight("w2")
+    assert forked._data_version != sample._data_version
+
+
+# ── The catastrophic path: held facade must not serve a stale cache ─────────
+
+
+def test_held_facade_rebuilds_after_set_data(sample, df):
+    """A held Estimation facade must reflect new data after set_data, not a
+    stale cached design/estimate."""
+    est = sample.estimation
+    mean_before = est.mean("y").estimates[0].est
+    assert mean_before == pytest.approx(16.0)
+
+    # Replace data with y scaled 10x → the correct mean is 160.
+    sample.set_data(df.with_columns((pl.col("y") * 10).alias("y")))
+
+    mean_after = est.mean("y").estimates[0].est
+    assert mean_after == pytest.approx(160.0)
+    # The cache that produced it must be stamped with the current version.
+    assert est._design_cache["_data_version"] == sample._data_version
+
+
+def test_held_facade_rebuilds_after_inplace_wrangling(sample):
+    """In-place row filtering under a held facade must change the estimate."""
+    est = sample.estimation
+    full_mean = est.mean("y").estimates[0].est
+
+    # Keep only stratum 'a' rows in place; the mean must change.
+    sample.wrangling.filter_records(svy.col("stratum") == "a", inplace=True)
+    filtered_mean = est.mean("y").estimates[0].est
+
+    assert filtered_mean != pytest.approx(full_mean)
+    assert est._design_cache["_data_version"] == sample._data_version
+
+
+def test_polars_design_cache_also_rebuilds(sample, df):
+    """The second design cache (_get_polars_design_info) is version-keyed too."""
+    est = sample.estimation
+    info1 = est._get_polars_design_info()
+    assert info1["_data_version"] == sample._data_version
+
+    sample.set_data(df)
+    info2 = est._get_polars_design_info()
+    assert info2["_data_version"] == sample._data_version
+    assert info2["_data_version"] != info1["_data_version"]


### PR DESCRIPTION
Working branch for the svy-rs estimation performance plan. Lands the correctness prerequisite, a committed benchmark harness, and the first kernel-optimization phase. Each commit is independently shippable; later phases (C: cached integer factorization, D: parallelism, E: marshalling) will follow.

## Results (1M rows, warm, M-series)

| case | before | after | change |
|---|---|---|---|
| mean / strat+cluster | 232.9 ms | **119.4 ms** | **−49%** |
| total / strat+cluster | 226.8 ms | 130.8 ms | −42% |
| ratio / strat+cluster | 236.8 ms | 138.3 ms | −42% |
| no-design kernel | 30.1 ms | 11.9 ms | −60% |

All bit-identical: 2438 R-validated goldens + 67 Rust unit tests green at every step.

## Commits

1. **`fix(svy)`: version-keyed estimation caches** — the design caches were keyed on `id(sample._data)` without holding a reference, so CPython id-reuse after an in-place mutation could serve stale design arrays (silent wrong result). Replaced with a globally-monotonic `_data_version` counter enforced in `Sample.__setattr__` (covers every wrangling/weighting/selection writeback in one place; read path untouched). +11 regression tests. Foundation for Phase C invalidation.

2. **`bench(svy-rs)`: criterion benches + host-buildable crate** — per-function kernel micro-benchmarks (no PyO3 noise). Made the pyo3 crate `cargo test`/`cargo bench`-able (add `rlib`; `extension-module` now an optional default-on feature so `--no-default-features` links a host binary). New `make` targets: `test-svy-rs-cargo`, `bench-svy-rs`. Wheel verified unchanged.

3. **`bench(svy)`: self-contained Python harness** — end-to-end + direct-kernel, generates its own synthetic survey data (no WB-CSV dependency), machine-readable output.

4. **`perf(svy-rs)`: Taylor kernel fast paths (~2x)** — four internal changes, no API change:
   - FxHashMap (rustc-hash) in the design-indexing maps (codes are first-appearance order → hash-independent → identical output);
   - fused no-null `cont_slice` loops for point/scores/srs (branch-free over `&[f64]`, same summation order → exact; Option-iterator fallback kept for chunked/nullable input);
   - rechunk at the boundary so fragmented frames reach the fast paths;
   - `degrees_of_freedom` borrows `&str` into FxHash sets instead of allocating a String per row (the biggest single hidden cost).

## Notes

- The private working docs `PERF_PLAN.md` / `REMAINING_FIXES.md` are gitignored and not included.
- Remaining string design-indexing (`taylor_variance` + df) is Phase C's integer-code target, driving toward the ≤25 ms end goal.