### PR TITLE
perf: Phase D — by-group dedup + replication 27-33x (parallel, no matrix)

### DIFF
--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -867,6 +867,131 @@ pub fn matrix_prop_estimates(
     (levels, theta_full, theta_reps)
 }
 
+/// Sorted category levels and the per-row level index for integer category data.
+fn prop_level_index(y: &[i64]) -> (Vec<i64>, Vec<usize>) {
+    let mut level_map: HashMap<i64, usize> = HashMap::new();
+    let mut levels: Vec<i64> = Vec::new();
+    for &val in y {
+        if !level_map.contains_key(&val) {
+            level_map.insert(val, levels.len());
+            levels.push(val);
+        }
+    }
+    levels.sort();
+    for (idx, &lev) in levels.iter().enumerate() {
+        level_map.insert(lev, idx);
+    }
+    let lev_idx: Vec<usize> = y.iter().map(|v| level_map[v]).collect();
+    (levels, lev_idx)
+}
+
+/// `matrix_prop_estimates` from the contiguous replicate columns (no matrix).
+/// Bit-identical: each replicate accumulates per-level weight in row order,
+/// parallel over replicates, reshaped to `[level][rep]`.
+pub fn matrix_prop_estimates_cols(
+    y: &[i64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    n: usize,
+) -> (Vec<i64>, Vec<f64>, Vec<Vec<f64>>) {
+    let (levels, lev_idx) = prop_level_index(y);
+    let n_levels = levels.len();
+
+    let mut sum_w_level = vec![0.0; n_levels];
+    let mut sum_w_total = 0.0;
+    for i in 0..n {
+        sum_w_level[lev_idx[i]] += full_weights[i];
+        sum_w_total += full_weights[i];
+    }
+    let theta_full: Vec<f64> = sum_w_level
+        .iter()
+        .map(|&w_l| if sum_w_total > 0.0 { w_l / sum_w_total } else { f64::NAN })
+        .collect();
+
+    use rayon::prelude::*;
+    let per_rep: Vec<Vec<f64>> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swl = vec![0.0; n_levels];
+            let mut swt = 0.0;
+            for i in 0..n {
+                let w = col[i];
+                swl[lev_idx[i]] += w;
+                swt += w;
+            }
+            (0..n_levels)
+                .map(|l| if swt > 0.0 { swl[l] / swt } else { f64::NAN })
+                .collect()
+        })
+        .collect();
+
+    let n_reps = rep_cols.len();
+    let theta_reps: Vec<Vec<f64>> = (0..n_levels)
+        .map(|l| (0..n_reps).map(|r| per_rep[r][l]).collect())
+        .collect();
+
+    (levels, theta_full, theta_reps)
+}
+
+/// `matrix_prop_estimates_str` from the contiguous replicate columns. Same as
+/// the integer version but with string category levels. Bit-identical.
+pub fn matrix_prop_estimates_str_cols(
+    y: &[String],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    n: usize,
+) -> (Vec<String>, Vec<f64>, Vec<Vec<f64>>) {
+    let mut level_map: HashMap<&str, usize> = HashMap::new();
+    let mut levels: Vec<String> = Vec::new();
+    for val in y {
+        if !level_map.contains_key(val.as_str()) {
+            level_map.insert(val.as_str(), levels.len());
+            levels.push(val.clone());
+        }
+    }
+    levels.sort();
+    for (idx, lev) in levels.iter().enumerate() {
+        level_map.insert(lev.as_str(), idx);
+    }
+    let n_levels = levels.len();
+    let lev_idx: Vec<usize> = y.iter().map(|v| level_map[v.as_str()]).collect();
+
+    let mut sum_w_level = vec![0.0; n_levels];
+    let mut sum_w_total = 0.0;
+    for i in 0..n {
+        sum_w_level[lev_idx[i]] += full_weights[i];
+        sum_w_total += full_weights[i];
+    }
+    let theta_full: Vec<f64> = sum_w_level
+        .iter()
+        .map(|&w_l| if sum_w_total > 0.0 { w_l / sum_w_total } else { f64::NAN })
+        .collect();
+
+    use rayon::prelude::*;
+    let per_rep: Vec<Vec<f64>> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swl = vec![0.0; n_levels];
+            let mut swt = 0.0;
+            for i in 0..n {
+                let w = col[i];
+                swl[lev_idx[i]] += w;
+                swt += w;
+            }
+            (0..n_levels)
+                .map(|l| if swt > 0.0 { swl[l] / swt } else { f64::NAN })
+                .collect()
+        })
+        .collect();
+
+    let n_reps = rep_cols.len();
+    let theta_reps: Vec<Vec<f64>> = (0..n_levels)
+        .map(|l| (0..n_reps).map(|r| per_rep[r][l]).collect())
+        .collect();
+
+    (levels, theta_full, theta_reps)
+}
+
 /// Compute proportion estimates by level and domain.
 /// Category values are integers (Boolean or numeric columns).
 pub fn matrix_prop_by_domain(

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -531,6 +531,65 @@ pub fn matrix_mean_by_domain(
     (theta_full, theta_reps, counts)
 }
 
+/// By-domain replicate mean from the contiguous replicate columns (no matrix).
+/// Each replicate accumulates per-domain sums over rows in order, in parallel
+/// across replicates; the per-replicate results are reshaped to the
+/// `[domain][rep]` layout `matrix_mean_by_domain` returns. Bit-identical.
+pub fn matrix_mean_by_domain_cols(
+    y: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    domain_ids: &[u32],
+    n_domains: usize,
+    n: usize,
+) -> (Vec<f64>, Vec<Vec<f64>>, Vec<u32>) {
+    let mut sum_wy = vec![0.0; n_domains];
+    let mut sum_w = vec![0.0; n_domains];
+    let mut counts = vec![0u32; n_domains];
+    for i in 0..n {
+        let d = domain_ids[i] as usize;
+        if d >= n_domains {
+            continue;
+        }
+        sum_wy[d] += y[i] * full_weights[i];
+        sum_w[d] += full_weights[i];
+        counts[d] += 1;
+    }
+    let theta_full: Vec<f64> = sum_wy
+        .iter()
+        .zip(sum_w.iter())
+        .map(|(&wy, &w)| if w > 0.0 { wy / w } else { f64::NAN })
+        .collect();
+
+    use rayon::prelude::*;
+    let per_rep: Vec<Vec<f64>> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = vec![0.0; n_domains];
+            let mut sw = vec![0.0; n_domains];
+            for i in 0..n {
+                let d = domain_ids[i] as usize;
+                if d < n_domains {
+                    let w = col[i];
+                    swy[d] += y[i] * w;
+                    sw[d] += w;
+                }
+            }
+            (0..n_domains)
+                .map(|d| if sw[d] > 0.0 { swy[d] / sw[d] } else { f64::NAN })
+                .collect()
+        })
+        .collect();
+
+    // Reshape per_rep[rep][domain] → theta_reps[domain][rep].
+    let n_reps = rep_cols.len();
+    let theta_reps: Vec<Vec<f64>> = (0..n_domains)
+        .map(|d| (0..n_reps).map(|r| per_rep[r][d]).collect())
+        .collect();
+
+    (theta_full, theta_reps, counts)
+}
+
 /// Compute total estimates by domain
 pub fn matrix_total_by_domain(
     y: &[f64],

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -389,6 +389,62 @@ pub fn matrix_ratio_estimates(
     (theta_full, theta_reps)
 }
 
+/// Replicate total estimates from the contiguous replicate columns (no matrix).
+/// Bit-identical to `matrix_total_estimates`; see `matrix_mean_estimates_cols`.
+pub fn matrix_total_estimates_cols(
+    y: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    n: usize,
+) -> (f64, Vec<f64>) {
+    let theta_full: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
+
+    use rayon::prelude::*;
+    let theta_reps: Vec<f64> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = 0.0f64;
+            for i in 0..n {
+                swy += y[i] * col[i];
+            }
+            swy
+        })
+        .collect();
+
+    (theta_full, theta_reps)
+}
+
+/// Replicate ratio estimates from the contiguous replicate columns (no matrix).
+/// Bit-identical to `matrix_ratio_estimates`; see `matrix_mean_estimates_cols`.
+pub fn matrix_ratio_estimates_cols(
+    y: &[f64],
+    x: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    n: usize,
+) -> (f64, Vec<f64>) {
+    let sum_wy: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
+    let sum_wx: f64 = x.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
+    let theta_full = if sum_wx > 0.0 { sum_wy / sum_wx } else { f64::NAN };
+
+    use rayon::prelude::*;
+    let theta_reps: Vec<f64> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = 0.0f64;
+            let mut swx = 0.0f64;
+            for i in 0..n {
+                let w = col[i];
+                swy += y[i] * w;
+                swx += x[i] * w;
+            }
+            if swx > 0.0 { swy / swx } else { f64::NAN }
+        })
+        .collect();
+
+    (theta_full, theta_reps)
+}
+
 // ============================================================================
 // Domain-level computation
 // ============================================================================

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -169,6 +169,15 @@ pub fn variance_from_replicates(
 
 /// Extract replicate weights matrix from DataFrame columns
 /// Returns flattened row-major matrix (n × R)
+///
+/// The naive build (column-outer loop writing `matrix[i*n_reps + r]`) is a
+/// strided write — a cache miss on essentially every store — and dominated the
+/// whole replication call (~530 ms at 1M rows × 40 reps). Instead, when the
+/// replicate columns are contiguous and null-free (the common post-`prepare_data`
+/// case) this does a **cache-blocked parallel transpose**: each row block's
+/// slice of the row-major matrix (BLOCK × R floats) fits in L2, so its writes
+/// stay hot, and blocks are filled in parallel. The output matrix is byte-for-
+/// byte identical to the naive build, so downstream results are unchanged.
 pub fn extract_rep_weights_matrix(
     df: &DataFrame,
     rep_weight_cols: &[String],
@@ -176,11 +185,47 @@ pub fn extract_rep_weights_matrix(
     let n = df.height();
     let n_reps = rep_weight_cols.len();
     let mut matrix = vec![0.0; n * n_reps];
+    if n == 0 || n_reps == 0 {
+        return Ok((matrix, n, n_reps));
+    }
 
-    for (r, col_name) in rep_weight_cols.iter().enumerate() {
-        let col = df.column(col_name)?.f64()?;
-        for (i, v) in col.into_iter().enumerate() {
-            matrix[i * n_reps + r] = v.unwrap_or(0.0);
+    let f64_cols: Vec<&Float64Chunked> = rep_weight_cols
+        .iter()
+        .map(|c| df.column(c)?.f64())
+        .collect::<PolarsResult<_>>()?;
+
+    // Borrow each column as one contiguous null-free slice, if possible.
+    let contiguous: Option<Vec<&[f64]>> = f64_cols
+        .iter()
+        .map(|c| c.cont_slice().ok())
+        .collect();
+
+    match contiguous {
+        Some(cols) => {
+            use rayon::prelude::*;
+            const BLOCK: usize = 256; // BLOCK * n_reps * 8 bytes stays in L2
+            matrix
+                .par_chunks_mut(BLOCK * n_reps)
+                .enumerate()
+                .for_each(|(b, chunk)| {
+                    let start = b * BLOCK;
+                    let rows = chunk.len() / n_reps;
+                    for local_i in 0..rows {
+                        let i = start + local_i;
+                        let dst = &mut chunk[local_i * n_reps..local_i * n_reps + n_reps];
+                        for (r, col) in cols.iter().enumerate() {
+                            dst[r] = col[i];
+                        }
+                    }
+                });
+        }
+        None => {
+            // Fallback for chunked/nullable columns — identical semantics.
+            for (r, col) in f64_cols.iter().enumerate() {
+                for (i, v) in col.into_iter().enumerate() {
+                    matrix[i * n_reps + r] = v.unwrap_or(0.0);
+                }
+            }
         }
     }
 

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -590,6 +590,106 @@ pub fn matrix_mean_by_domain_cols(
     (theta_full, theta_reps, counts)
 }
 
+/// By-domain replicate total from the contiguous replicate columns (no matrix).
+/// Bit-identical to `matrix_total_by_domain`.
+pub fn matrix_total_by_domain_cols(
+    y: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    domain_ids: &[u32],
+    n_domains: usize,
+    n: usize,
+) -> (Vec<f64>, Vec<Vec<f64>>, Vec<u32>) {
+    let mut sum_wy = vec![0.0; n_domains];
+    let mut counts = vec![0u32; n_domains];
+    for i in 0..n {
+        let d = domain_ids[i] as usize;
+        if d >= n_domains {
+            continue;
+        }
+        sum_wy[d] += y[i] * full_weights[i];
+        counts[d] += 1;
+    }
+
+    use rayon::prelude::*;
+    let per_rep: Vec<Vec<f64>> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = vec![0.0; n_domains];
+            for i in 0..n {
+                let d = domain_ids[i] as usize;
+                if d < n_domains {
+                    swy[d] += y[i] * col[i];
+                }
+            }
+            swy
+        })
+        .collect();
+
+    let n_reps = rep_cols.len();
+    let theta_reps: Vec<Vec<f64>> = (0..n_domains)
+        .map(|d| (0..n_reps).map(|r| per_rep[r][d]).collect())
+        .collect();
+
+    (sum_wy, theta_reps, counts)
+}
+
+/// By-domain replicate ratio from the contiguous replicate columns (no matrix).
+/// Bit-identical to `matrix_ratio_by_domain`.
+pub fn matrix_ratio_by_domain_cols(
+    y: &[f64],
+    x: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    domain_ids: &[u32],
+    n_domains: usize,
+    n: usize,
+) -> (Vec<f64>, Vec<Vec<f64>>, Vec<u32>) {
+    let mut sum_wy = vec![0.0; n_domains];
+    let mut sum_wx = vec![0.0; n_domains];
+    let mut counts = vec![0u32; n_domains];
+    for i in 0..n {
+        let d = domain_ids[i] as usize;
+        if d >= n_domains {
+            continue;
+        }
+        let w = full_weights[i];
+        sum_wy[d] += y[i] * w;
+        sum_wx[d] += x[i] * w;
+        counts[d] += 1;
+    }
+    let theta_full: Vec<f64> = (0..n_domains)
+        .map(|d| if sum_wx[d] > 0.0 { sum_wy[d] / sum_wx[d] } else { f64::NAN })
+        .collect();
+
+    use rayon::prelude::*;
+    let per_rep: Vec<Vec<f64>> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = vec![0.0; n_domains];
+            let mut swx = vec![0.0; n_domains];
+            for i in 0..n {
+                let d = domain_ids[i] as usize;
+                if d < n_domains {
+                    let w = col[i];
+                    swy[d] += y[i] * w;
+                    swx[d] += x[i] * w;
+                }
+            }
+            (0..n_domains)
+                .map(|d| if swx[d] > 0.0 { swy[d] / swx[d] } else { f64::NAN })
+                .collect()
+        })
+        .collect();
+
+    let n_reps = rep_cols.len();
+    let theta_reps: Vec<Vec<f64>> = (0..n_domains)
+        .map(|d| (0..n_reps).map(|r| per_rep[r][d]).collect())
+        .collect();
+
+    (theta_full, theta_reps, counts)
+}
+
 /// Compute total estimates by domain
 pub fn matrix_total_by_domain(
     y: &[f64],

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -278,6 +278,42 @@ pub fn matrix_mean_estimates(
     (theta_full, theta_reps)
 }
 
+/// Replicate mean estimates computed directly from the (contiguous) replicate
+/// weight columns — no n×R matrix is materialised.
+///
+/// Each replicate is summed over rows in order, in parallel across replicates,
+/// so the result is bit-identical to `matrix_mean_estimates`. Reading each
+/// column once, contiguously, avoids both the 3× memory traffic (zero + write +
+/// read) of building the flat matrix and its strided gather, which dominate at
+/// large replicate counts.
+pub fn matrix_mean_estimates_cols(
+    y: &[f64],
+    full_weights: &[f64],
+    rep_cols: &[&[f64]],
+    n: usize,
+) -> (f64, Vec<f64>) {
+    let sum_wy: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
+    let sum_w: f64 = full_weights.iter().sum();
+    let theta_full = if sum_w > 0.0 { sum_wy / sum_w } else { f64::NAN };
+
+    use rayon::prelude::*;
+    let theta_reps: Vec<f64> = rep_cols
+        .par_iter()
+        .map(|col| {
+            let mut swy = 0.0f64;
+            let mut sw = 0.0f64;
+            for i in 0..n {
+                let w = col[i];
+                swy += y[i] * w;
+                sw += w;
+            }
+            if sw > 0.0 { swy / sw } else { f64::NAN }
+        })
+        .collect();
+
+    (theta_full, theta_reps)
+}
+
 /// Compute total estimates for all replicates
 pub fn matrix_total_estimates(
     y: &[f64],

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -17,8 +17,8 @@ use crate::estimation::replication::{
     matrix_median_by_domain, matrix_median_estimates,
     matrix_prop_by_domain, matrix_prop_estimates,
     matrix_prop_by_domain_str, matrix_prop_estimates_str,
-    matrix_ratio_by_domain, matrix_ratio_estimates,
-    matrix_total_by_domain, matrix_total_estimates,
+    matrix_ratio_by_domain, matrix_ratio_estimates, matrix_ratio_estimates_cols,
+    matrix_total_by_domain, matrix_total_estimates, matrix_total_estimates_cols,
     replicate_coefficients,
     variance_from_replicates,
 };
@@ -26,6 +26,24 @@ use crate::estimation::replication::{
 // ============================================================================
 // Shared helpers
 // ============================================================================
+
+/// Borrow every replicate-weight column as a contiguous null-free slice, or
+/// `None` if any column is chunked/nullable (→ caller uses the flat-matrix
+/// fallback). Lets the ungrouped estimators accumulate straight from the
+/// columns with no n×R matrix materialised.
+fn get_cont_rep_cols<'a>(
+    df: &'a DataFrame,
+    rep_weight_cols: &[String],
+) -> PolarsResult<Option<Vec<&'a [f64]>>> {
+    let mut cols = Vec::with_capacity(rep_weight_cols.len());
+    for name in rep_weight_cols {
+        match df.column(name)?.f64()?.cont_slice() {
+            Ok(s) => cols.push(s),
+            Err(_) => return Ok(None),
+        }
+    }
+    Ok(Some(cols))
+}
 
 fn parse_rep_method(method: &str) -> PyResult<RepMethod> {
     RepMethod::from_str(method).ok_or_else(|| {
@@ -91,15 +109,9 @@ fn compute_replicate_mean_ungrouped(
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
-    // Prefer the no-materialisation path: accumulate straight from the
-    // contiguous replicate columns (parallel over replicates). Falls back to the
-    // flat-matrix path for chunked/nullable columns.
-    let f64_cols: Vec<&Float64Chunked> = rep_weight_cols
-        .iter()
-        .map(|c| df.column(c)?.f64())
-        .collect::<PolarsResult<_>>()?;
-    let cont: Option<Vec<&[f64]>> = f64_cols.iter().map(|c| c.cont_slice().ok()).collect();
-    let (theta_full, theta_reps) = match cont {
+    // No-materialisation path: accumulate from the contiguous replicate columns
+    // (parallel over replicates); flat-matrix fallback for chunked/nullable.
+    let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
         Some(cols) => matrix_mean_estimates_cols(&y_arr, &w_arr, &cols, n),
         None => {
             let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
@@ -200,8 +212,13 @@ fn compute_replicate_total_ungrouped(
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full, theta_reps) = matrix_total_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps);
+    let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
+        Some(cols) => matrix_total_estimates_cols(&y_arr, &w_arr, &cols, n),
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_total_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();
@@ -301,9 +318,13 @@ fn compute_replicate_ratio_ungrouped(
     let x_arr: Vec<f64> = x.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full, theta_reps) =
-        matrix_ratio_estimates(&y_arr, &x_arr, &w_arr, &rep_w_matrix, n, n_reps);
+    let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
+        Some(cols) => matrix_ratio_estimates_cols(&y_arr, &x_arr, &w_arr, &cols, n),
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_ratio_estimates(&y_arr, &x_arr, &w_arr, &rep_w_matrix, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -13,7 +13,8 @@ use crate::estimation::replication::{
     RepMethod, VarianceCenter,
     extract_rep_weights_matrix,
     index_domains,
-    matrix_mean_by_domain, matrix_mean_estimates, matrix_mean_estimates_cols,
+    matrix_mean_by_domain, matrix_mean_by_domain_cols, matrix_mean_estimates,
+    matrix_mean_estimates_cols,
     matrix_median_by_domain, matrix_median_estimates,
     matrix_prop_by_domain, matrix_prop_estimates,
     matrix_prop_by_domain_str, matrix_prop_estimates_str,
@@ -141,9 +142,15 @@ fn compute_replicate_mean_grouped(
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full_vec, theta_reps_vec, counts) =
-        matrix_mean_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps);
+    let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
+        Some(cols) => {
+            matrix_mean_by_domain_cols(&y_arr, &w_arr, &cols, &domain_ids, n_domains, n)
+        }
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_mean_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -13,7 +13,7 @@ use crate::estimation::replication::{
     RepMethod, VarianceCenter,
     extract_rep_weights_matrix,
     index_domains,
-    matrix_mean_by_domain, matrix_mean_estimates,
+    matrix_mean_by_domain, matrix_mean_estimates, matrix_mean_estimates_cols,
     matrix_median_by_domain, matrix_median_estimates,
     matrix_prop_by_domain, matrix_prop_estimates,
     matrix_prop_by_domain_str, matrix_prop_estimates_str,
@@ -91,8 +91,21 @@ fn compute_replicate_mean_ungrouped(
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full, theta_reps) = matrix_mean_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps);
+    // Prefer the no-materialisation path: accumulate straight from the
+    // contiguous replicate columns (parallel over replicates). Falls back to the
+    // flat-matrix path for chunked/nullable columns.
+    let f64_cols: Vec<&Float64Chunked> = rep_weight_cols
+        .iter()
+        .map(|c| df.column(c)?.f64())
+        .collect::<PolarsResult<_>>()?;
+    let cont: Option<Vec<&[f64]>> = f64_cols.iter().map(|c| c.cont_slice().ok()).collect();
+    let (theta_full, theta_reps) = match cont {
+        Some(cols) => matrix_mean_estimates_cols(&y_arr, &w_arr, &cols, n),
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_mean_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -16,8 +16,8 @@ use crate::estimation::replication::{
     matrix_mean_by_domain, matrix_mean_by_domain_cols, matrix_mean_estimates,
     matrix_mean_estimates_cols,
     matrix_median_by_domain, matrix_median_estimates,
-    matrix_prop_by_domain, matrix_prop_estimates,
-    matrix_prop_by_domain_str, matrix_prop_estimates_str,
+    matrix_prop_by_domain, matrix_prop_estimates, matrix_prop_estimates_cols,
+    matrix_prop_by_domain_str, matrix_prop_estimates_str, matrix_prop_estimates_str_cols,
     matrix_ratio_by_domain, matrix_ratio_by_domain_cols, matrix_ratio_estimates,
     matrix_ratio_estimates_cols,
     matrix_total_by_domain, matrix_total_by_domain_cols, matrix_total_estimates,
@@ -441,7 +441,7 @@ fn compute_replicate_prop_ungrouped(
     let n = y_series.len();
     let n_reps = rep_weight_cols.len();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+    let cont_cols = get_cont_rep_cols(df, rep_weight_cols)?;
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
 
     // String/Categorical: use string-keyed level functions so level labels are
@@ -453,8 +453,13 @@ fn compute_replicate_prop_ungrouped(
         let y_arr: Vec<String> = y_cast.str()?.into_iter()
             .map(|v| v.unwrap_or("").to_string())
             .collect();
-        let (levels, theta_full, theta_reps) =
-            matrix_prop_estimates_str(&y_arr, &w_arr, &rep_w_matrix, n, n_reps);
+        let (levels, theta_full, theta_reps) = match &cont_cols {
+            Some(cols) => matrix_prop_estimates_str_cols(&y_arr, &w_arr, cols, n),
+            None => {
+                let (m, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+                matrix_prop_estimates_str(&y_arr, &w_arr, &m, n, n_reps)
+            }
+        };
         let n_l = levels.len();
         let vars: Vec<f64> = (0..n_l)
             .map(|l| variance_from_replicates(method, theta_full[l], &theta_reps[l], &rep_coefs, center))
@@ -477,8 +482,13 @@ fn compute_replicate_prop_ungrouped(
                 ).into()
             ));
         };
-        let (levels, theta_full, theta_reps) =
-            matrix_prop_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps);
+        let (levels, theta_full, theta_reps) = match &cont_cols {
+            Some(cols) => matrix_prop_estimates_cols(&y_arr, &w_arr, cols, n),
+            None => {
+                let (m, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+                matrix_prop_estimates(&y_arr, &w_arr, &m, n, n_reps)
+            }
+        };
         let n_l = levels.len();
         let vars: Vec<f64> = (0..n_l)
             .map(|l| variance_from_replicates(method, theta_full[l], &theta_reps[l], &rep_coefs, center))

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -18,8 +18,10 @@ use crate::estimation::replication::{
     matrix_median_by_domain, matrix_median_estimates,
     matrix_prop_by_domain, matrix_prop_estimates,
     matrix_prop_by_domain_str, matrix_prop_estimates_str,
-    matrix_ratio_by_domain, matrix_ratio_estimates, matrix_ratio_estimates_cols,
-    matrix_total_by_domain, matrix_total_estimates, matrix_total_estimates_cols,
+    matrix_ratio_by_domain, matrix_ratio_by_domain_cols, matrix_ratio_estimates,
+    matrix_ratio_estimates_cols,
+    matrix_total_by_domain, matrix_total_by_domain_cols, matrix_total_estimates,
+    matrix_total_estimates_cols,
     replicate_coefficients,
     variance_from_replicates,
 };
@@ -249,9 +251,15 @@ fn compute_replicate_total_grouped(
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full_vec, theta_reps_vec, counts) =
-        matrix_total_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps);
+    let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
+        Some(cols) => {
+            matrix_total_by_domain_cols(&y_arr, &w_arr, &cols, &domain_ids, n_domains, n)
+        }
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_total_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);
@@ -358,9 +366,15 @@ fn compute_replicate_ratio_grouped(
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
-    let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let (theta_full_vec, theta_reps_vec, counts) =
-        matrix_ratio_by_domain(&y_arr, &x_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps);
+    let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
+        Some(cols) => {
+            matrix_ratio_by_domain_cols(&y_arr, &x_arr, &w_arr, &cols, &domain_ids, n_domains, n)
+        }
+        None => {
+            let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
+            matrix_ratio_by_domain(&y_arr, &x_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
+        }
+    };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -105,17 +105,33 @@ pub fn point_estimate_mean_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
-    let sum_wy: f64 = y
-        .iter()
-        .zip(weights.iter())
-        .zip(domain_mask.iter())
-        .filter_map(|((yi, wi), m)| if m? { Some(yi? * wi?) } else { None })
-        .sum();
-    let sum_w: f64 = weights
-        .iter()
-        .zip(domain_mask.iter())
-        .filter_map(|(w, m)| if m? { w } else { None })
-        .sum();
+    // Fast path: y/weights are contiguous null-free (post-prepare_data), so
+    // index them as slices while iterating the mask once — no per-element
+    // Option unwrap on y/w, and a single pass. Bit-identical (same rows, order).
+    let (sum_wy, sum_w) = if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        let mut sum_w = 0.0f64;
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                sum_wy += ys[i] * ws[i];
+                sum_w += ws[i];
+            }
+        }
+        (sum_wy, sum_w)
+    } else {
+        let sum_wy: f64 = y
+            .iter()
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
+            .filter_map(|((yi, wi), m)| if m? { Some(yi? * wi?) } else { None })
+            .sum();
+        let sum_w: f64 = weights
+            .iter()
+            .zip(domain_mask.iter())
+            .filter_map(|(w, m)| if m? { w } else { None })
+            .sum();
+        (sum_wy, sum_w)
+    };
 
     if sum_w == 0.0 {
         return Err(PolarsError::ComputeError(
@@ -440,7 +456,31 @@ pub fn scores_mean_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<Float64Chunked> {
-    // Single pass: accumulate sum_wy / sum_w and collect triples.
+    // Fast path: contiguous null-free y/weights. Materialise the in-domain flag
+    // once (a Vec<bool>, vs the fallback's Vec<Option<(f64,f64)>>), then two
+    // branch-free slice passes. Same rows/order → bit-identical.
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let n = ys.len();
+        let in_domain: Vec<bool> = domain_mask.iter().map(|m| m == Some(true)).collect();
+        let mut sum_wy = 0.0f64;
+        let mut sum_w = 0.0f64;
+        for i in 0..n {
+            if in_domain[i] {
+                sum_wy += ys[i] * ws[i];
+                sum_w += ws[i];
+            }
+        }
+        if sum_w == 0.0 {
+            return Ok(Float64Chunked::from_slice("scores".into(), &vec![0.0; n]));
+        }
+        let est = sum_wy / sum_w;
+        let scores: Vec<f64> = (0..n)
+            .map(|i| if in_domain[i] { (ws[i] / sum_w) * (ys[i] - est) } else { 0.0 })
+            .collect();
+        return Ok(Float64Chunked::from_slice("scores".into(), &scores));
+    }
+
+    // Fallback: single pass accumulating sums while collecting in-domain pairs.
     let n = y.len();
     let mut sum_wy = 0.0f64;
     let mut sum_w  = 0.0f64;
@@ -1505,18 +1545,32 @@ pub fn srs_variance_mean_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
-    let mut yv = Vec::new();
-    let mut wv = Vec::new();
-    for ((yi, wi), mi) in y
-        .into_iter()
-        .zip(weights.into_iter())
-        .zip(domain_mask.into_iter())
-    {
-        if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
-            yv.push(y_val);
-            wv.push(w_val);
+    let (yv, wv) = if let Some((ys, ws)) = cont_pair(y, weights) {
+        // Fast path: slice-index y/weights while filtering by the mask.
+        let mut yv = Vec::new();
+        let mut wv = Vec::new();
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                yv.push(ys[i]);
+                wv.push(ws[i]);
+            }
         }
-    }
+        (yv, wv)
+    } else {
+        let mut yv = Vec::new();
+        let mut wv = Vec::new();
+        for ((yi, wi), mi) in y
+            .into_iter()
+            .zip(weights.into_iter())
+            .zip(domain_mask.into_iter())
+        {
+            if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
+                yv.push(y_val);
+                wv.push(w_val);
+            }
+        }
+        (yv, wv)
+    };
     let n = yv.len() as f64;
     if n < 2.0 {
         return Ok(f64::NAN);

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -1069,6 +1069,209 @@ fn compute_stage2_variance(
 // Main Public Variance Function
 // ============================================================================
 
+/// Design-only intermediates for the Taylor variance, factored out of
+/// `taylor_variance` so a domain/by-group loop can build them ONCE (the design
+/// is identical across groups — only the scores change) instead of re-indexing
+/// the strata/PSU/SSU columns on every group. See `taylor_variance` (which is
+/// just `build_taylor_design` + `taylor_variance_apply`) for the reference
+/// semantics; splitting it here keeps a single source of truth.
+pub struct TaylorDesign {
+    sm_enum: SingletonMethod,
+    // Stage 1 — one of {unstratified, stratified}
+    strata_indices: Option<Vec<u32>>, // None ⇒ unstratified
+    n_strata: u32,
+    psu_indices: Option<Vec<u32>>, // stage-1 PSU codes (nested when stratified)
+    n_psus: u32,                   // unstratified PSU count
+    psu_per_stratum: Option<Vec<Vec<u32>>>,
+    n_psus_per_stratum: Option<Vec<u32>>,
+    fpc_val: f64,                     // unstratified single FPC
+    fpc_per_stratum: Option<Vec<f64>>, // stratified per-stratum FPC (or [fpc_val] unstrat)
+    // Stage 2
+    has_stage2: bool,
+    ssu_indices: Option<Vec<u32>>,
+    fpc_ssu_arr: Option<Vec<f64>>,
+    psu_to_stratum: Option<Vec<u32>>,
+}
+
+pub fn build_taylor_design(
+    strata: Option<&Column>,
+    psu: Option<&Column>,
+    ssu: Option<&Column>,
+    fpc: Option<&Float64Chunked>,
+    fpc_ssu: Option<&Float64Chunked>,
+    singleton_method: Option<&str>,
+    n: usize,
+) -> PolarsResult<TaylorDesign> {
+    let sm_enum = match singleton_method {
+        Some(s) if s.eq_ignore_ascii_case("center") || s.eq_ignore_ascii_case("adjust") => {
+            SingletonMethod::Center
+        }
+        _ => SingletonMethod::None,
+    };
+
+    let fpc_arr: Option<Vec<f64>> = fpc.map(|f| f.iter().map(|v| v.unwrap_or(1.0)).collect());
+    let fpc_ssu_arr: Option<Vec<f64>> =
+        fpc_ssu.map(|f| f.iter().map(|v| v.unwrap_or(1.0)).collect());
+
+    let has_stage2 = ssu.is_some() && psu.is_some();
+
+    if strata.is_none() {
+        // Unstratified: single FPC value (take first element or 1.0)
+        let fpc_val = fpc_arr
+            .as_ref()
+            .and_then(|f| f.first().copied())
+            .unwrap_or(1.0);
+        let (psu_indices, n_psus) = match psu {
+            Some(psu_col) => {
+                let (idx, cnt) = design_col_codes(psu_col)?;
+                (Some(idx), cnt)
+            }
+            None => (None, 0),
+        };
+        let ssu_indices = if has_stage2 {
+            Some(design_col_codes(ssu.unwrap())?.0)
+        } else {
+            None
+        };
+        return Ok(TaylorDesign {
+            sm_enum,
+            strata_indices: None,
+            n_strata: 0,
+            psu_indices,
+            n_psus,
+            psu_per_stratum: None,
+            n_psus_per_stratum: None,
+            fpc_val,
+            // Pass the single stage-1 FPC through so stage 2 can derive the
+            // stage-1 sampling fraction (mirrors the original tuple).
+            fpc_per_stratum: Some(vec![fpc_val]),
+            has_stage2,
+            ssu_indices,
+            fpc_ssu_arr,
+            psu_to_stratum: None,
+        });
+    }
+
+    let strata_col = strata.unwrap();
+    let (strata_indices, n_strata) = design_col_codes(strata_col)?;
+
+    // Per-stratum FPC: for each stratum h, the FPC of its first row.
+    let fpc_by_stratum: Option<Vec<f64>> = fpc_arr.as_ref().map(|fpc_vals| {
+        let mut per_stratum = vec![1.0; n_strata as usize];
+        let mut seen = vec![false; n_strata as usize];
+        for (i, &s) in strata_indices.iter().enumerate() {
+            if s != u32::MAX && !seen[s as usize] {
+                per_stratum[s as usize] = fpc_vals[i];
+                seen[s as usize] = true;
+            }
+        }
+        per_stratum
+    });
+
+    let ssu_indices = if has_stage2 {
+        Some(design_col_codes(ssu.unwrap())?.0)
+    } else {
+        None
+    };
+
+    match psu {
+        Some(psu_col) => {
+            // Nest PSU within stratum so PSU labels reused across strata are
+            // distinct PSUs (matches R survey / glm.rs).
+            let (psu_indices, _) = design_pair_codes(strata_col, psu_col)?;
+            let (psu_per_stratum, n_psus_per_stratum) =
+                build_stratum_psu_map(&strata_indices, n_strata, &psu_indices);
+
+            // PSU → stratum mapping for stage 2.
+            let max_psu = psu_indices
+                .iter()
+                .filter(|&&p| p != u32::MAX)
+                .max()
+                .copied()
+                .unwrap_or(0);
+            let mut psu_to_stratum = vec![0u32; (max_psu + 1) as usize];
+            for (&psu_idx, &str_idx) in psu_indices.iter().zip(strata_indices.iter()) {
+                if psu_idx != u32::MAX && str_idx != u32::MAX {
+                    psu_to_stratum[psu_idx as usize] = str_idx;
+                }
+            }
+
+            Ok(TaylorDesign {
+                sm_enum,
+                strata_indices: Some(strata_indices),
+                n_strata,
+                psu_indices: Some(psu_indices),
+                n_psus: 0,
+                psu_per_stratum: Some(psu_per_stratum),
+                n_psus_per_stratum: Some(n_psus_per_stratum),
+                fpc_val: 1.0,
+                fpc_per_stratum: fpc_by_stratum,
+                has_stage2,
+                ssu_indices,
+                fpc_ssu_arr,
+                psu_to_stratum: Some(psu_to_stratum),
+            })
+        }
+        None => Ok(TaylorDesign {
+            sm_enum,
+            strata_indices: Some(strata_indices),
+            n_strata,
+            psu_indices: None,
+            n_psus: 0,
+            psu_per_stratum: None,
+            n_psus_per_stratum: None,
+            fpc_val: 1.0,
+            fpc_per_stratum: fpc_by_stratum,
+            has_stage2,
+            ssu_indices,
+            fpc_ssu_arr,
+            psu_to_stratum: None,
+        }),
+    }
+}
+
+/// Apply a prebuilt [`TaylorDesign`] to a score vector. This is the only
+/// scores-dependent part; a by-group loop calls it once per group.
+pub fn taylor_variance_apply(scores_arr: &[f64], d: &TaylorDesign) -> f64 {
+    // --- STAGE 1 ---
+    let var_stage1 = if d.strata_indices.is_none() {
+        d.fpc_val * variance_unstratified_optimized(scores_arr, d.psu_indices.as_deref(), d.n_psus)
+    } else {
+        variance_stratified_optimized(
+            scores_arr,
+            d.strata_indices.as_deref().unwrap(),
+            d.n_strata,
+            d.psu_indices.as_deref(),
+            d.psu_per_stratum.as_deref(),
+            d.n_psus_per_stratum.as_deref(),
+            d.fpc_per_stratum.as_deref(),
+            d.sm_enum,
+        )
+    };
+
+    // --- STAGE 2 ---
+    if !d.has_stage2 {
+        return var_stage1;
+    }
+
+    // Stage 2 needs a per-row PSU vector; for the two-stage designs that reach
+    // here it is always the stage-1 PSU codes (present whenever psu is set).
+    let psu_indices = d.psu_indices.as_deref().unwrap();
+    let ssu_indices = d.ssu_indices.as_deref().unwrap();
+
+    let var_stage2 = compute_stage2_variance(
+        scores_arr,
+        psu_indices,
+        ssu_indices,
+        d.strata_indices.as_deref(),
+        d.fpc_per_stratum.as_deref(),
+        d.fpc_ssu_arr.as_deref(),
+        d.psu_to_stratum.as_deref(),
+    );
+
+    var_stage1 + var_stage2
+}
+
 pub fn taylor_variance(
     scores: &Float64Chunked,
     strata: Option<&Column>,
@@ -1082,165 +1285,9 @@ pub fn taylor_variance(
     if n == 0 {
         return Ok(0.0);
     }
-
-    let sm_enum = match singleton_method {
-        Some(s) if s.eq_ignore_ascii_case("center") || s.eq_ignore_ascii_case("adjust") => {
-            SingletonMethod::Center
-        }
-        _ => SingletonMethod::None,
-    };
-
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, n)?;
     let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
-    let fpc_arr: Option<Vec<f64>> = fpc.map(|f| f.iter().map(|v| v.unwrap_or(1.0)).collect());
-    let fpc_ssu_arr: Option<Vec<f64>> =
-        fpc_ssu.map(|f| f.iter().map(|v| v.unwrap_or(1.0)).collect());
-
-    // --- STAGE 1 VARIANCE ---
-    let (
-        var_stage1,
-        psu_indices_opt,
-        strata_indices_opt,
-        _n_strata_val,
-        fpc_per_stratum,
-        psu_stratum_map,
-    ) = if strata.is_none() {
-        // Unstratified: single FPC value (take first element or 1.0)
-        let fpc_val = fpc_arr
-            .as_ref()
-            .and_then(|f| f.first().copied())
-            .unwrap_or(1.0);
-
-        let (psu_indices, n_psus) = match psu {
-            Some(psu_col) => {
-                let (idx, n) = design_col_codes(psu_col)?;
-                (Some(idx), n)
-            }
-            None => (None, 0),
-        };
-        let var = variance_unstratified_optimized(&scores_arr, psu_indices.as_deref(), n_psus);
-        // Pass the (single) stage-1 FPC through so compute_stage2_variance
-        // can derive the stage-1 sampling fraction; returning None here would
-        // silently drop the stage-2 contribution for unstratified designs.
-        (
-            fpc_val * var,
-            psu_indices,
-            None,
-            0u32,
-            Some(vec![fpc_val]),
-            None,
-        )
-    } else {
-        let strata_col = strata.unwrap();
-        let (strata_indices, n_strata) = design_col_codes(strata_col)?;
-
-        // Build per-stratum FPC: for each stratum index h, take the FPC value
-        // from the first row belonging to that stratum.
-        let fpc_by_stratum: Option<Vec<f64>> = fpc_arr.as_ref().map(|fpc_vals| {
-            let mut per_stratum = vec![1.0; n_strata as usize];
-            let mut seen = vec![false; n_strata as usize];
-            for (i, &s) in strata_indices.iter().enumerate() {
-                if s != u32::MAX && !seen[s as usize] {
-                    per_stratum[s as usize] = fpc_vals[i];
-                    seen[s as usize] = true;
-                }
-            }
-            per_stratum
-        });
-
-        match psu {
-            Some(psu_col) => {
-                // Nest PSU within stratum so PSU labels reused across strata
-                // are distinct PSUs (matches R survey / glm.rs).
-                let (psu_indices, _) = design_pair_codes(strata_col, psu_col)?;
-                let (psu_per_stratum, n_psus_per_stratum) =
-                    build_stratum_psu_map(&strata_indices, n_strata, &psu_indices);
-
-                // Build PSU -> stratum mapping for stage 2
-                let max_psu = psu_indices
-                    .iter()
-                    .filter(|&&p| p != u32::MAX)
-                    .max()
-                    .copied()
-                    .unwrap_or(0);
-                let mut psu_to_stratum = vec![0u32; (max_psu + 1) as usize];
-                for (&psu_idx, &str_idx) in psu_indices.iter().zip(strata_indices.iter()) {
-                    if psu_idx != u32::MAX && str_idx != u32::MAX {
-                        psu_to_stratum[psu_idx as usize] = str_idx;
-                    }
-                }
-
-                let var = variance_stratified_optimized(
-                    &scores_arr,
-                    &strata_indices,
-                    n_strata,
-                    Some(&psu_indices),
-                    Some(&psu_per_stratum),
-                    Some(&n_psus_per_stratum),
-                    fpc_by_stratum.as_deref(),
-                    sm_enum,
-                );
-                (
-                    var,
-                    Some(psu_indices),
-                    Some(strata_indices),
-                    n_strata,
-                    fpc_by_stratum,
-                    Some(psu_to_stratum),
-                )
-            }
-            None => {
-                let var = variance_stratified_optimized(
-                    &scores_arr,
-                    &strata_indices,
-                    n_strata,
-                    None,
-                    None,
-                    None,
-                    fpc_by_stratum.as_deref(),
-                    sm_enum,
-                );
-                (
-                    var,
-                    None,
-                    Some(strata_indices),
-                    n_strata,
-                    fpc_by_stratum,
-                    None,
-                )
-            }
-        }
-    };
-
-    // --- STAGE 2 VARIANCE ---
-    if ssu.is_none() || psu.is_none() {
-        return Ok(var_stage1);
-    }
-
-    let ssu_col = ssu.unwrap();
-    let (ssu_indices, _) = design_col_codes(ssu_col)?;
-
-    let psu_indices = match psu_indices_opt {
-        Some(idx) => idx,
-        None => {
-            if let Some(p) = psu {
-                design_col_codes(p)?.0
-            } else {
-                (0..n as u32).collect()
-            }
-        }
-    };
-
-    let var_stage2 = compute_stage2_variance(
-        &scores_arr,
-        &psu_indices,
-        &ssu_indices,
-        strata_indices_opt.as_deref(),
-        fpc_per_stratum.as_deref(),
-        fpc_ssu_arr.as_deref(),
-        psu_stratum_map.as_deref(),
-    );
-
-    Ok(var_stage1 + var_stage2)
+    Ok(taylor_variance_apply(&scores_arr, &design))
 }
 
 pub fn degrees_of_freedom(

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -1100,7 +1100,6 @@ pub fn build_taylor_design(
     fpc: Option<&Float64Chunked>,
     fpc_ssu: Option<&Float64Chunked>,
     singleton_method: Option<&str>,
-    n: usize,
 ) -> PolarsResult<TaylorDesign> {
     let sm_enum = match singleton_method {
         Some(s) if s.eq_ignore_ascii_case("center") || s.eq_ignore_ascii_case("adjust") => {
@@ -1285,7 +1284,7 @@ pub fn taylor_variance(
     if n == 0 {
         return Ok(0.0);
     }
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, n)?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
     let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
     Ok(taylor_variance_apply(&scores_arr, &design))
 }

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -160,6 +160,15 @@ pub fn point_estimate_total_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                sum_wy += ys[i] * ws[i];
+            }
+        }
+        return Ok(sum_wy);
+    }
     Ok(y.iter()
         .zip(weights.iter())
         .zip(domain_mask.iter())
@@ -213,18 +222,35 @@ pub fn point_estimate_ratio_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
-    let sum_wy: f64 = y
-        .iter()
-        .zip(weights.iter())
-        .zip(domain_mask.iter())
-        .filter_map(|((yi, wi), m)| if m? { Some(yi? * wi?) } else { None })
-        .sum();
-    let sum_wx: f64 = x
-        .iter()
-        .zip(weights.iter())
-        .zip(domain_mask.iter())
-        .filter_map(|((xi, wi), m)| if m? { Some(xi? * wi?) } else { None })
-        .sum();
+    let fast = match (cont_pair(y, weights), x.null_count() == 0) {
+        (Some((ys, ws)), true) => x.cont_slice().ok().map(|xs| (ys, ws, xs)),
+        _ => None,
+    };
+    let (sum_wy, sum_wx) = if let Some((ys, ws, xs)) = fast {
+        let mut sum_wy = 0.0f64;
+        let mut sum_wx = 0.0f64;
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                sum_wy += ys[i] * ws[i];
+                sum_wx += xs[i] * ws[i];
+            }
+        }
+        (sum_wy, sum_wx)
+    } else {
+        let sum_wy: f64 = y
+            .iter()
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
+            .filter_map(|((yi, wi), m)| if m? { Some(yi? * wi?) } else { None })
+            .sum();
+        let sum_wx: f64 = x
+            .iter()
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
+            .filter_map(|((xi, wi), m)| if m? { Some(xi? * wi?) } else { None })
+            .sum();
+        (sum_wy, sum_wx)
+    };
 
     if sum_wx == 0.0 {
         return Err(PolarsError::ComputeError(
@@ -531,6 +557,14 @@ pub fn scores_total_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<Float64Chunked> {
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let scores: Vec<f64> = domain_mask
+            .iter()
+            .enumerate()
+            .map(|(i, m)| if m == Some(true) { ws[i] * ys[i] } else { 0.0 })
+            .collect();
+        return Ok(Float64Chunked::from_slice("scores".into(), &scores));
+    }
     let scores: Vec<Option<f64>> = y
         .iter()
         .zip(weights.iter())
@@ -585,6 +619,37 @@ pub fn scores_ratio_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<Float64Chunked> {
+    let fast = match (cont_pair(y, weights), x.null_count() == 0) {
+        (Some((ys, ws)), true) => x.cont_slice().ok().map(|xs| (ys, ws, xs)),
+        _ => None,
+    };
+    if let Some((ys, ws, xs)) = fast {
+        let n = ys.len();
+        let in_domain: Vec<bool> = domain_mask.iter().map(|m| m == Some(true)).collect();
+        let mut sum_wy = 0.0f64;
+        let mut sum_wx = 0.0f64;
+        for i in 0..n {
+            if in_domain[i] {
+                sum_wy += ys[i] * ws[i];
+                sum_wx += xs[i] * ws[i];
+            }
+        }
+        if sum_wx == 0.0 {
+            return Ok(Float64Chunked::from_slice("scores".into(), &vec![0.0; n]));
+        }
+        let r_hat = sum_wy / sum_wx;
+        let scores: Vec<f64> = (0..n)
+            .map(|i| {
+                if in_domain[i] {
+                    (ws[i] / sum_wx) * (ys[i] - r_hat * xs[i])
+                } else {
+                    0.0
+                }
+            })
+            .collect();
+        return Ok(Float64Chunked::from_slice("scores".into(), &scores));
+    }
+
     // Single pass: accumulate sum_wy, sum_wx (in-domain) and collect quads.
     let n = y.len();
     let mut sum_wy = 0.0f64;
@@ -1607,18 +1672,31 @@ pub fn srs_variance_total_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
-    let mut yv = Vec::new();
-    let mut wv = Vec::new();
-    for ((yi, wi), mi) in y
-        .into_iter()
-        .zip(weights.into_iter())
-        .zip(domain_mask.into_iter())
-    {
-        if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
-            yv.push(y_val);
-            wv.push(w_val);
+    let (yv, wv) = if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut yv = Vec::new();
+        let mut wv = Vec::new();
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                yv.push(ys[i]);
+                wv.push(ws[i]);
+            }
         }
-    }
+        (yv, wv)
+    } else {
+        let mut yv = Vec::new();
+        let mut wv = Vec::new();
+        for ((yi, wi), mi) in y
+            .into_iter()
+            .zip(weights.into_iter())
+            .zip(domain_mask.into_iter())
+        {
+            if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
+                yv.push(y_val);
+                wv.push(w_val);
+            }
+        }
+        (yv, wv)
+    };
     let n = yv.len() as f64;
     if n < 2.0 {
         return Ok(f64::NAN);
@@ -1672,21 +1750,40 @@ pub fn srs_variance_ratio_domain(
     weights: &Float64Chunked,
     domain_mask: &BooleanChunked,
 ) -> PolarsResult<f64> {
-    let mut yv = Vec::new();
-    let mut xv = Vec::new();
-    let mut wv = Vec::new();
-    for (((yi, xi), wi), mi) in y
-        .into_iter()
-        .zip(x.into_iter())
-        .zip(weights.into_iter())
-        .zip(domain_mask.into_iter())
-    {
-        if let (Some(y_val), Some(x_val), Some(w_val), Some(true)) = (yi, xi, wi, mi) {
-            yv.push(y_val);
-            xv.push(x_val);
-            wv.push(w_val);
+    let fast = match (cont_pair(y, weights), x.null_count() == 0) {
+        (Some((ys, ws)), true) => x.cont_slice().ok().map(|xs| (ys, ws, xs)),
+        _ => None,
+    };
+    let (yv, xv, wv) = if let Some((ys, ws, xs)) = fast {
+        let mut yv = Vec::new();
+        let mut xv = Vec::new();
+        let mut wv = Vec::new();
+        for (i, m) in domain_mask.iter().enumerate() {
+            if m == Some(true) {
+                yv.push(ys[i]);
+                xv.push(xs[i]);
+                wv.push(ws[i]);
+            }
         }
-    }
+        (yv, xv, wv)
+    } else {
+        let mut yv = Vec::new();
+        let mut xv = Vec::new();
+        let mut wv = Vec::new();
+        for (((yi, xi), wi), mi) in y
+            .into_iter()
+            .zip(x.into_iter())
+            .zip(weights.into_iter())
+            .zip(domain_mask.into_iter())
+        {
+            if let (Some(y_val), Some(x_val), Some(w_val), Some(true)) = (yi, xi, wi, mi) {
+                yv.push(y_val);
+                xv.push(x_val);
+                wv.push(w_val);
+            }
+        }
+        (yv, xv, wv)
+    };
     let n = yv.len() as f64;
     if n < 2.0 {
         return Ok(f64::NAN);

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -137,7 +137,7 @@ fn compute_mean_grouped(
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     // Index the design once — it is identical across by-groups; only the
     // domain-masked scores change per group.
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -257,7 +257,7 @@ fn compute_total_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -380,7 +380,7 @@ fn compute_ratio_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -478,7 +478,7 @@ fn compute_prop_ungrouped(
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     let n = weights.len() as u32;
     // Design is identical across levels; index it once.
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, n as usize)?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
     for lvl in &levels {
         let indicator: Vec<Option<f64>> = value_str.iter()
@@ -544,7 +544,7 @@ fn compute_prop_grouped(
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     // Design is identical across all (group, level) cells; index it once.
-    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, weights.len())?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -10,6 +10,7 @@ use pyo3_polars::PyDataFrame;
 
 use crate::estimation::taylor::{
     SvyQuantileMethod,
+    build_taylor_design,
     degrees_of_freedom,
     median_variance_woodruff,
     median_variance_woodruff_domain,
@@ -22,7 +23,7 @@ use crate::estimation::taylor::{
     srs_variance_mean, srs_variance_mean_domain,
     srs_variance_ratio, srs_variance_ratio_domain,
     srs_variance_total, srs_variance_total_domain,
-    taylor_variance,
+    taylor_variance, taylor_variance_apply,
     weighted_median, weighted_median_domain,
 };
 
@@ -134,6 +135,9 @@ fn compute_mean_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
+    // Index the design once — it is identical across by-groups; only the
+    // domain-masked scores change per group.
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -141,7 +145,8 @@ fn compute_mean_grouped(
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_mean_domain(y, weights, &domain_mask)?;
             let scores      = scores_mean_domain(y, weights, &domain_mask)?;
-            let variance    = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+            let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+            let variance    = taylor_variance_apply(&scores_arr, &design);
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_mean_domain(y, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
@@ -252,6 +257,7 @@ fn compute_total_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -259,7 +265,8 @@ fn compute_total_grouped(
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_total_domain(y, weights, &domain_mask)?;
             let scores      = scores_total_domain(y, weights, &domain_mask)?;
-            let variance    = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+            let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+            let variance    = taylor_variance_apply(&scores_arr, &design);
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_total_domain(y, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
@@ -373,6 +380,7 @@ fn compute_ratio_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, y.len())?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -380,7 +388,8 @@ fn compute_ratio_grouped(
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_ratio_domain(y, x, weights, &domain_mask)?;
             let scores      = scores_ratio_domain(y, x, weights, &domain_mask)?;
-            let variance    = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+            let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+            let variance    = taylor_variance_apply(&scores_arr, &design);
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_ratio_domain(y, x, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
@@ -468,6 +477,8 @@ fn compute_prop_ungrouped(
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     let n = weights.len() as u32;
+    // Design is identical across levels; index it once.
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, n as usize)?;
 
     for lvl in &levels {
         let indicator: Vec<Option<f64>> = value_str.iter()
@@ -480,7 +491,8 @@ fn compute_prop_ungrouped(
         let indicator_ca = Float64Chunked::from_slice_options("indicator".into(), &indicator);
         let estimate = point_estimate_mean(&indicator_ca, weights)?;
         let scores   = scores_mean(&indicator_ca, weights)?;
-        let variance = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+        let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+        let variance = taylor_variance_apply(&scores_arr, &design);
         let se       = variance.max(0.0).sqrt();
         let srs_var  = srs_variance_mean(&indicator_ca, weights)?;
         let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
@@ -531,6 +543,8 @@ fn compute_prop_grouped(
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
+    // Design is identical across all (group, level) cells; index it once.
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method, weights.len())?;
 
     for group_val in unique_groups.iter() {
         if let Some(group) = group_val {
@@ -547,7 +561,8 @@ fn compute_prop_grouped(
                 let indicator_ca = Float64Chunked::from_slice_options("indicator".into(), &indicator);
                 let estimate = point_estimate_mean_domain(&indicator_ca, weights, &domain_mask)?;
                 let scores   = scores_mean_domain(&indicator_ca, weights, &domain_mask)?;
-                let variance = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+                let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+                let variance = taylor_variance_apply(&scores_arr, &design);
                 let se       = variance.max(0.0).sqrt();
                 let srs_var  = srs_variance_mean_domain(&indicator_ca, weights, &domain_mask)?;
                 let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };


### PR DESCRIPTION
Builds on merged Phase A/B/C. Two Rust-side threads: dedup the per-group design indexing, and make replication fast (it was the slowest estimator, now the fastest). All commits bit-identical — the full 2441-test suite is green at each step.

## Headline: replication went from slowest to fastest

| case (1M × R=40) | before | after |
|---|---|---|
| mean / replication | ~405 ms | **14 ms (27×)** |
| total / ratio replication | ~405 ms | 13 / 17 ms |
| by-group replication (by=sex) | ~400 ms | **82 ms** |

Profiling drove this: the cost was never the replicate *compute* (7 ms) — it was building the flat n×R weight matrix. Two layers:
1. **Layout** (`a9a360b`): the naive `matrix[i*n_reps+r]` build is a strided store (cache miss per write) — replaced with a **cache-blocked parallel transpose** (byte-identical output, no consumer touched). 405→40 ms.
2. **Materialisation** (`d029e78`/`7c9a727`/`93900dd`/`aaac779`): at realistic high replicate counts the n×R matrix itself is the limit (moved through memory 3× + strided gather). The real fix is **not building it** — accumulate each replicate straight from its contiguous weight column, parallel over replicates. Bit-identical (each replicate still sums in row order). Now covers mean/total/ratio, overall and by-group. 40→14 ms and scales far better at high R.

## Commits

1. **`863a07c` by-group design dedup** — split `taylor_variance` into `build_taylor_design` (design-only) + `taylor_variance_apply` (scores-only); `taylor_variance` = build + apply (single source, bit-identical). `compute_*_grouped` build the design once and apply per group/level instead of re-indexing every group.
2. **`a9a360b`** cache-blocked parallel replicate-matrix build (all estimators, ~10×).
3. **`d029e78` / `7c9a727`** no-materialisation ungrouped replicate mean / total / ratio (27×).
4. **`93900dd` / `aaac779`** same for the by-group variants.

## Parallelism notes
- Uses rayon's **global pool** — no explicit config, so thread count = `RAYON_NUM_THREADS` env else all logical cores. A first-class thread-count control is deferred as a follow-up (needs `build_global` at init + coordination with polars' separate pool).
- Determinism: parallelism is **over replicates** (independent) or **over disjoint matrix blocks**, so results are identical regardless of thread count — not just within tolerance.

## Not in this PR (follow-ups)
- **prop / median** replication still use the (≥10× transpose) path — prop has level indicators, median is a per-replicate weighted quantile (sort-bound). Convertible with the same column pattern.
- Domain-kernel fusing, `par_iter` over by-groups, `faer` parallel GLM solves.