### PR TITLE
fix(estimation): fail fast on unhandled singleton PSUs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ change under `[Unreleased]` in the same PR that makes it; on release, rename
 
 ### Changed
 
+- **Estimation now fails fast on unhandled singleton PSUs** instead of silently
+  under-reporting the variance. Taylor estimation (`mean`, `total`, `prop`,
+  `ratio`, `median`) raises `SingletonError` when a design has single-PSU strata
+  and no handling strategy was chosen — matching R's
+  `options(survey.lonely.psu = "fail")`. Pick a strategy explicitly with
+  `sample.singleton.skip()` / `.certainty()` / `.center()` / `.scale()` /
+  `.collapse()` / `.pool()`. Previously such strata were dropped from the
+  variance with no error or warning.
+
 ### Fixed
 
 <!-- Also available when needed: ### Deprecated, ### Removed, ### Security -->

--- a/packages/svy/src/svy/errors/singleton_errors.py
+++ b/packages/svy/src/svy/errors/singleton_errors.py
@@ -53,11 +53,15 @@ class SingletonError(SvyError):
             lines.append(f"  ... and {n - 5} more")
 
         lines.append("")
-        lines.append("Variance cannot be estimated with singleton PSUs.")
-        lines.append("Consider using one of these handling methods:")
-        lines.append("  • sample.singleton.certainty()")
-        lines.append("  • sample.singleton.skip()")
-        lines.append("  • sample.singleton.combine(mapping)")
+        lines.append("Variance cannot be estimated with unhandled singleton PSUs.")
+        lines.append("Inspect them with sample.singleton.summary(), then pick a strategy:")
+        lines.append("  • sample.singleton.certainty()  — treat as self-representing units")
+        lines.append("  • sample.singleton.skip()       — drop from variance (R 'remove')")
+        lines.append("  • sample.singleton.center()     — grand-mean centering (R 'adjust')")
+        lines.append("  • sample.singleton.scale()      — variance inflation (R 'average')")
+        lines.append("  • sample.singleton.collapse()   — merge into nearby strata")
+        lines.append("  • sample.singleton.pool()       — pool singletons into one stratum")
+        lines.append("  • sample.singleton.combine(map) — manual stratum/PSU remapping")
 
         # Convert to plain Python types; works for msgspec.Struct, dataclasses, dicts, etc.
         payload = [msgspec.to_builtins(s) for s in singletons]

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -16,6 +16,7 @@ from svy.core.data_prep import prepare_data
 from svy.core.enumerations import EstimationMethod, PopParam
 from svy.core.enumerations import QuantileMethod as _QuantileMethod
 from svy.core.types import WhereArg
+from svy.errors.singleton_errors import SingletonError
 from svy.estimation.estimate import Estimate, ParamEst
 from svy.estimation.replication import (
     replicate_estimate as _replicate_estimate,
@@ -151,6 +152,16 @@ class Estimation:
 
         singleton_result = getattr(self._sample, "_singleton_result", None)
         config = singleton_result.config if singleton_result else None
+
+        # Fail-fast on unhandled singletons (Taylor variance path).
+        # Singletons are chosen/handled at the sample level; a handled sample
+        # carries a config. If no strategy was chosen and the design still has
+        # singleton strata, refuse to under-report the variance silently
+        # (mirrors R's options(survey.lonely.psu = "fail")).
+        if config is None and getattr(self._sample, "_singletons", None):
+            singles = self._sample.singleton.detected()
+            if singles:
+                raise SingletonError.from_singletons(singles, where="estimation")
 
         strata_col = None
         psu_col = None

--- a/packages/svy/tests/svy/core/test_singleton_adjustments.py
+++ b/packages/svy/tests/svy/core/test_singleton_adjustments.py
@@ -143,8 +143,23 @@ def test_center_arg_passing(adjustment_sample, monkeypatch):
     assert captured_kwargs.get("singleton_method") == "center"
 
 
-def test_center_idempotent_if_not_configured(adjustment_sample, monkeypatch):
-    sample = adjustment_sample
+def test_center_idempotent_if_not_configured(monkeypatch):
+    # A design WITHOUT singletons: without a .center() call the engine must
+    # receive singleton_method=None. (A singleton design would instead raise;
+    # that fail-fast policy is covered in tests/svy/estimation/test_singletons.py.)
+    rows = [
+        (0, "B", "201", 20.0, 1.0),
+        (1, "B", "202", 22.0, 1.0),
+        (2, "D", "401", 40.0, 1.0),
+        (3, "D", "402", 42.0, 1.0),
+    ]
+    df = pl.DataFrame(
+        rows,
+        schema=[SVY_ROW_INDEX, "stratum", "cluster", "income", "weight"],
+        orient="row",
+    )
+    design = svy.Design(stratum="stratum", psu="cluster", wgt="weight")
+    sample = svy.Sample(data=df, design=design)
     captured_kwargs = {}
 
     def mock_taylor_mean(*args, **kwargs):

--- a/packages/svy/tests/svy/estimation/test_singletons.py
+++ b/packages/svy/tests/svy/estimation/test_singletons.py
@@ -1,0 +1,190 @@
+# tests/svy/estimation/test_singletons.py
+"""
+Singleton handling at the ESTIMATION level.
+
+Singletons (strata with a single PSU) are chosen/handled at the *sample* level
+(``sample.singleton.*``), but they only become a problem when a variance is
+actually computed. Estimation is therefore the decision point: when it hits an
+unhandled singleton it must either adopt a chosen method or fail.
+
+Target behavior exercised here (mirrors R's ``options(survey.lonely.psu="fail")``):
+
+  * Default, no strategy chosen  -> estimation raises ``SingletonError``.
+  * A strategy chosen at the sample level -> estimation proceeds.
+  * A design with no singletons  -> estimation proceeds with no handling.
+
+Scenarios are parametrised across the estimation methods (mean, total, prop,
+ratio, median) so the policy is uniform across the API surface.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+import svy
+
+from svy.errors.singleton_errors import SingletonError
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# FIXTURES
+# ══════════════════════════════════════════════════════════════════════════════
+#
+# Strata A and C have a single PSU each (singletons); B and D have two PSUs.
+# Columns support every estimator:
+#   income     -> mean / total / median (continuous)
+#   fam_size   -> ratio denominator
+#   low_income -> proportion (0/1)
+
+
+def _rows_with_singletons():
+    # (id, stratum, psu, income, fam_size)
+    return [
+        (0, "A", "101", 10_000.0, 2),  # stratum A: single PSU -> singleton
+        (1, "A", "101", 12_000.0, 3),
+        (2, "B", "201", 20_000.0, 2),
+        (3, "B", "201", 22_000.0, 1),
+        (4, "B", "202", 24_000.0, 4),
+        (5, "B", "202", 26_000.0, 3),
+        (6, "C", "301", 30_000.0, 2),  # stratum C: single PSU -> singleton
+        (7, "C", "301", 15_000.0, 1),
+        (8, "D", "401", 40_000.0, 3),
+        (9, "D", "401", 42_000.0, 2),
+        (10, "D", "402", 44_000.0, 4),
+        (11, "D", "402", 46_000.0, 2),
+    ]
+
+
+def _to_frame(rows):
+    df = pl.DataFrame(
+        rows,
+        schema=["id", "stratum", "psu", "income", "fam_size"],
+        orient="row",
+    )
+    return df.with_columns(
+        pl.lit(1.0).alias("weight"),
+        (pl.col("income") < 25_000).cast(pl.Int64).alias("low_income"),
+    )
+
+
+@pytest.fixture
+def singleton_sample():
+    """Stratified, clustered design containing two singleton strata (A, C)."""
+    df = _to_frame(_rows_with_singletons())
+    design = svy.Design(row_index="id", stratum="stratum", psu="psu", wgt="weight")
+    return svy.Sample(data=df, design=design)
+
+
+@pytest.fixture
+def clean_sample():
+    """Same shape but every stratum has >= 2 PSUs (no singletons)."""
+    rows = [r for r in _rows_with_singletons() if r[1] in ("B", "D")]
+    df = _to_frame(rows)
+    design = svy.Design(row_index="id", stratum="stratum", psu="psu", wgt="weight")
+    return svy.Sample(data=df, design=design)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# HELPERS
+# ══════════════════════════════════════════════════════════════════════════════
+
+ALL_METHODS = ["mean", "total", "prop", "ratio", "median"]
+
+
+def estimate(sample, method):
+    """Invoke an estimation method by name and return the Estimate object."""
+    est = sample.estimation
+    if method == "mean":
+        return est.mean("income")
+    if method == "total":
+        return est.total("income")
+    if method == "prop":
+        return est.prop("low_income")
+    if method == "ratio":
+        return est.ratio("income", "fam_size")
+    if method == "median":
+        return est.median("income")
+    raise ValueError(f"unknown method {method!r}")
+
+
+def assert_valid_estimate(result):
+    """A produced estimate must have a finite, non-negative standard error."""
+    pe = result.estimates[0]
+    assert pe.est is not None
+    assert pe.se is not None
+    assert pe.se >= 0.0
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SCENARIO 1: default (no strategy) FAILS on unhandled singletons
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_default_unhandled_singletons_raise(singleton_sample, method):
+    """With singletons present and no strategy chosen, estimation must raise."""
+    assert singleton_sample.singleton.exists
+    with pytest.raises(SingletonError):
+        estimate(singleton_sample, method)
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SCENARIO 2: strategies that remove singletons from the design -> succeed
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+@pytest.mark.parametrize("strategy", ["collapse", "pool"])
+def test_structural_strategies_allow_estimation(singleton_sample, method, strategy):
+    """collapse/pool remap the variance design (via a config) so estimation runs.
+
+    Note: these leave the original stratum column untouched, so ``.exists`` stays
+    True; "handled" is signalled by the attached config (``last_result``), which
+    is exactly the predicate the fail-by-default check keys off.
+    """
+    handled = getattr(singleton_sample.singleton, strategy)()
+    assert handled.singleton.last_result is not None
+    assert_valid_estimate(estimate(handled, method))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SCENARIO 3: variance-config strategies -> succeed
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+@pytest.mark.parametrize("strategy", ["skip", "certainty", "center"])
+def test_variance_config_strategies_allow_estimation(singleton_sample, method, strategy):
+    """skip/certainty/center attach a config the variance engine consumes."""
+    handled = getattr(singleton_sample.singleton, strategy)()
+    assert_valid_estimate(estimate(handled, method))
+
+
+@pytest.mark.parametrize("method", ["mean", "total"])
+def test_scale_allows_estimation(singleton_sample, method):
+    """scale (R's 'average') excludes singletons then inflates the variance."""
+    handled = singleton_sample.singleton.scale()
+    assert_valid_estimate(estimate(handled, method))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SCENARIO 4: no singletons -> no handling required, no false positive
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+@pytest.mark.parametrize("method", ALL_METHODS)
+def test_clean_design_needs_no_handling(clean_sample, method):
+    """A design without singletons estimates cleanly and never raises."""
+    assert not clean_sample.singleton.exists
+    assert_valid_estimate(estimate(clean_sample, method))
+
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SCENARIO 5: explicit raise_error() short-circuits before estimation
+# ══════════════════════════════════════════════════════════════════════════════
+
+
+def test_explicit_raise_error(singleton_sample):
+    with pytest.raises(SingletonError):
+        singleton_sample.singleton.raise_error()


### PR DESCRIPTION
## What

Taylor estimation (`mean`, `total`, `prop`, `ratio`, `median`) now **raises `SingletonError`** when a design has single-PSU strata and no handling strategy was chosen — instead of silently dropping those strata from the variance and under-reporting the standard error.

This matches R's `options(survey.lonely.psu = "fail")` default. Closes the gap where a naive `sample.estimation.mean(...)` on a lonely-PSU design returned a plausible-but-too-small SE with no error or warning.

## How

- Guard added in the Taylor design-info chokepoint (`_get_polars_design_info`). It keys off the **presence of a singleton config**, not `.exists`, so samples handled via `sample.singleton.skip()/.certainty()/.center()/.scale()/.collapse()/.pool()` pass through unchanged.
- The replication path is unaffected (singletons are a Taylor-linearization concern).
- `SingletonError` message now points to `sample.singleton.summary()` and lists every strategy with its R-option equivalence.

## Behavior

| Sample state at estimation | Result |
|---|---|
| singletons present, no strategy chosen | **raises `SingletonError`** |
| a `sample.singleton.*` strategy chosen | estimates normally |
| no singletons | estimates normally |

## Tests

New `tests/svy/estimation/test_singletons.py`, parametrized across all five estimators: default → raises; every handling strategy → estimates cleanly; no-singleton control; explicit `raise_error()`. Full suite green (2479 passed, 1 skipped).

## Notes

Behavior change — code that estimated on lonely-PSU designs will now raise until a strategy is chosen. Documented under `### Changed` in the changelog.