### PR TITLE
perf: parallelise estimation by releasing the GIL (Phase D follow-up)

### DIFF
--- a/packages/svy-rs/src/estimation/mod.rs
+++ b/packages/svy-rs/src/estimation/mod.rs
@@ -1,4 +1,20 @@
 // src/estimation/mod.rs
+//
+// # Parallelism & determinism policy
+//
+// Estimation kernels parallelise over *independent* dimensions only — by-group
+// cells (`taylor_api`) and replicate weights (`replication`) — never over the
+// summation of a single estimate. Each group/replicate is still accumulated in
+// row order, and results are collected back in the original (group, replicate)
+// order. Consequently **output is bit-for-bit identical regardless of the rayon
+// thread count** (`RAYON_NUM_THREADS`) and stable run-to-run for a given input.
+// The golden suite is the contract; changing thread count must not change a bit.
+//
+// The PyO3 entry points release the GIL (`Python::detach`) around this compute.
+// This is mandatory, not cosmetic: without it the interpreter lock keeps the
+// rayon worker threads from ever running the closures, so the `par_iter` /
+// per-replicate parallelism silently executes serially. Release-then-parallelise
+// is what turns the fan-out into real wall-clock speedup (measured 3–6×).
 pub mod replication;
 pub mod replication_api;
 pub mod taylor;

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -90,13 +90,15 @@ pub fn replicate_mean(
     let variance_center  = parse_variance_center(center)?;
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
-    let result = if by_col.is_none() {
-        compute_replicate_mean_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val)
-    } else {
-        compute_replicate_mean_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
-    };
+    let result = _py.detach(|| {
+        if by_col.is_none() {
+            compute_replicate_mean_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val)
+        } else {
+            compute_replicate_mean_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+        }
+    });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 
@@ -199,13 +201,15 @@ pub fn replicate_total(
     let variance_center = parse_variance_center(center)?;
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
-    let result = if by_col.is_none() {
-        compute_replicate_total_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val)
-    } else {
-        compute_replicate_total_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
-    };
+    let result = _py.detach(|| {
+        if by_col.is_none() {
+            compute_replicate_total_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val)
+        } else {
+            compute_replicate_total_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+        }
+    });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 
@@ -307,14 +311,16 @@ pub fn replicate_ratio(
     let variance_center = parse_variance_center(center)?;
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
-    let result = if by_col.is_none() {
-        compute_replicate_ratio_ungrouped(&df, &numerator_col, &denominator_col, &weight_col,
-            &rep_weight_cols, rep_method, fay_coef, variance_center, df_val)
-    } else {
-        compute_replicate_ratio_grouped(&df, &numerator_col, &denominator_col, &weight_col,
-            &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
-            by_col.as_ref().unwrap())
-    };
+    let result = _py.detach(|| {
+        if by_col.is_none() {
+            compute_replicate_ratio_ungrouped(&df, &numerator_col, &denominator_col, &weight_col,
+                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val)
+        } else {
+            compute_replicate_ratio_grouped(&df, &numerator_col, &denominator_col, &weight_col,
+                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
+                by_col.as_ref().unwrap())
+        }
+    });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 
@@ -421,13 +427,15 @@ pub fn replicate_prop(
     let variance_center = parse_variance_center(center)?;
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
-    let result = if by_col.is_none() {
-        compute_replicate_prop_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val)
-    } else {
-        compute_replicate_prop_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
-    };
+    let result = _py.detach(|| {
+        if by_col.is_none() {
+            compute_replicate_prop_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val)
+        } else {
+            compute_replicate_prop_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+        }
+    });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 
@@ -610,13 +618,15 @@ pub fn replicate_median(
         .unwrap_or(SvyQuantileMethod::Higher);
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
-    let result = if by_col.is_none() {
-        compute_replicate_median_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val, q_method)
-    } else {
-        compute_replicate_median_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-            rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap(), q_method)
-    };
+    let result = _py.detach(|| {
+        if by_col.is_none() {
+            compute_replicate_median_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val, q_method)
+        } else {
+            compute_replicate_median_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
+                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap(), q_method)
+        }
+    });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }
 

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -7,6 +7,7 @@
 use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
+use rayon::prelude::*;
 
 use crate::estimation::taylor::{
     SvyQuantileMethod,
@@ -72,13 +73,17 @@ pub fn taylor_mean(
         return Ok(PyDataFrame(result));
     }
 
-    let result = compute_mean_grouped(
-        &df, &value_col, &weight_col,
-        strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
-        fpc_col.as_deref(), fpc_ssu_col.as_deref(),
-        &by_col.unwrap(), singleton_method.as_deref(),
-    )
-    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let by = by_col.unwrap();
+    let result = _py
+        .detach(|| {
+            compute_mean_grouped(
+                &df, &value_col, &weight_col,
+                strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
+                fpc_col.as_deref(), fpc_ssu_col.as_deref(),
+                &by, singleton_method.as_deref(),
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
     Ok(PyDataFrame(result))
 }
 
@@ -127,20 +132,17 @@ fn compute_mean_grouped(
     let by_str = df.column(by_col)?.str()?;
     let unique_groups = by_str.unique()?;
 
-    let mut by_vals: Vec<&str> = Vec::new();
-    let mut estimates: Vec<f64> = Vec::new();
-    let mut ses: Vec<f64> = Vec::new();
-    let mut variances: Vec<f64> = Vec::new();
-    let mut dfs: Vec<u32> = Vec::new();
-    let mut ns: Vec<u32> = Vec::new();
-    let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     // Index the design once — it is identical across by-groups; only the
     // domain-masked scores change per group.
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
-    for group_val in unique_groups.iter() {
-        if let Some(group) = group_val {
+    // Groups are independent; fan the per-group work out over the rayon pool
+    // and collect in group order (deterministic, thread-count-independent).
+    let groups: Vec<&str> = unique_groups.iter().flatten().collect();
+    let rows = groups
+        .par_iter()
+        .map(|&group| -> PolarsResult<(&str, f64, f64, f64, u32, f64)> {
             let domain_mask = by_str.equal(group);
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_mean_domain(y, weights, &domain_mask)?;
@@ -150,17 +152,26 @@ fn compute_mean_grouped(
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_mean_domain(y, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+            Ok((group, estimate, se, variance, n_domain, deff))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
 
-            by_vals.push(group);
-            estimates.push(estimate);
-            ses.push(se);
-            variances.push(variance);
-            dfs.push(df_val);
-            ns.push(n_domain);
-            deffs.push(deff);
-        }
+    let n_groups = rows.len();
+    let mut by_vals: Vec<&str> = Vec::with_capacity(n_groups);
+    let mut estimates: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ses: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut variances: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ns: Vec<u32> = Vec::with_capacity(n_groups);
+    let mut deffs: Vec<f64> = Vec::with_capacity(n_groups);
+    for (g, est, se, var, n, deff) in rows {
+        by_vals.push(g);
+        estimates.push(est);
+        ses.push(se);
+        variances.push(var);
+        ns.push(n);
+        deffs.push(deff);
     }
-    let n_groups = by_vals.len();
+    let dfs = vec![df_val; n_groups];
     df![by_col => by_vals, "y" => vec![value_col; n_groups], "est" => estimates,
         "se" => ses, "var" => variances, "df" => dfs, "n" => ns, "deff" => deffs]
 }
@@ -194,13 +205,17 @@ pub fn taylor_total(
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         return Ok(PyDataFrame(result));
     }
-    let result = compute_total_grouped(
-        &df, &value_col, &weight_col,
-        strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
-        fpc_col.as_deref(), fpc_ssu_col.as_deref(),
-        &by_col.unwrap(), singleton_method.as_deref(),
-    )
-    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let by = by_col.unwrap();
+    let result = _py
+        .detach(|| {
+            compute_total_grouped(
+                &df, &value_col, &weight_col,
+                strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
+                fpc_col.as_deref(), fpc_ssu_col.as_deref(),
+                &by, singleton_method.as_deref(),
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
     Ok(PyDataFrame(result))
 }
 
@@ -249,18 +264,13 @@ fn compute_total_grouped(
     let by_str = df.column(by_col)?.str()?;
     let unique_groups = by_str.unique()?;
 
-    let mut by_vals: Vec<&str> = Vec::new();
-    let mut estimates: Vec<f64> = Vec::new();
-    let mut ses: Vec<f64> = Vec::new();
-    let mut variances: Vec<f64> = Vec::new();
-    let mut dfs: Vec<u32> = Vec::new();
-    let mut ns: Vec<u32> = Vec::new();
-    let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
-    for group_val in unique_groups.iter() {
-        if let Some(group) = group_val {
+    let groups: Vec<&str> = unique_groups.iter().flatten().collect();
+    let rows = groups
+        .par_iter()
+        .map(|&group| -> PolarsResult<(&str, f64, f64, f64, u32, f64)> {
             let domain_mask = by_str.equal(group);
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_total_domain(y, weights, &domain_mask)?;
@@ -270,17 +280,26 @@ fn compute_total_grouped(
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_total_domain(y, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+            Ok((group, estimate, se, variance, n_domain, deff))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
 
-            by_vals.push(group);
-            estimates.push(estimate);
-            ses.push(se);
-            variances.push(variance);
-            dfs.push(df_val);
-            ns.push(n_domain);
-            deffs.push(deff);
-        }
+    let n_groups = rows.len();
+    let mut by_vals: Vec<&str> = Vec::with_capacity(n_groups);
+    let mut estimates: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ses: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut variances: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ns: Vec<u32> = Vec::with_capacity(n_groups);
+    let mut deffs: Vec<f64> = Vec::with_capacity(n_groups);
+    for (g, est, se, var, n, deff) in rows {
+        by_vals.push(g);
+        estimates.push(est);
+        ses.push(se);
+        variances.push(var);
+        ns.push(n);
+        deffs.push(deff);
     }
-    let n_groups = by_vals.len();
+    let dfs = vec![df_val; n_groups];
     df![by_col => by_vals, "y" => vec![value_col; n_groups], "est" => estimates,
         "se" => ses, "var" => variances, "df" => dfs, "n" => ns, "deff" => deffs]
 }
@@ -315,13 +334,17 @@ pub fn taylor_ratio(
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         return Ok(PyDataFrame(result));
     }
-    let result = compute_ratio_grouped(
-        &df, &numerator_col, &denominator_col, &weight_col,
-        strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
-        fpc_col.as_deref(), fpc_ssu_col.as_deref(),
-        &by_col.unwrap(), singleton_method.as_deref(),
-    )
-    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let by = by_col.unwrap();
+    let result = _py
+        .detach(|| {
+            compute_ratio_grouped(
+                &df, &numerator_col, &denominator_col, &weight_col,
+                strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
+                fpc_col.as_deref(), fpc_ssu_col.as_deref(),
+                &by, singleton_method.as_deref(),
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
     Ok(PyDataFrame(result))
 }
 
@@ -372,18 +395,13 @@ fn compute_ratio_grouped(
     let by_str = df.column(by_col)?.str()?;
     let unique_groups = by_str.unique()?;
 
-    let mut by_vals: Vec<&str> = Vec::new();
-    let mut estimates: Vec<f64> = Vec::new();
-    let mut ses: Vec<f64> = Vec::new();
-    let mut variances: Vec<f64> = Vec::new();
-    let mut dfs: Vec<u32> = Vec::new();
-    let mut ns: Vec<u32> = Vec::new();
-    let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
-    for group_val in unique_groups.iter() {
-        if let Some(group) = group_val {
+    let groups: Vec<&str> = unique_groups.iter().flatten().collect();
+    let rows = groups
+        .par_iter()
+        .map(|&group| -> PolarsResult<(&str, f64, f64, f64, u32, f64)> {
             let domain_mask = by_str.equal(group);
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
             let estimate    = point_estimate_ratio_domain(y, x, weights, &domain_mask)?;
@@ -393,17 +411,26 @@ fn compute_ratio_grouped(
             let se          = variance.max(0.0).sqrt();
             let srs_var     = srs_variance_ratio_domain(y, x, weights, &domain_mask)?;
             let deff        = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+            Ok((group, estimate, se, variance, n_domain, deff))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
 
-            by_vals.push(group);
-            estimates.push(estimate);
-            ses.push(se);
-            variances.push(variance);
-            dfs.push(df_val);
-            ns.push(n_domain);
-            deffs.push(deff);
-        }
+    let n_groups = rows.len();
+    let mut by_vals: Vec<&str> = Vec::with_capacity(n_groups);
+    let mut estimates: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ses: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut variances: Vec<f64> = Vec::with_capacity(n_groups);
+    let mut ns: Vec<u32> = Vec::with_capacity(n_groups);
+    let mut deffs: Vec<f64> = Vec::with_capacity(n_groups);
+    for (g, est, se, var, n, deff) in rows {
+        by_vals.push(g);
+        estimates.push(est);
+        ses.push(se);
+        variances.push(var);
+        ns.push(n);
+        deffs.push(deff);
     }
-    let n_groups = by_vals.len();
+    let dfs = vec![df_val; n_groups];
     df![by_col => by_vals, "y" => vec![numerator_col; n_groups], "x" => vec![denominator_col; n_groups],
         "est" => estimates, "se" => ses, "var" => variances, "df" => dfs, "n" => ns, "deff" => deffs]
 }
@@ -437,13 +464,17 @@ pub fn taylor_prop(
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         return Ok(PyDataFrame(result));
     }
-    let result = compute_prop_grouped(
-        &df, &value_col, &weight_col,
-        strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
-        fpc_col.as_deref(), fpc_ssu_col.as_deref(),
-        &by_col.unwrap(), singleton_method.as_deref(),
-    )
-    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let by = by_col.unwrap();
+    let result = _py
+        .detach(|| {
+            compute_prop_grouped(
+                &df, &value_col, &weight_col,
+                strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
+                fpc_col.as_deref(), fpc_ssu_col.as_deref(),
+                &by, singleton_method.as_deref(),
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
     Ok(PyDataFrame(result))
 }
 
@@ -534,22 +565,20 @@ fn compute_prop_grouped(
     let by_str = df.column(by_col)?.str()?;
     let unique_groups = by_str.unique()?;
 
-    let mut by_vals: Vec<String> = Vec::new();
-    let mut level_vals: Vec<String> = Vec::new();
-    let mut estimates: Vec<f64> = Vec::new();
-    let mut ses: Vec<f64> = Vec::new();
-    let mut variances: Vec<f64> = Vec::new();
-    let mut dfs_vec: Vec<u32> = Vec::new();
-    let mut ns: Vec<u32> = Vec::new();
-    let mut deffs: Vec<f64> = Vec::new();
     let df_val = degrees_of_freedom(weights, strata, psu)?;
     // Design is identical across all (group, level) cells; index it once.
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
 
-    for group_val in unique_groups.iter() {
-        if let Some(group) = group_val {
+    // Fan out over groups; each group emits its level rows in `levels` order,
+    // then flatten in group order for a deterministic layout.
+    type PropRow = (String, String, f64, f64, f64, u32, f64);
+    let groups: Vec<&str> = unique_groups.iter().flatten().collect();
+    let per_group = groups
+        .par_iter()
+        .map(|&group| -> PolarsResult<Vec<PropRow>> {
             let domain_mask = by_str.equal(group);
             let n_domain    = domain_mask.sum().unwrap_or(0) as u32;
+            let mut out: Vec<PropRow> = Vec::with_capacity(levels.len());
             for lvl in &levels {
                 let indicator: Vec<Option<f64>> = value_str.iter()
                     .map(|v| match v {
@@ -566,19 +595,32 @@ fn compute_prop_grouped(
                 let se       = variance.max(0.0).sqrt();
                 let srs_var  = srs_variance_mean_domain(&indicator_ca, weights, &domain_mask)?;
                 let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
-
-                by_vals.push(group.to_string());
-                level_vals.push(lvl.clone());
-                estimates.push(estimate);
-                ses.push(se);
-                variances.push(variance);
-                dfs_vec.push(df_val);
-                ns.push(n_domain);
-                deffs.push(deff);
+                out.push((group.to_string(), lvl.clone(), estimate, se, variance, n_domain, deff));
             }
+            Ok(out)
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let mut by_vals: Vec<String> = Vec::new();
+    let mut level_vals: Vec<String> = Vec::new();
+    let mut estimates: Vec<f64> = Vec::new();
+    let mut ses: Vec<f64> = Vec::new();
+    let mut variances: Vec<f64> = Vec::new();
+    let mut ns: Vec<u32> = Vec::new();
+    let mut deffs: Vec<f64> = Vec::new();
+    for group_rows in per_group {
+        for (g, lvl, est, se, var, n, deff) in group_rows {
+            by_vals.push(g);
+            level_vals.push(lvl);
+            estimates.push(est);
+            ses.push(se);
+            variances.push(var);
+            ns.push(n);
+            deffs.push(deff);
         }
     }
     let n_rows = by_vals.len();
+    let dfs_vec = vec![df_val; n_rows];
     df![by_col => by_vals, "y" => vec![value_col; n_rows], "level" => level_vals,
         "est" => estimates, "se" => ses, "var" => variances, "df" => dfs_vec, "n" => ns, "deff" => deffs]
 }

--- a/packages/svy-rs/src/regression/api.rs
+++ b/packages/svy-rs/src/regression/api.rs
@@ -74,18 +74,22 @@ pub fn fit_glm_rs(
 
     // No by_col: single fit, wrap in one-element vec for API uniformity.
     if by_col.is_none() {
-        let result = fit_glm(
-            &y,
-            x_cols,
-            &weights,
-            stratum.as_ref(),
-            psu.as_ref(),
-            &family,
-            &link,
-            tol,
-            max_iter,
-        )
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        // Release the GIL for the (iterative, CPU-bound) IRLS solve.
+        let result = _py
+            .detach(|| {
+                fit_glm(
+                    &y,
+                    x_cols,
+                    &weights,
+                    stratum.as_ref(),
+                    psu.as_ref(),
+                    &family,
+                    &link,
+                    tol,
+                    max_iter,
+                )
+            })
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
         return Ok(vec![(
             String::new(),
@@ -100,22 +104,26 @@ pub fn fit_glm_rs(
         )]);
     }
 
-    // by_col supplied: one fit per domain level.
+    // by_col supplied: one fit per domain level (fanned out in parallel, GIL
+    // released — the domain fits are independent).
     let by_series = column_to_series(&df, &by_col.unwrap())?;
 
-    let results = fit_glm_by(
-        &y,
-        x_cols,
-        &weights,
-        stratum.as_ref(),
-        psu.as_ref(),
-        &by_series,
-        &family,
-        &link,
-        tol,
-        max_iter,
-    )
-    .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    let results = _py
+        .detach(|| {
+            fit_glm_by(
+                &y,
+                x_cols,
+                &weights,
+                stratum.as_ref(),
+                psu.as_ref(),
+                &by_series,
+                &family,
+                &link,
+                tol,
+                max_iter,
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
 
     Ok(results
         .into_iter()

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -23,6 +23,7 @@ use faer::prelude::Solve;
 use faer::{Mat, MatRef, Side};
 
 use polars::prelude::*;
+use rayon::prelude::*;
 use std::collections::HashMap;
 
 // ============================================================================
@@ -444,10 +445,13 @@ pub fn fit_glm_by(
     let by_str = by_str_series.str()?;
     let unique_groups = by_str.unique()?;
 
-    let mut results: Vec<(String, GlmResult)> = Vec::new();
-
-    for group_opt in unique_groups.iter() {
-        if let Some(group_val) = group_opt {
+    // Domain fits are independent; fan them out over the rayon pool and collect
+    // in level order (deterministic, thread-count-independent — see the policy
+    // note in estimation/mod.rs). Each fit is a full, self-contained IRLS solve.
+    let groups: Vec<&str> = unique_groups.iter().flatten().collect();
+    let results = groups
+        .par_iter()
+        .map(|&group_val| -> PolarsResult<(String, GlmResult)> {
             let mask_vec: Vec<bool> = by_str
                 .iter()
                 .map(|v| v.map_or(false, |s| s == group_val))
@@ -470,9 +474,9 @@ pub fn fit_glm_by(
                 max_iter,
             )?;
 
-            results.push((group_val.to_string(), res));
-        }
-    }
+            Ok((group_val.to_string(), res))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
 
     Ok(results)
 }


### PR DESCRIPTION
Follow-up to #29: the parallelism added in Phase D was dormant, and this extends it to regression.

## The problem
by-group Taylor, per-replicate replication, and by-domain GLM all fan work out with rayon — but a `#[pyfunction]` holds the Python GIL for its whole body, which blocks the rayon workers from running the closures. The fan-out executed serially on one core.

## The fix (2 commits)
**1. Estimation** — by-group Taylor (`compute_{mean,total,ratio,prop}_grouped`) serial loop → `par_iter` over independent groups; `Python::detach` around every grouped-Taylor and replication call so the pool engages.

**2. Regression** — `fit_glm_by` serial per-domain loop → `par_iter`; `detach` around the single fit and the by-domain fit (the by-domain path backs the `where=` restriction).

## Determinism
Parallelism is over independent dimensions only (groups, replicates, domain fits); each is summed in row order and collected back in original order. **Bit-for-bit identical regardless of `RAYON_NUM_THREADS`.** Policy documented in `estimation/mod.rs`.

## Measured (1M rows unless noted, 10 cores), serial → parallel
| case | serial | parallel | speedup |
|---|---|---|---|
| replication mean R=40 | 46.7 ms | 13.9 ms | 3.4× |
| replication mean R=200 | 203.6 ms | 37.3 ms | 5.5× |
| by=g50 (50 groups) | 668 ms | 156 ms | 4.3× |
| by=g200 (200 groups) | 2310 ms | 381 ms | 6.1× |
| GLM where-domain (400k, binomial) | 255.8 ms | 142.0 ms | 1.8× |

Single-threaded compute (ungrouped Taylor, single GLM fit) is unchanged in wall-clock; `detach` there just frees the GIL for other Python threads.

Full 2441-test golden suite green; 68 Rust unit tests green.