### PR TITLE
feat(svy): allow a variable in both by= and where= (issue #9)

### DIFF
--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -484,16 +484,13 @@ def prepare_data(
         by_cols_list = []
         by_col = None
 
-    # Validate: by and where cannot reference the same column
-    if by_cols_list and where is not None:
-        where_cols = set(extract_where_cols(where))
-        by_cols_set = set(by_cols_list)
-        overlap = by_cols_set & where_cols
-        if overlap:
-            raise ValueError(
-                f"Column(s) {sorted(overlap)} appear in both 'by' and 'where'. "
-                f"Use 'by' to stratify or 'where' to restrict, not both on the same variable."
-            )
+    # A variable may appear in BOTH `by` and `where` (issue #9). The two are
+    # orthogonal: `where` is domain estimation (out-of-domain rows keep their
+    # place but have their weight zeroed and are flagged via `__svy_domain__`),
+    # while `by` groups on the original values. When a `where` predicate
+    # excludes an entire `by` level, that level is dropped from the results by
+    # blanking its grouping label in the `where` block below, matching R's
+    # `design %>% filter(...) %>% group_by(...)`.
 
     # ── Paired difference ────────────────────────────────────────────────
     y_col = y
@@ -577,6 +574,35 @@ def prepare_data(
         df = df.with_columns(exprs).drop(_MASK_COL)
         domain_col = "__svy_domain__"
         domain_val = "true"
+
+        # A variable may appear in BOTH `by` and `where` (issue #9). When a
+        # `where` predicate excludes an entire `by` level (every one of its rows
+        # out of the domain, e.g. a "don't know"/missing code), that level has
+        # no domain estimate to report and must simply be absent from the
+        # results — matching R's `design %>% filter(...) %>% group_by(...)`.
+        #
+        # We do NOT drop those rows: domain estimation requires the full sample
+        # with out-of-domain weights zeroed so the design-based (Taylor /
+        # replicate) variance of the surviving groups stays correct. Instead we
+        # blank the grouping *label* of a fully-excluded level, so it forms no
+        # group in the kernel (which iterates `by.unique()` and skips nulls) and
+        # produces no row — while every row still flows to Rust and continues to
+        # contribute to the shared design/df exactly as before. Partially
+        # excluded levels keep their label (they have in-domain rows) and are
+        # domain-estimated over their surviving observations as usual.
+        if by_col is not None and by_col in df.columns:
+            live_levels = (
+                df.filter(pl.col(domain_col) == domain_val)
+                .get_column(by_col)
+                .unique()
+                .to_list()
+            )
+            df = df.with_columns(
+                pl.when(pl.col(by_col).is_in(live_levels))
+                .then(pl.col(by_col))
+                .otherwise(None)
+                .alias(by_col)
+            )
     else:
         # No where → still need (a) the main weight column to exist and be
         # Float64 for Rust, and (b) replicate weights to be Float64. Bundle

--- a/packages/svy/tests/svy/estimation/test_where_by.py
+++ b/packages/svy/tests/svy/estimation/test_where_by.py
@@ -281,6 +281,178 @@ class TestWhereWithBy:
 
 
 # =============================================================================
+# Where and By on the SAME variable (issue #9)
+# =============================================================================
+
+
+@pytest.fixture
+def dk_survey_data() -> pl.DataFrame:
+    """
+    Survey data with a categorical variable that carries a "don't know" /
+    missing sentinel code (99) alongside its real levels.
+
+    This is the canonical use case for issue #9: restrict to the real levels
+    of a variable via ``where`` while simultaneously breaking the estimate
+    down ``by`` that same variable. The 99 code is sprinkled across every PSU
+    so that physically filtering it out never removes a whole PSU (keeping the
+    filtered-vs-domain point estimates exactly comparable).
+    """
+    np.random.seed(2024)
+    n = 600
+
+    return pl.DataFrame(
+        {
+            "id": range(1, n + 1),
+            "stratum": np.random.choice(["A", "B", "C"], n),
+            "psu": np.random.choice(range(1, 21), n),
+            "weight": np.random.uniform(0.5, 2.0, n),
+            # sex carries a 99 "don't know" code on ~6% of rows.
+            "sex": np.random.choice([1, 2, 99], n, p=[0.47, 0.47, 0.06]),
+            "income": np.random.exponential(50000, n),
+            "positive": np.random.choice([0, 1], n, p=[0.4, 0.6]),
+        }
+    )
+
+
+@pytest.fixture
+def dk_sample(dk_survey_data: pl.DataFrame) -> Sample:
+    """Stratified Sample built on the DK-coded survey data."""
+    design = Design(stratum="stratum", psu="psu", wgt="weight")
+    return Sample(dk_survey_data, design)
+
+
+class TestWhereAndByOnSameVariable:
+    """
+    A variable may appear in BOTH ``by`` and ``where`` (issue #9).
+
+    Semantics: ``where`` performs domain estimation by zeroing out-of-domain
+    weights; ``by`` groups on the original values. When a ``where`` predicate
+    excludes an entire ``by`` level (e.g. the 99 "don't know" code), that level
+    must simply be absent from the result — matching R's
+    ``design %>% filter(sex != 99) %>% group_by(sex) %>% survey_prop()`` —
+    rather than surfacing as a zero-weight / NaN row.
+    """
+
+    def test_prop_by_and_where_same_variable_does_not_raise(self, dk_sample: Sample):
+        """The historical guard against by/where overlap is gone."""
+        result = dk_sample.estimation.prop(
+            "positive",
+            by="sex",
+            where=col("sex") != 99,
+        )
+        assert isinstance(result, Estimate)
+
+    def test_excluded_level_is_absent(self, dk_sample: Sample):
+        """The filtered-out 99 level must not appear as a (NaN) row."""
+        result = dk_sample.estimation.prop(
+            "positive",
+            by="sex",
+            where=col("sex") != 99,
+        )
+
+        by_levels = {est.by_level[0] for est in result.estimates}
+        assert "99" not in by_levels
+        assert by_levels == {"1", "2"}
+
+        # Nothing NaN slips through.
+        for est in result.estimates:
+            assert not np.isnan(est.est)
+            assert est.se > 0
+            assert 0 <= est.est <= 1
+
+    def test_remaining_levels_unaffected_by_exclusion(self, dk_sample: Sample):
+        """
+        Excluding one by-level via ``where`` must leave every other level's
+        estimate untouched: filtering on the grouping variable itself cannot
+        perturb the domain estimate of a different group.
+        """
+        with_where = dk_sample.estimation.mean(
+            "income",
+            by="sex",
+            where=col("sex") != 99,
+        )
+        without_where = dk_sample.estimation.mean("income", by="sex")
+
+        wo_by_level = {e.by_level[0]: e for e in without_where.estimates}
+
+        for est in with_where.estimates:
+            ref = wo_by_level[est.by_level[0]]
+            assert est.est == pytest.approx(ref.est, rel=1e-9)
+            assert est.se == pytest.approx(ref.se, rel=1e-6)
+
+    def test_point_estimates_match_physical_filter(self, dk_sample: Sample):
+        """
+        Point estimates for the surviving levels must equal those from a
+        physically pre-filtered sample (domain vs. filtering agree on the
+        point estimate; only SEs may differ by design accounting).
+        """
+        domain = dk_sample.estimation.mean(
+            "income",
+            by="sex",
+            where=col("sex") != 99,
+        )
+
+        filtered_data = dk_sample._data.filter(pl.col("sex") != 99)
+        filtered = Sample(filtered_data, dk_sample._design).estimation.mean(
+            "income", by="sex"
+        )
+
+        filtered_by_level = {e.by_level[0]: e for e in filtered.estimates}
+        assert {e.by_level[0] for e in domain.estimates} == set(filtered_by_level)
+
+        for est in domain.estimates:
+            ref = filtered_by_level[est.by_level[0]]
+            assert est.est == pytest.approx(ref.est, rel=1e-9)
+
+    def test_multi_predicate_overlap(self, dk_sample: Sample):
+        """
+        One predicate on the by-variable, one cross-cutting: the by-variable
+        predicate drops its level; the cross-cutting one is a genuine domain
+        restriction within the surviving levels.
+        """
+        result = dk_sample.estimation.prop(
+            "positive",
+            by="sex",
+            where=[col("sex") != 99, col("income") > 10000],
+        )
+
+        by_levels = {est.by_level[0] for est in result.estimates}
+        assert "99" not in by_levels
+        for est in result.estimates:
+            assert 0 <= est.est <= 1
+            assert est.se > 0
+
+    def test_multi_by_with_where_on_one_by_variable(self, dk_sample: Sample):
+        """
+        The issue's literal request: group ``by`` two variables while the
+        ``where`` restricts one of them. Every ``(excluded_level, *)`` cell —
+        i.e. each concatenated group whose first component is the excluded
+        level — must drop out, leaving the full cross of surviving levels.
+        """
+        # Add a second grouping variable with no missing code.
+        data = dk_sample._data.with_columns(
+            pl.Series("region", ["North", "South"] * (dk_sample._data.height // 2))
+        )
+        sample = Sample(data, dk_sample._design)
+
+        result = sample.estimation.mean(
+            "income",
+            by=["sex", "region"],
+            where=col("sex") != 99,
+        )
+
+        sex_levels = {est.by_level[0] for est in result.estimates}
+        region_levels = {est.by_level[1] for est in result.estimates}
+        assert sex_levels == {"1", "2"}  # 99 fully dropped
+        assert region_levels == {"North", "South"}  # region untouched
+        # Full cross of the surviving sex levels x regions.
+        assert len(result.estimates) == 2 * 2
+        for est in result.estimates:
+            assert est.est > 0
+            assert est.se > 0
+
+
+# =============================================================================
 # Domain Estimation Correctness Tests
 # =============================================================================
 

--- a/packages/svy/tests/svy/estimation/test_where_replication.py
+++ b/packages/svy/tests/svy/estimation/test_where_replication.py
@@ -9,8 +9,9 @@ point estimates that reflect the domain but standard errors that reflect
 the full sample (identical SEs for filtered vs. unfiltered runs).
 
 Convention: the where clause restricts on ``educ``, and the ``by`` variable
-is always ``sex``. The library forbids overlap between ``where`` and ``by``
-on the same column, so we keep them strictly separate throughout.
+is usually ``sex``. A variable may appear in both ``where`` and ``by`` on the
+same column (issue #9); that overlap case is covered by
+``test_where_and_by_same_column``.
 
 The file is organized in five sections:
 
@@ -127,9 +128,9 @@ def assert_est_prop(result, expected):
     assert result.se == pytest.approx(expected["se"], rel=TOL)
 
 
-# Domain: educ values that exist in the test CSVs. The library raises if a
-# column appears in both `where` and `by`, so `educ` is reserved for `where`
-# and `sex` is reserved for `by` throughout this file.
+# Domain: educ values that exist in the test CSVs. `educ` is used for `where`
+# and `sex` for `by` in most tests here; a variable may also appear in both
+# (see test_where_and_by_same_column, issue #9).
 def _default_where():
     return col("educ").is_in(["Med", "High"])
 
@@ -353,7 +354,8 @@ class TestWhereReplicationSmoke:
         """The where+by combination that surfaced the original bug.
 
         ``by`` is on ``sex`` (a different column from the where clause's
-        ``educ``), since the library forbids overlap.
+        ``educ``). Overlap of the two on the same column is covered separately
+        by ``test_where_and_by_same_column``.
 
         Note: single-observation by-groups (e.g. ``sex="None"`` in the test
         fixtures) produce NaN SEs under Bootstrap/Jackknife because some
@@ -383,22 +385,37 @@ class TestWhereReplicationSmoke:
                 assert est.lci <= est.uci
 
     @pytest.mark.parametrize("method, csv, prefix, reps, df, psu_col, _gold", SCENARIOS)
-    def test_where_and_by_same_column_raises(
+    def test_where_and_by_same_column(
         self, load_survey_data, make_design, method, csv, prefix, reps, df, psu_col, _gold
     ):
-        """Using the same column in `where` and `by` must raise."""
+        """A column may appear in both `where` and `by` (issue #9).
+
+        Grouping ``by="educ"`` while restricting ``where=educ in {Med, High}``
+        keeps the domain estimate for each surviving level and drops the
+        excluded ones (e.g. ``Low``) entirely — no zero-weight/NaN rows for
+        levels the ``where`` clause filtered out.
+        """
+        import math
+
         data = load_survey_data(csv)
         design = make_design(method, prefix, reps, df, psu_col)
         sample = Sample(data, design)
 
-        with pytest.raises(ValueError, match="both 'by' and 'where'"):
-            sample.estimation.mean(
-                y="income",
-                by="educ",  # same column as the where clause
-                method="replication",
-                where=_default_where(),
-                drop_nulls=True,
-            )
+        result = sample.estimation.mean(
+            y="income",
+            by="educ",  # same column as the where clause
+            method="replication",
+            where=_default_where(),
+            drop_nulls=True,
+        )
+
+        by_levels = {est.by_level[0] for est in result.estimates}
+        # Only the domain's levels survive; excluded educ levels are absent.
+        assert by_levels <= {"Med", "High"}
+        assert by_levels  # at least one surviving level
+        for est in result.estimates:
+            assert est.est > 0
+            assert math.isnan(est.se) or est.se >= 0
 
 
 # ═════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Closes #9.

## Summary

A variable may now appear in **both** `by` and `where`. `where` is domain estimation (out-of-domain weights zeroed, full vector preserved) and `by` groups on the original values — the two are orthogonal, so the guard that raised `ValueError` on overlap is removed.

The use case from the issue: restrict to the real levels of a variable via `where` while still breaking the estimate down `by` that same variable, e.g.

```python
sample.estimation.prop("y", by=["Age_Range", "Car_Color"], where=col("Age_Range") != "under_18")
```

Previously raised; now returns the adult age-ranges × colors with `under_18` simply absent.

## How it works

When a `where` predicate excludes an **entire** `by` level (e.g. a "don't know"/missing code like `99`), that level has no domain estimate to report and must be absent from the results — matching R's `design %>% filter(...) %>% group_by(...)`.

The mechanism is a single change in `prepare_data`, **before** Rust:

- The excluded level's rows are **not dropped** — that would remove PSUs and corrupt the design-based variance of the surviving groups. They stay in the frame with weights zeroed (ordinary domain estimation).
- Instead their **grouping label is set to `null`**. The kernel enumerates groups via `by.unique()` and skips nulls, so the level is never formed as a group — no wasted per-group compute, and it sidesteps the `"Sum of weights is zero in domain"` abort that would otherwise kill the whole call.
- Every row still flows to Rust and contributes to the shared strata/PSU design and df.

Selection uses the domain flag (`__svy_domain__`), not zero-weight testing, so a level carrying genuine zero survey weights (but still in-domain) is never mistaken for a `where`-excluded one.

**No Rust change.** Covers Taylor + replication, all estimands (mean/total/prop/ratio/median), and multi-`by`.

## Correctness

Surviving groups' `est`/`se`/`df` are byte-identical to the un-excluded computation — verified: `se` for a surviving level matches the standalone full-design domain estimate to 1e-12. `degrees_of_freedom` counts only positive-weight observations, and zeroed rows contribute zero score, so a surviving group is unaffected by whether the excluded level's rows carry their label or `null`.

## Tests

- `test_where_by.py` — new `TestWhereAndByOnSameVariable`: no-raise, excluded level absent (no NaN row), surviving levels' est+se unchanged, point estimates match a physical filter, multi-predicate (one on the by-var + one cross-cutting), and the issue's literal multi-`by` case.
- `test_where_replication.py` — the old `test_where_and_by_same_column_raises` is now a positive test across BRR/Bootstrap/Jackknife; stale "forbids overlap" docs updated.

Full suite: **2526 passed, 1 skipped**. Ruff clean.

## Not included

The reporter's follow-up `shape (0, 0)` empty-DataFrame case (no `by`/`where` overlap) looks like a separate defect in the empty-domain path and is not addressed here; their workaround (both predicates in `where`) now works via this change.