### PR TITLE
release(svy-io): v0.1.1

### DIFF
--- a/packages/svy-io/native/readstat-sys/Cargo.lock
+++ b/packages/svy-io/native/readstat-sys/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
 
 [[package]]
 name = "readstat-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
  "cc",

--- a/packages/svy-io/native/readstat-sys/Cargo.toml
+++ b/packages/svy-io/native/readstat-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readstat-sys"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 links = "readstat"
 license = "MIT"

--- a/packages/svy-io/native/svyreadstat_rs/Cargo.lock
+++ b/packages/svy-io/native/svyreadstat_rs/Cargo.lock
@@ -1042,7 +1042,7 @@ dependencies = [
 
 [[package]]
 name = "readstat-sys"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "bindgen",
  "cc",
@@ -1180,7 +1180,7 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "svyreadstat_rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/packages/svy-io/native/svyreadstat_rs/Cargo.toml
+++ b/packages/svy-io/native/svyreadstat_rs/Cargo.toml
@@ -1,7 +1,7 @@
 # native/svyreadstat_rs/Cargo.toml
 [package]
 name = "svyreadstat_rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/samplics-org/svy-io"

--- a/packages/svy-io/pyproject.toml
+++ b/packages/svy-io/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy-io"
-version = "0.1.0"
+version = "0.1.1"
 description = "SAS/SPSS/Stata I/O with Polars, powered by ReadStat + PyO3"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/svy-io/python/svy_io/__init__.py
+++ b/packages/svy-io/python/svy_io/__init__.py
@@ -71,4 +71,4 @@ __all__ = [
     "write_xpt",
 ]
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"


### PR DESCRIPTION
Patch release bundling the fixes that landed since \`svy-io\` 0.1.0 (currently the latest on PyPI).

## Changes
- SAS datetime conversion, opt-in inference, FFI hardening
- Bundle ReadStat sources in the sdist and publish Intel macOS wheels

No public API changes — fixes and packaging only.

## Version bumps
- \`pyproject.toml\`, \`python/svy_io/__init__.py\` → 0.1.1
- \`native/svyreadstat_rs\` + \`native/readstat-sys\` Cargo.toml + lockfiles → 0.1.1

## Release
Merge, then push tag \`svy-io-v0.1.1\` to trigger the wheel build + PyPI publish.