### PR TITLE
perf: mask ungrouped where= replication instead of materializing R zeroed columns (Phase E.1)

### DIFF
--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -240,6 +240,7 @@ pub fn matrix_mean_estimates(
     rep_weights: &[f64], // Flattened (n × R) row-major
     n: usize,
     n_reps: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     // Full sample estimate
     let sum_wy: f64 = y
@@ -254,15 +255,18 @@ pub fn matrix_mean_estimates(
         f64::NAN
     };
 
-    // Replicate estimates - single pass
+    // Replicate estimates - single pass. `domain_mask` (1.0 inside the domain,
+    // 0.0 outside) zeroes the replicate weight on the fly for `where=` domains,
+    // avoiding materialising R zeroed columns upstream. mask=None ⇒ mi=1.0.
     let mut rep_sum_wy = vec![0.0; n_reps];
     let mut rep_sum_w = vec![0.0; n_reps];
 
     for i in 0..n {
         let yi = y[i];
+        let mi = domain_mask.map_or(1.0, |m| m[i]);
         let base_idx = i * n_reps;
         for r in 0..n_reps {
-            let w_ir = rep_weights[base_idx + r];
+            let w_ir = rep_weights[base_idx + r] * mi;
             rep_sum_wy[r] += yi * w_ir;
             rep_sum_w[r] += w_ir;
         }
@@ -291,21 +295,36 @@ pub fn matrix_mean_estimates_cols(
     full_weights: &[f64],
     rep_cols: &[&[f64]],
     n: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     let sum_wy: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
     let sum_w: f64 = full_weights.iter().sum();
     let theta_full = if sum_w > 0.0 { sum_wy / sum_w } else { f64::NAN };
 
     use rayon::prelude::*;
+    // `domain_mask` zeroes the replicate weight for `where=` domain rows in the
+    // accumulation loop, so no R zeroed columns are materialised upstream. The
+    // mask=None path stays multiply-free (the hot, non-domain case).
     let theta_reps: Vec<f64> = rep_cols
         .par_iter()
         .map(|col| {
             let mut swy = 0.0f64;
             let mut sw = 0.0f64;
-            for i in 0..n {
-                let w = col[i];
-                swy += y[i] * w;
-                sw += w;
+            match domain_mask {
+                None => {
+                    for i in 0..n {
+                        let w = col[i];
+                        swy += y[i] * w;
+                        sw += w;
+                    }
+                }
+                Some(m) => {
+                    for i in 0..n {
+                        let w = col[i] * m[i];
+                        swy += y[i] * w;
+                        sw += w;
+                    }
+                }
             }
             if sw > 0.0 { swy / sw } else { f64::NAN }
         })
@@ -321,6 +340,7 @@ pub fn matrix_total_estimates(
     rep_weights: &[f64],
     n: usize,
     n_reps: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     let theta_full: f64 = y
         .iter()
@@ -332,9 +352,10 @@ pub fn matrix_total_estimates(
 
     for i in 0..n {
         let yi = y[i];
+        let mi = domain_mask.map_or(1.0, |m| m[i]);
         let base_idx = i * n_reps;
         for r in 0..n_reps {
-            theta_reps[r] += yi * rep_weights[base_idx + r];
+            theta_reps[r] += yi * rep_weights[base_idx + r] * mi;
         }
     }
 
@@ -349,6 +370,7 @@ pub fn matrix_ratio_estimates(
     rep_weights: &[f64],
     n: usize,
     n_reps: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     let sum_wy: f64 = y
         .iter()
@@ -372,9 +394,10 @@ pub fn matrix_ratio_estimates(
     for i in 0..n {
         let yi = y[i];
         let xi = x[i];
+        let mi = domain_mask.map_or(1.0, |m| m[i]);
         let base_idx = i * n_reps;
         for r in 0..n_reps {
-            let w_ir = rep_weights[base_idx + r];
+            let w_ir = rep_weights[base_idx + r] * mi;
             rep_sum_wy[r] += yi * w_ir;
             rep_sum_wx[r] += xi * w_ir;
         }
@@ -396,6 +419,7 @@ pub fn matrix_total_estimates_cols(
     full_weights: &[f64],
     rep_cols: &[&[f64]],
     n: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     let theta_full: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
 
@@ -404,8 +428,17 @@ pub fn matrix_total_estimates_cols(
         .par_iter()
         .map(|col| {
             let mut swy = 0.0f64;
-            for i in 0..n {
-                swy += y[i] * col[i];
+            match domain_mask {
+                None => {
+                    for i in 0..n {
+                        swy += y[i] * col[i];
+                    }
+                }
+                Some(m) => {
+                    for i in 0..n {
+                        swy += y[i] * col[i] * m[i];
+                    }
+                }
             }
             swy
         })
@@ -422,6 +455,7 @@ pub fn matrix_ratio_estimates_cols(
     full_weights: &[f64],
     rep_cols: &[&[f64]],
     n: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (f64, Vec<f64>) {
     let sum_wy: f64 = y.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
     let sum_wx: f64 = x.iter().zip(full_weights.iter()).map(|(a, b)| a * b).sum();
@@ -433,10 +467,21 @@ pub fn matrix_ratio_estimates_cols(
         .map(|col| {
             let mut swy = 0.0f64;
             let mut swx = 0.0f64;
-            for i in 0..n {
-                let w = col[i];
-                swy += y[i] * w;
-                swx += x[i] * w;
+            match domain_mask {
+                None => {
+                    for i in 0..n {
+                        let w = col[i];
+                        swy += y[i] * w;
+                        swx += x[i] * w;
+                    }
+                }
+                Some(m) => {
+                    for i in 0..n {
+                        let w = col[i] * m[i];
+                        swy += y[i] * w;
+                        swx += x[i] * w;
+                    }
+                }
             }
             if swx > 0.0 { swy / swx } else { f64::NAN }
         })
@@ -800,6 +845,7 @@ pub fn matrix_prop_estimates(
     rep_weights: &[f64],
     n: usize,
     n_reps: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (Vec<i64>, Vec<f64>, Vec<Vec<f64>>) {
     // Find unique levels
     let mut level_map: HashMap<i64, usize> = HashMap::new();
@@ -833,9 +879,10 @@ pub fn matrix_prop_estimates(
         sum_w_level[lev_idx] += wi;
         sum_w_total += wi;
 
+        let mi = domain_mask.map_or(1.0, |m| m[i]);
         let base_idx = i * n_reps;
         for r in 0..n_reps {
-            let w_ir = rep_weights[base_idx + r];
+            let w_ir = rep_weights[base_idx + r] * mi;
             rep_sum_w_level[lev_idx][r] += w_ir;
             rep_sum_w_total[r] += w_ir;
         }
@@ -893,6 +940,7 @@ pub fn matrix_prop_estimates_cols(
     full_weights: &[f64],
     rep_cols: &[&[f64]],
     n: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (Vec<i64>, Vec<f64>, Vec<Vec<f64>>) {
     let (levels, lev_idx) = prop_level_index(y);
     let n_levels = levels.len();
@@ -914,10 +962,21 @@ pub fn matrix_prop_estimates_cols(
         .map(|col| {
             let mut swl = vec![0.0; n_levels];
             let mut swt = 0.0;
-            for i in 0..n {
-                let w = col[i];
-                swl[lev_idx[i]] += w;
-                swt += w;
+            match domain_mask {
+                None => {
+                    for i in 0..n {
+                        let w = col[i];
+                        swl[lev_idx[i]] += w;
+                        swt += w;
+                    }
+                }
+                Some(m) => {
+                    for i in 0..n {
+                        let w = col[i] * m[i];
+                        swl[lev_idx[i]] += w;
+                        swt += w;
+                    }
+                }
             }
             (0..n_levels)
                 .map(|l| if swt > 0.0 { swl[l] / swt } else { f64::NAN })
@@ -940,6 +999,7 @@ pub fn matrix_prop_estimates_str_cols(
     full_weights: &[f64],
     rep_cols: &[&[f64]],
     n: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (Vec<String>, Vec<f64>, Vec<Vec<f64>>) {
     let mut level_map: HashMap<&str, usize> = HashMap::new();
     let mut levels: Vec<String> = Vec::new();
@@ -973,10 +1033,21 @@ pub fn matrix_prop_estimates_str_cols(
         .map(|col| {
             let mut swl = vec![0.0; n_levels];
             let mut swt = 0.0;
-            for i in 0..n {
-                let w = col[i];
-                swl[lev_idx[i]] += w;
-                swt += w;
+            match domain_mask {
+                None => {
+                    for i in 0..n {
+                        let w = col[i];
+                        swl[lev_idx[i]] += w;
+                        swt += w;
+                    }
+                }
+                Some(m) => {
+                    for i in 0..n {
+                        let w = col[i] * m[i];
+                        swl[lev_idx[i]] += w;
+                        swt += w;
+                    }
+                }
             }
             (0..n_levels)
                 .map(|l| if swt > 0.0 { swl[l] / swt } else { f64::NAN })
@@ -1093,6 +1164,7 @@ pub fn matrix_prop_estimates_str(
     rep_weights: &[f64],
     n: usize,
     n_reps: usize,
+    domain_mask: Option<&[f64]>,
 ) -> (Vec<String>, Vec<f64>, Vec<Vec<f64>>) {
     // Find unique levels
     let mut level_map: HashMap<&str, usize> = HashMap::new();
@@ -1126,9 +1198,10 @@ pub fn matrix_prop_estimates_str(
         sum_w_level[lev_idx] += wi;
         sum_w_total += wi;
 
+        let mi = domain_mask.map_or(1.0, |m| m[i]);
         let base_idx = i * n_reps;
         for r in 0..n_reps {
-            let w_ir = rep_weights[base_idx + r];
+            let w_ir = rep_weights[base_idx + r] * mi;
             rep_sum_w_level[lev_idx][r] += w_ir;
             rep_sum_w_total[r] += w_ir;
         }
@@ -1523,7 +1596,7 @@ mod tests {
         let rep_w = vec![1.0f64; 6 * 2];
 
         let (levels, theta_full, theta_reps) =
-            matrix_prop_estimates_str(&y, &w, &rep_w, 6, 2);
+            matrix_prop_estimates_str(&y, &w, &rep_w, 6, 2, None);
 
         assert_eq!(levels, vec!["no".to_string(), "yes".to_string()]);
         let no_idx = 0;

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -48,6 +48,21 @@ fn get_cont_rep_cols<'a>(
     Ok(Some(cols))
 }
 
+/// Materialise the `where=` domain mask as a dense `Vec<f64>` (1.0 inside the
+/// domain, 0.0 outside), or `None` when no domain is set. Passed to the
+/// ungrouped replicate kernels so they zero out-of-domain replicate weights on
+/// the fly — replacing the R materialised zeroed columns the Python side would
+/// otherwise build per `where=` call.
+fn get_domain_mask(df: &DataFrame, mask_col: Option<&str>) -> PolarsResult<Option<Vec<f64>>> {
+    match mask_col {
+        None => Ok(None),
+        Some(name) => {
+            let ca = df.column(name)?.f64()?;
+            Ok(Some(ca.into_iter().map(|o| o.unwrap_or(0.0)).collect()))
+        }
+    }
+}
+
 fn parse_rep_method(method: &str) -> PyResult<RepMethod> {
     RepMethod::from_str(method).ok_or_else(|| {
         PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
@@ -71,7 +86,7 @@ fn parse_variance_center(center: &str) -> PyResult<VarianceCenter> {
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_mean(
     _py: Python,
     data: PyDataFrame,
@@ -83,6 +98,7 @@ pub fn replicate_mean(
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
+    domain_mask_col: Option<String>,
 ) -> PyResult<PyDataFrame> {
     let df: DataFrame = data.into();
     let n_reps = rep_weight_cols.len();
@@ -93,7 +109,7 @@ pub fn replicate_mean(
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_mean_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val)
+                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_mean_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
                 rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
@@ -106,6 +122,7 @@ fn compute_replicate_mean_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
     method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
     let weights = df.column(weight_col)?.f64()?;
@@ -113,14 +130,16 @@ fn compute_replicate_mean_ungrouped(
     let n_reps = rep_weight_cols.len();
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let domain_mask = get_domain_mask(df, domain_mask_col)?;
+    let mask = domain_mask.as_deref();
 
     // No-materialisation path: accumulate from the contiguous replicate columns
     // (parallel over replicates); flat-matrix fallback for chunked/nullable.
     let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
-        Some(cols) => matrix_mean_estimates_cols(&y_arr, &w_arr, &cols, n),
+        Some(cols) => matrix_mean_estimates_cols(&y_arr, &w_arr, &cols, n, mask),
         None => {
             let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-            matrix_mean_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps)
+            matrix_mean_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
@@ -182,7 +201,7 @@ fn compute_replicate_mean_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_total(
     _py: Python,
     data: PyDataFrame,
@@ -194,6 +213,7 @@ pub fn replicate_total(
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
+    domain_mask_col: Option<String>,
 ) -> PyResult<PyDataFrame> {
     let df: DataFrame = data.into();
     let n_reps = rep_weight_cols.len();
@@ -204,7 +224,7 @@ pub fn replicate_total(
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_total_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val)
+                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_total_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
                 rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
@@ -217,6 +237,7 @@ fn compute_replicate_total_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
     method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
     let weights = df.column(weight_col)?.f64()?;
@@ -224,12 +245,14 @@ fn compute_replicate_total_ungrouped(
     let n_reps = rep_weight_cols.len();
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let domain_mask = get_domain_mask(df, domain_mask_col)?;
+    let mask = domain_mask.as_deref();
 
     let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
-        Some(cols) => matrix_total_estimates_cols(&y_arr, &w_arr, &cols, n),
+        Some(cols) => matrix_total_estimates_cols(&y_arr, &w_arr, &cols, n, mask),
         None => {
             let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-            matrix_total_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps)
+            matrix_total_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
@@ -291,7 +314,7 @@ fn compute_replicate_total_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, numerator_col, denominator_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None))]
+#[pyo3(signature = (data, numerator_col, denominator_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_ratio(
     _py: Python,
     data: PyDataFrame,
@@ -304,6 +327,7 @@ pub fn replicate_ratio(
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
+    domain_mask_col: Option<String>,
 ) -> PyResult<PyDataFrame> {
     let df: DataFrame = data.into();
     let n_reps = rep_weight_cols.len();
@@ -314,7 +338,8 @@ pub fn replicate_ratio(
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_ratio_ungrouped(&df, &numerator_col, &denominator_col, &weight_col,
-                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val)
+                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
+                domain_mask_col.as_deref())
         } else {
             compute_replicate_ratio_grouped(&df, &numerator_col, &denominator_col, &weight_col,
                 &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
@@ -329,6 +354,7 @@ fn compute_replicate_ratio_ungrouped(
     numerator_col: &str, denominator_col: &str, weight_col: &str,
     rep_weight_cols: &[String],
     method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(numerator_col)?.f64()?;
     let x = df.column(denominator_col)?.f64()?;
@@ -338,12 +364,14 @@ fn compute_replicate_ratio_ungrouped(
     let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let x_arr: Vec<f64> = x.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let domain_mask = get_domain_mask(df, domain_mask_col)?;
+    let mask = domain_mask.as_deref();
 
     let (theta_full, theta_reps) = match get_cont_rep_cols(df, rep_weight_cols)? {
-        Some(cols) => matrix_ratio_estimates_cols(&y_arr, &x_arr, &w_arr, &cols, n),
+        Some(cols) => matrix_ratio_estimates_cols(&y_arr, &x_arr, &w_arr, &cols, n, mask),
         None => {
             let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-            matrix_ratio_estimates(&y_arr, &x_arr, &w_arr, &rep_w_matrix, n, n_reps)
+            matrix_ratio_estimates(&y_arr, &x_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
@@ -408,7 +436,7 @@ fn compute_replicate_ratio_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_prop(
     _py: Python,
     data: PyDataFrame,
@@ -420,6 +448,7 @@ pub fn replicate_prop(
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
+    domain_mask_col: Option<String>,
 ) -> PyResult<PyDataFrame> {
     let df: DataFrame = data.into();
     let n_reps = rep_weight_cols.len();
@@ -430,7 +459,7 @@ pub fn replicate_prop(
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_prop_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val)
+                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_prop_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
                 rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
@@ -443,6 +472,7 @@ fn compute_replicate_prop_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
     method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y_series = df.column(value_col)?;
     let weights  = df.column(weight_col)?.f64()?;
@@ -450,6 +480,8 @@ fn compute_replicate_prop_ungrouped(
     let n_reps = rep_weight_cols.len();
     let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
     let cont_cols = get_cont_rep_cols(df, rep_weight_cols)?;
+    let domain_mask = get_domain_mask(df, domain_mask_col)?;
+    let mask = domain_mask.as_deref();
     let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
 
     // String/Categorical: use string-keyed level functions so level labels are
@@ -462,10 +494,10 @@ fn compute_replicate_prop_ungrouped(
             .map(|v| v.unwrap_or("").to_string())
             .collect();
         let (levels, theta_full, theta_reps) = match &cont_cols {
-            Some(cols) => matrix_prop_estimates_str_cols(&y_arr, &w_arr, cols, n),
+            Some(cols) => matrix_prop_estimates_str_cols(&y_arr, &w_arr, cols, n, mask),
             None => {
                 let (m, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-                matrix_prop_estimates_str(&y_arr, &w_arr, &m, n, n_reps)
+                matrix_prop_estimates_str(&y_arr, &w_arr, &m, n, n_reps, mask)
             }
         };
         let n_l = levels.len();
@@ -491,10 +523,10 @@ fn compute_replicate_prop_ungrouped(
             ));
         };
         let (levels, theta_full, theta_reps) = match &cont_cols {
-            Some(cols) => matrix_prop_estimates_cols(&y_arr, &w_arr, cols, n),
+            Some(cols) => matrix_prop_estimates_cols(&y_arr, &w_arr, cols, n, mask),
             None => {
                 let (m, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-                matrix_prop_estimates(&y_arr, &w_arr, &m, n, n_reps)
+                matrix_prop_estimates(&y_arr, &w_arr, &m, n, n_reps, mask)
             }
         };
         let n_l = levels.len();

--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -118,6 +118,12 @@ _design_fields_cache: dict[int, tuple] = {}
 # Created and dropped within prepare_data; never exposed to the caller.
 _MASK_COL = "__svy_where_mask__"
 
+# Internal Float64 domain-mask column (1.0 inside the `where=` domain, 0.0
+# outside). Emitted instead of zeroing R replicate columns when
+# ``domain_mask_for_replication=True``; the Rust replicate kernels apply it on
+# the fly. Carried through to Rust (not dropped), so it stays namespaced.
+_DOMAIN_MASK_COL = "__svy_domain_mask__"
+
 
 # ═══════════════════════════════════════════════════════════════════════
 # Return type
@@ -138,6 +144,7 @@ class PreparedData:
     fpc_ssu_col: str | None = None
     domain_col: str | None = None
     domain_val: str | None = None
+    domain_mask_col: str | None = None
     by_col: str | None = None
     by_cols: list[str] = field(default_factory=list)
     singleton_method: str | None = None
@@ -283,6 +290,7 @@ def prepare_data(
     cast_y_float: bool,
     select_columns: bool,
     apply_singleton_filter: bool,
+    domain_mask_for_replication: bool = False,
 ) -> PreparedData:
     """
     Unified data preparation for all Rust backend calls.
@@ -523,6 +531,7 @@ def prepare_data(
     # ``with_columns`` call. The mask column is dropped before returning.
     domain_col = None
     domain_val = None
+    domain_mask_col = None
 
     if where is not None:
         where_expr = sample.estimation._compile_where_expr(where)
@@ -536,7 +545,9 @@ def prepare_data(
         exprs: list[pl.Expr] = [mask.cast(pl.String).alias("__svy_domain__")]
 
         # Main weight: zero on the non-domain branch. If design has no wgt
-        # the column doesn't exist yet — synthesize it inline.
+        # the column doesn't exist yet — synthesize it inline. This one column
+        # is what the Taylor path and the replicate full-sample estimate read,
+        # so it is always zeroed (cheap).
         if design.wgt:
             exprs.append(
                 pl.when(mask)
@@ -547,11 +558,21 @@ def prepare_data(
         else:
             exprs.append(pl.when(mask).then(pl.lit(1.0)).otherwise(0.0).alias(weight_col))
 
-        # Replicate weights: cast + zero in one pass per column. The Python
-        # loop only builds expression objects; the actual column rewrites
-        # happen in parallel inside Polars/Rust.
-        for c in rep_weight_cols_in_df:
-            exprs.append(pl.when(mask).then(pl.col(c).cast(pl.Float64)).otherwise(0.0).alias(c))
+        if domain_mask_for_replication and rep_weight_cols_in_df:
+            # Fast path (ungrouped replication): emit ONE Float64 domain mask
+            # (1.0/0.0) and cast the replicate weights to Float64 WITHOUT
+            # zeroing them. The Rust replicate kernels multiply the mask in on
+            # the fly, avoiding the R materialised zeroed columns this loop
+            # would otherwise write (R×n float stores per `where=` call).
+            exprs.append(mask.cast(pl.Float64).alias(_DOMAIN_MASK_COL))
+            for c in rep_weight_cols_in_df:
+                exprs.append(pl.col(c).cast(pl.Float64).alias(c))
+            domain_mask_col = _DOMAIN_MASK_COL
+        else:
+            # Default: cast + zero every replicate weight in one pass per
+            # column (grouped/median replication and non-mask-aware callers).
+            for c in rep_weight_cols_in_df:
+                exprs.append(pl.when(mask).then(pl.col(c).cast(pl.Float64)).otherwise(0.0).alias(c))
 
         df = df.with_columns(exprs).drop(_MASK_COL)
         domain_col = "__svy_domain__"
@@ -631,6 +652,7 @@ def prepare_data(
         fpc_ssu_col=None,  # when needed (not all APIs use FPC)
         domain_col=domain_col,
         domain_val=domain_val,
+        domain_mask_col=domain_mask_col,
         by_col=by_col,
         by_cols=by_cols_list,
         singleton_method=singleton_method,

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -1081,6 +1081,11 @@ class Estimation:
             cast_y_float=True,
             apply_singleton_filter=True,
             select_columns=True,
+            # Ungrouped replication only: the mask path covers the ungrouped
+            # kernels. Grouped (by=) replication keeps the zeroing path.
+            domain_mask_for_replication=(
+                target_method != EstimationMethod.TAYLOR and by is None
+            ),
         )
 
         try:
@@ -1150,6 +1155,11 @@ class Estimation:
             cast_y_float=True,
             apply_singleton_filter=True,
             select_columns=True,
+            # Ungrouped replication only: the mask path covers the ungrouped
+            # kernels. Grouped (by=) replication keeps the zeroing path.
+            domain_mask_for_replication=(
+                target_method != EstimationMethod.TAYLOR and by is None
+            ),
         )
 
         try:
@@ -1218,6 +1228,11 @@ class Estimation:
             cast_y_float=False,
             apply_singleton_filter=True,
             select_columns=True,
+            # Ungrouped replication only: the mask path covers the ungrouped
+            # kernels. Grouped (by=) replication keeps the zeroing path.
+            domain_mask_for_replication=(
+                target_method != EstimationMethod.TAYLOR and by is None
+            ),
         )
 
         try:
@@ -1288,6 +1303,11 @@ class Estimation:
             cast_y_float=True,
             apply_singleton_filter=True,
             select_columns=True,
+            # Ungrouped replication only: the mask path covers the ungrouped
+            # kernels. Grouped (by=) replication keeps the zeroing path.
+            domain_mask_for_replication=(
+                target_method != EstimationMethod.TAYLOR and by is None
+            ),
         )
 
         try:

--- a/packages/svy/src/svy/estimation/replication.py
+++ b/packages/svy/src/svy/estimation/replication.py
@@ -213,6 +213,7 @@ def replicate_mean(
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
+        domain_mask_col=prep.domain_mask_col,
     )
     est_list = est._polars_result_to_param_est(
         result_df, y, PopParam.MEAN, alpha, deff=False, by_col=prep.by_col, as_factor=False
@@ -251,6 +252,7 @@ def replicate_total(
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
+        domain_mask_col=prep.domain_mask_col,
     )
     est_list = est._polars_result_to_param_est(
         result_df, y, PopParam.TOTAL, alpha, deff=False, by_col=prep.by_col, as_factor=False
@@ -291,6 +293,7 @@ def replicate_ratio(
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
+        domain_mask_col=prep.domain_mask_col,
     )
     est_list = est._polars_result_to_param_est(
         result_df,
@@ -338,6 +341,7 @@ def replicate_prop(
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
+        domain_mask_col=prep.domain_mask_col,
     )
     est_list = est._polars_result_to_param_est(
         result_df,


### PR DESCRIPTION
Phase E, item 1. Eliminates the largest per-call allocation on the replication + `where=` path.

## Problem
A `where=` domain on a replication design materialized **R brand-new zeroed replicate columns** in `prepare_data` — one `when/then/otherwise` per replicate, i.e. R×n float stores (~1.6 GB at R=200/n=1M). The kernel then just summed those mostly-zero columns.

## Fix
For **ungrouped** replication (mean/total/ratio/prop), emit a **single Float64 domain mask** column (1.0 inside the domain, 0.0 outside) and apply it on the fly in the replicate accumulation loops (`w_r[i] * mask[i]`). No R columns are built.

- **Bit-identical**: the mask is exactly 1.0/0.0, same as the `then/otherwise` it replaces.
- The **main weight** is still zeroed (one cheap column that the Taylor path and the replicate full-sample estimate both read).
- The `mask=None` path (the common, non-domain replicate case) stays multiply-free — no regression to the hot path.

## Scope (opt-in flag in `prepare_data`)
Ungrouped replication only. **Taylor** (unaffected), **grouped `by=` replication**, and **median** keep the existing zeroing path unchanged — so every `where=` combination stays correct, and the 2443-test suite (which covers `where=` for mean/total/ratio/prop and `where=`+`by=`) passes bit-identically.

## Measured (1M rows, R=200, 10 cores)
| | ms |
|---|---|
| replication no-where | 36.0 |
| replication `where=` **before** | 69.3 |
| replication `where=` **after** | **51.8** |

Domain overhead over the no-where call: **31.7 → 15.8 ms (halved)**; the R-column allocation is gone entirely. The residual is the on-the-fly mask multiply (compute, not allocation).

## Follow-up
Grouped `by=`+`where=` replication and median could take the same mask path (rarer; left on the zeroing path for now). Item 2 (batched multi-variable API) is separate and TBD.

Full 2443-test golden suite green; 68 Rust unit tests green.