### PR TITLE
release(svy-rs): v0.10.0

### DIFF
--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -3495,7 +3495,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svy_rs"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "approx",

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svy_rs"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2024"
 repository = "https://gitlab.com/samplics/svy"
 homepage = "https://gitlab.com/samplics/svy"

--- a/packages/svy-rs/pyproject.toml
+++ b/packages/svy-rs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy_rs"
-version = "0.9.0"
+version = "0.10.0"
 description = "Internal Rust extension for the svy package. Do not depend on this directly."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/uv.lock
+++ b/uv.lock
@@ -2370,7 +2370,7 @@ dev = [
 
 [[package]]
 name = "svy-io"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/svy-io" }
 dependencies = [
     { name = "polars", extra = ["pyarrow"] },
@@ -2397,7 +2397,7 @@ dev = [
 
 [[package]]
 name = "svy-rs"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "packages/svy-rs" }
 dependencies = [
     { name = "polars", extra = ["pyarrow"] },


### PR DESCRIPTION
Minor release of the internal Rust extension `svy_rs`.

## Changes since 0.9.0
- **feat:** batched multi-variable estimation API — one design build shared across mean/total/ratio/prop/median
- **fix:** deterministic Taylor variance (sort PSUs, drop the std `HashSet`)
- **perf:** Phase C/D/E estimation + replicate-weight optimizations (parallel by-domain GLM/Taylor, no-materialisation replicate kernels, cache-blocked weight matrix, integer design codes)

## Version bumps
- `Cargo.toml`, `pyproject.toml`, `Cargo.lock` → 0.10.0
- `uv.lock` synced (also picks up svy-io 0.1.1)

## Release
Merge, then push tag `svy-rs-v0.10.0` to trigger the wheel build + PyPI publish.