### PR TITLE
release(svy): v0.19.0 + per-package changelogs + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,64 @@
+# Dependabot configuration.
+# Keeps Python (uv), Rust (cargo), and GitHub Actions dependencies patched and
+# opens security PRs for all ecosystems. Updates are grouped to reduce PR noise.
+version: 2
+updates:
+  # --- Python workspace (root uv.lock) ---
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Rust: svy-rs extension ---
+  - package-ecosystem: "cargo"
+    directory: "/packages/svy-rs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Rust: svy-io ReadStat binding ---
+  - package-ecosystem: "cargo"
+    directory: "/packages/svy-io/native/svyreadstat_rs"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Rust: svy-io ReadStat -sys crate ---
+  - package-ecosystem: "cargo"
+    directory: "/packages/svy-io/native/readstat-sys"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- GitHub Actions (workflows pin actions by SHA) ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      actions:
+        update-types:
+          - "minor"
+          - "patch"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,7 +147,9 @@ that affect `native/readstat-sys/wrapper.h` before merging.
 ## Versioning & releases
 
 - **SemVer** per package; breaking changes require a major bump.
-- Add entries to `CHANGELOG.md` (Keep a Changelog style).
+- Add entries to the affected package's `CHANGELOG.md` (Keep a Changelog style):
+  `packages/svy/CHANGELOG.md`, `packages/svy-io/CHANGELOG.md`, or
+  `packages/svy-rs/CHANGELOG.md`.
 - Packages are published separately; tagging a release triggers CI wheel builds
   (manylinux/macOS/Windows for native packages).
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -147,11 +147,16 @@ that affect `native/readstat-sys/wrapper.h` before merging.
 ## Versioning & releases
 
 - **SemVer** per package; breaking changes require a major bump.
-- Add entries to the affected package's `CHANGELOG.md` (Keep a Changelog style):
-  `packages/svy/CHANGELOG.md`, `packages/svy-io/CHANGELOG.md`, or
-  `packages/svy-rs/CHANGELOG.md`.
-- Packages are published separately; tagging a release triggers CI wheel builds
-  (manylinux/macOS/Windows for native packages).
+- Document user-facing changes in the affected package's `CHANGELOG.md`
+  (`packages/svy/`, `packages/svy-io/`, or `packages/svy-rs/`), Keep a Changelog
+  style. Add each entry under `[Unreleased]` in the same PR that makes the
+  change, written for readers — *what changed and why it matters*, not a raw
+  commit summary.
+- On release, rename that package's `[Unreleased]` section to the new version +
+  date, open a fresh empty `[Unreleased]`, and update the compare/tag links at
+  the bottom of the file.
+- Packages are published separately; tagging a release (e.g. `svy-v0.19.0`)
+  triggers CI wheel builds (manylinux/macOS/Windows for native packages).
 
 ---
 

--- a/packages/svy-io/CHANGELOG.md
+++ b/packages/svy-io/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 
-All notable changes to **svy-io** are documented in this file.
-
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
-`svy-io` adheres to [Semantic Versioning](https://semver.org/). Entries are
-written for readers — _what changed and why it matters_ — not raw commit logs.
-Add each change under `[Unreleased]` in the same PR that makes it; on release,
-rename `[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
+All notable changes to **svy-io**, high-speed reading and writing of survey files (SAS, SPSS, Stata) as Polars frames via ReadStat, are recorded here. Releases follow [Semantic Versioning](https://semver.org/); the layout follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Part of the [svy](../svy/CHANGELOG.md) project.
 
 ## [Unreleased]
 
@@ -16,39 +10,20 @@ rename `[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
 
 ### Fixed
 
-- **SAS datetime values are now decoded correctly.** Datetime formats were
-  matched by a `"date"` prefix test, so `DATETIME` columns were sent through the
-  days-since-1960 date path and lost their time-of-day. Datetime formats are now
-  checked first and decoded against a true `Datetime` epoch, preserving the time
-  component. Also fixes an `AttributeError` on variables with a null format on
-  the default `read_sav` path.
-- **Numeric ID columns stay numeric.** The magnitude/name-based temporal
-  inference heuristics are now gated behind `infer_temporal_formats` (opt-in), so
-  numeric identifier columns are no longer coerced to dates/times.
-- **`as_factor(levels="both")` on numeric coded columns** no longer mis-handles
-  literal separators; values are stringified before the `Categorical` cast.
+- **SAS datetime values are now decoded correctly.** Datetime formats were matched by a `"date"` prefix test, so `DATETIME` columns were sent through the days-since-1960 date path and lost their time-of-day. Datetime formats are now checked first and decoded against a true `Datetime` epoch, preserving the time component. Also fixes an `AttributeError` on variables with a null format on the default `read_sav` path.
+- **Numeric ID columns stay numeric.** The magnitude/name-based temporal inference heuristics are now gated behind `infer_temporal_formats` (opt-in), so numeric identifier columns are no longer coerced to dates/times.
+- **`as_factor(levels="both")` on numeric coded columns** no longer mis-handles literal separators; values are stringified before the `Categorical` cast.
 - **`write_sav` no longer mutates the caller's `value_labels`.**
-- **All file-like reader inputs** work again (a missing `tempfile` import
-  crashed them).
-- **FFI hardening.** Builder pre-allocation is clamped to 65,536 rows so a
-  crafted header can no longer drive a multi-GB eager allocation and abort the
-  process; ReadStat callbacks are wrapped in panic guards that raise Python
-  exceptions instead of aborting; the XPT writer now emits all record batches
-  (rows after the first batch were silently dropped) and handles
-  StringView/dictionary columns.
+- **All file-like reader inputs** work again (a missing `tempfile` import crashed them).
+- **FFI hardening.** Builder pre-allocation is clamped to 65,536 rows so a crafted header can no longer drive a multi-GB eager allocation and abort the process; ReadStat callbacks are wrapped in panic guards that raise Python exceptions instead of aborting; the XPT writer now emits all record batches (rows after the first batch were silently dropped) and handles StringView/dictionary columns.
 
 ### Packaging
 
-- **Source builds and Intel macOS now work.** The sdist previously shipped
-  without ReadStat's C sources (an `include` glob matched zero files), so every
-  source build failed — and Intel Macs always hit that path because no
-  `x86_64-apple-darwin` wheel was published. The sdist now bundles all ReadStat
-  sources, and prebuilt Intel macOS wheels are published.
+- **Source builds and Intel macOS now work.** The sdist previously shipped without ReadStat's C sources (an `include` glob matched zero files), so every source build failed — and Intel Macs always hit that path because no `x86_64-apple-darwin` wheel was published. The sdist now bundles all ReadStat sources, and prebuilt Intel macOS wheels are published.
 
 ## [0.1.0] — 2026-05
 
-First release tracked in this changelog. For earlier history, see the
-[Git tags](https://github.com/samplics-org/svy/tags).
+First release tracked in this changelog. For earlier history, see the [Git tags](https://github.com/samplics-org/svy/tags).
 
 [Unreleased]: https://github.com/samplics-org/svy/compare/svy-io-v0.1.1...HEAD
 [0.1.1]: https://github.com/samplics-org/svy/releases/tag/svy-io-v0.1.1

--- a/packages/svy-io/CHANGELOG.md
+++ b/packages/svy-io/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to **svy-io** are documented in this file.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
+`svy-io` adheres to [Semantic Versioning](https://semver.org/). Entries are
+written for readers — _what changed and why it matters_ — not raw commit logs.
+Add each change under `[Unreleased]` in the same PR that makes it; on release,
+rename `[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
+
+## [Unreleased]
+
+<!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
+
+## [0.1.1] — 2026-07-12
+
+### Fixed
+
+- **SAS datetime values are now decoded correctly.** Datetime formats were
+  matched by a `"date"` prefix test, so `DATETIME` columns were sent through the
+  days-since-1960 date path and lost their time-of-day. Datetime formats are now
+  checked first and decoded against a true `Datetime` epoch, preserving the time
+  component. Also fixes an `AttributeError` on variables with a null format on
+  the default `read_sav` path.
+- **Numeric ID columns stay numeric.** The magnitude/name-based temporal
+  inference heuristics are now gated behind `infer_temporal_formats` (opt-in), so
+  numeric identifier columns are no longer coerced to dates/times.
+- **`as_factor(levels="both")` on numeric coded columns** no longer mis-handles
+  literal separators; values are stringified before the `Categorical` cast.
+- **`write_sav` no longer mutates the caller's `value_labels`.**
+- **All file-like reader inputs** work again (a missing `tempfile` import
+  crashed them).
+- **FFI hardening.** Builder pre-allocation is clamped to 65,536 rows so a
+  crafted header can no longer drive a multi-GB eager allocation and abort the
+  process; ReadStat callbacks are wrapped in panic guards that raise Python
+  exceptions instead of aborting; the XPT writer now emits all record batches
+  (rows after the first batch were silently dropped) and handles
+  StringView/dictionary columns.
+
+### Packaging
+
+- **Source builds and Intel macOS now work.** The sdist previously shipped
+  without ReadStat's C sources (an `include` glob matched zero files), so every
+  source build failed — and Intel Macs always hit that path because no
+  `x86_64-apple-darwin` wheel was published. The sdist now bundles all ReadStat
+  sources, and prebuilt Intel macOS wheels are published.
+
+## [0.1.0] — 2026-05
+
+First release tracked in this changelog. For earlier history, see the
+[Git tags](https://github.com/samplics-org/svy/tags).
+
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-io-v0.1.1...HEAD
+[0.1.1]: https://github.com/samplics-org/svy/releases/tag/svy-io-v0.1.1
+[0.1.0]: https://github.com/samplics-org/svy/releases/tag/svy-io-v0.1.0

--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -1,12 +1,6 @@
 # Changelog
 
-All notable changes to **svy_rs** are documented in this file.
-
-`svy_rs` is the internal Rust extension backing the `svy` package and is not a
-supported public API — depend on `svy`, not on this directly. Entries here are
-technical and describe what changed for `svy`'s consumers of the extension. The
-format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
-[Semantic Versioning](https://semver.org/).
+All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s estimation and replicate-weight kernels, are recorded here. It is not a supported public API — depend on [`svy`](../svy/CHANGELOG.md), not on this directly; entries are technical and describe what changed for `svy`'s use of the extension. Follows [Semantic Versioning](https://semver.org/) and [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
@@ -16,27 +10,15 @@ format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 ### Added
 
-- **Batched multi-variable estimation kernels.** `mean`, `total`, `ratio`,
-  `prop`, and `median` accept multiple variables and share a single design build,
-  running them in parallel for ungrouped Taylor estimation. Backs `svy`'s
-  list-input estimation API.
+- **Batched multi-variable estimation kernels.** `mean`, `total`, `ratio`, `prop`, and `median` accept multiple variables and share a single design build, running them in parallel for ungrouped Taylor estimation. Backs `svy`'s list-input estimation API.
 
 ### Fixed
 
-- **Deterministic Taylor variance.** Per-stratum PSU contributions were summed in
-  the iteration order of a standard `HashSet`, making the last digits of a
-  standard error vary run-to-run. PSUs are now summed in a canonical (sorted)
-  order, so results are bit-reproducible.
+- **Deterministic Taylor variance.** Per-stratum PSU contributions were summed in the iteration order of a standard `HashSet`, making the last digits of a standard error vary run-to-run. PSUs are now summed in a canonical (sorted) order, so results are bit-reproducible.
 
 ### Performance
 
-- **Phase C–E estimation and replicate-weight optimizations:** dtype-polymorphic
-  design indexing with cached integer codes; the design is indexed once per
-  by-group/level loop; replicate mean/total/ratio/proportion kernels accumulate
-  without materializing the replicate matrix; cache-blocked parallel
-  replicate-weight matrix build; fused mean/total/ratio domain kernels; by-group
-  Taylor and by-domain GLM parallelized with the GIL released; Taylor kernel fast
-  paths (~2× at 1M rows).
+- **Phase C–E estimation and replicate-weight optimizations:** dtype-polymorphic design indexing with cached integer codes; the design is indexed once per by-group/level loop; replicate mean/total/ratio/proportion kernels accumulate without materializing the replicate matrix; cache-blocked parallel replicate-weight matrix build; fused mean/total/ratio domain kernels; by-group Taylor and by-domain GLM parallelized with the GIL released; Taylor kernel fast paths (~2× at 1M rows).
 
 ### Build
 
@@ -44,8 +26,7 @@ format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
 
 ## [0.9.0] — 2026-05-19
 
-Baseline for this changelog. For earlier history, see the
-[Git tags](https://github.com/samplics-org/svy/tags).
+Baseline for this changelog. For earlier history, see the [Git tags](https://github.com/samplics-org/svy/tags).
 
 [Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.10.0...HEAD
 [0.10.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.10.0

--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to **svy_rs** are documented in this file.
+
+`svy_rs` is the internal Rust extension backing the `svy` package and is not a
+supported public API — depend on `svy`, not on this directly. Entries here are
+technical and describe what changed for `svy`'s consumers of the extension. The
+format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and
+[Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+<!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
+
+## [0.10.0] — 2026-07-12
+
+### Added
+
+- **Batched multi-variable estimation kernels.** `mean`, `total`, `ratio`,
+  `prop`, and `median` accept multiple variables and share a single design build,
+  running them in parallel for ungrouped Taylor estimation. Backs `svy`'s
+  list-input estimation API.
+
+### Fixed
+
+- **Deterministic Taylor variance.** Per-stratum PSU contributions were summed in
+  the iteration order of a standard `HashSet`, making the last digits of a
+  standard error vary run-to-run. PSUs are now summed in a canonical (sorted)
+  order, so results are bit-reproducible.
+
+### Performance
+
+- **Phase C–E estimation and replicate-weight optimizations:** dtype-polymorphic
+  design indexing with cached integer codes; the design is indexed once per
+  by-group/level loop; replicate mean/total/ratio/proportion kernels accumulate
+  without materializing the replicate matrix; cache-blocked parallel
+  replicate-weight matrix build; fused mean/total/ratio domain kernels; by-group
+  Taylor and by-domain GLM parallelized with the GIL released; Taylor kernel fast
+  paths (~2× at 1M rows).
+
+### Build
+
+- Bump `ethnum` 1.5.2 → 1.5.3 for newer Rust toolchains.
+
+## [0.9.0] — 2026-05-19
+
+Baseline for this changelog. For earlier history, see the
+[Git tags](https://github.com/samplics-org/svy/tags).
+
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.10.0...HEAD
+[0.10.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.10.0
+[0.9.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.9.0

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **svy** are documented in this file.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
 `svy` adheres to [Semantic Versioning](https://semver.org/). Entries are written
-for readers — *what changed and why it matters* — not raw commit logs. Add each
+for readers — _what changed and why it matters_ — not raw commit logs. Add each
 change under `[Unreleased]` in the same PR that makes it; on release, rename
 `[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
 
@@ -21,6 +21,27 @@ change under `[Unreleased]` in the same PR that makes it; on release, rename
   manual loop at 1M rows depending on the estimator. `by=`, replication,
   `drop_nulls`, and the singleton scale double-pass transparently fall back to
   independent per-variable calls (identical results).
+
+- **A variable may now appear in both `by=` and `where=`.** `where` is domain
+  estimation (out-of-domain weights zeroed) and `by` groups on the original
+  values — the two are orthogonal, so the previous guard forbidding overlap is
+  removed. When a `where` predicate excludes an entire `by` level (e.g. a
+  "don't know" code), that level is correctly absent from the results — matching
+  R's `filter(...) %>% group_by(...)` — while every row still contributes to the
+  shared design and degrees of freedom, so surviving groups' estimates, standard
+  errors, and df are byte-identical. Covers Taylor and replication, all
+  estimands, and multi-`by`.
+
+- **Serialization for result objects.** New `svy.serialize` module provides
+  stable, versioned serialization of every result type (estimates, t-tests,
+  chi-square, tables, GLM fits/predictions, describe): `serialize(result)`
+  returns a kind-tagged struct, `to_json` / `to_dict` export, and `from_json`
+  round-trips. Payloads carry a `SCHEMA_VERSION` for forward compatibility.
+
+- **Single-stage designs and explicit population sizes.** The design's `ssu`
+  (second-stage unit) is now optional, so single-stage designs no longer need a
+  placeholder. A `PopSize` type is exported for specifying finite-population
+  sizes (FPC).
 
 ### Changed
 
@@ -41,6 +62,22 @@ change under `[Unreleased]` in the same PR that makes it; on release, rename
   run-to-run (far below reporting precision, but not reproducible). PSUs are now
   summed in a canonical order, so `mean`/`total`/`ratio`/`prop`/`median` return
   identical standard errors across runs.
+
+- **Stale design cache could return silently wrong results.** Estimation design
+  caches were keyed on the identity of the data frame without holding a
+  reference to it; after an in-place mutation freed and reallocated the frame,
+  identity reuse could make a stale entry look current and serve design arrays
+  for the old data. Caches are now keyed on a monotonic per-`Sample` data version
+  bumped on every rebind, so every mutation, weighting, selection, and fork path
+  invalidates correctly.
+
+- **Replication-design crashes and related correctness fixes.** Clone, column
+  keep/remove/rename, and singleton handling now work on replication designs
+  (previously hit stale replicate-weight API usage and could crash). `Expr` now
+  raises `TypeError` on boolean use (`and`/`or`/`not`/chained comparisons) so a
+  malformed `where=` predicate fails loudly instead of silently filtering wrong,
+  and derived samples deep-copy metadata/warnings/design so they no longer share
+  mutable state with the original.
 
 <!-- Also available when needed: ### Deprecated, ### Removed, ### Security -->
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -1,93 +1,36 @@
 # Changelog
 
-All notable changes to **svy** are documented in this file.
+All notable changes to **svy**, the Python package for design-based analysis of complex survey data — means, totals, ratios, proportions, regression, weighting, and sample selection — are recorded here. Releases follow [Semantic Versioning](https://semver.org/); the layout follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and
-`svy` adheres to [Semantic Versioning](https://semver.org/). Entries are written
-for readers — _what changed and why it matters_ — not raw commit logs. Add each
-change under `[Unreleased]` in the same PR that makes it; on release, rename
-`[Unreleased]` to the new version + date and open a fresh `[Unreleased]`.
+Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (SAS/SPSS/Stata I/O) and [`svy-rs`](../svy-rs/CHANGELOG.md) (internal Rust extension).
 
 ## [Unreleased]
 
+<!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
+
+## [0.19.0] — 2026-07-12
+
 ### Added
 
-- **Batched multi-variable estimation.** `estimation.mean`, `total`, `ratio`,
-  `prop`, and `median` now accept a list of columns and return a
-  `list[Estimate]` (one per variable; `ratio` pairs numerator/denominator
-  element-wise and broadcasts a scalar side). A single string still returns a
-  single `Estimate`. For ungrouped Taylor estimation the list form shares one
-  design build across variables and runs them in parallel — 4–13× faster than a
-  manual loop at 1M rows depending on the estimator. `by=`, replication,
-  `drop_nulls`, and the singleton scale double-pass transparently fall back to
-  independent per-variable calls (identical results).
-
-- **A variable may now appear in both `by=` and `where=`.** `where` is domain
-  estimation (out-of-domain weights zeroed) and `by` groups on the original
-  values — the two are orthogonal, so the previous guard forbidding overlap is
-  removed. When a `where` predicate excludes an entire `by` level (e.g. a
-  "don't know" code), that level is correctly absent from the results — matching
-  R's `filter(...) %>% group_by(...)` — while every row still contributes to the
-  shared design and degrees of freedom, so surviving groups' estimates, standard
-  errors, and df are byte-identical. Covers Taylor and replication, all
-  estimands, and multi-`by`.
-
-- **Serialization for result objects.** New `svy.serialize` module provides
-  stable, versioned serialization of every result type (estimates, t-tests,
-  chi-square, tables, GLM fits/predictions, describe): `serialize(result)`
-  returns a kind-tagged struct, `to_json` / `to_dict` export, and `from_json`
-  round-trips. Payloads carry a `SCHEMA_VERSION` for forward compatibility.
-
-- **Single-stage designs and explicit population sizes.** The design's `ssu`
-  (second-stage unit) is now optional, so single-stage designs no longer need a
-  placeholder. A `PopSize` type is exported for specifying finite-population
-  sizes (FPC).
+- **Batched multi-variable estimation.** `estimation.mean`, `total`, `ratio`, `prop`, and `median` now accept a list of columns and return a `list[Estimate]` (one per variable; `ratio` pairs numerator/denominator element-wise and broadcasts a scalar side). A single string still returns a single `Estimate`. For ungrouped Taylor estimation the list form shares one design build across variables and runs them in parallel — 4–13× faster than a manual loop at 1M rows depending on the estimator. `by=`, replication, `drop_nulls`, and the singleton scale double-pass transparently fall back to independent per-variable calls (identical results).
+- **A variable may now appear in both `by=` and `where=`.** `where` is domain estimation (out-of-domain weights zeroed) and `by` groups on the original values — the two are orthogonal, so the previous guard forbidding overlap is removed. When a `where` predicate excludes an entire `by` level (e.g. a "don't know" code), that level is correctly absent from the results — matching R's `filter(...) %>% group_by(...)` — while every row still contributes to the shared design and degrees of freedom, so surviving groups' estimates, standard errors, and df are byte-identical. Covers Taylor and replication, all estimands, and multi-`by`.
+- **Serialization for result objects.** New `svy.serialize` module provides stable, versioned serialization of every result type (estimates, t-tests, chi-square, tables, GLM fits/predictions, describe): `serialize(result)` returns a kind-tagged struct, `to_json` / `to_dict` export, and `from_json` round-trips. Payloads carry a `SCHEMA_VERSION` for forward compatibility.
+- **Single-stage designs and explicit population sizes.** The design's `ssu` (second-stage unit) is now optional, so single-stage designs no longer need a placeholder. A `PopSize` type is exported for specifying finite-population sizes (FPC).
 
 ### Changed
 
-- **Estimation now fails fast on unhandled singleton PSUs** instead of silently
-  under-reporting the variance. Taylor estimation (`mean`, `total`, `prop`,
-  `ratio`, `median`) raises `SingletonError` when a design has single-PSU strata
-  and no handling strategy was chosen — matching R's
-  `options(survey.lonely.psu = "fail")`. Pick a strategy explicitly with
-  `sample.singleton.skip()` / `.certainty()` / `.center()` / `.scale()` /
-  `.collapse()` / `.pool()`. Previously such strata were dropped from the
-  variance with no error or warning.
+- **Estimation now fails fast on unhandled singleton PSUs** instead of silently under-reporting the variance. Taylor estimation (`mean`, `total`, `prop`, `ratio`, `median`) raises `SingletonError` when a design has single-PSU strata and no handling strategy was chosen — matching R's `options(survey.lonely.psu = "fail")`. Pick a strategy explicitly with `sample.singleton.skip()` / `.certainty()` / `.center()` / `.scale()` / `.collapse()` / `.pool()`. Previously such strata were dropped from the variance with no error or warning.
 
 ### Fixed
 
-- **Taylor standard errors are now bit-reproducible.** The stratified variance
-  summed each stratum's PSUs in the iteration order of a randomized hash set, so
-  a repeated estimate on identical data could differ in its last digits
-  run-to-run (far below reporting precision, but not reproducible). PSUs are now
-  summed in a canonical order, so `mean`/`total`/`ratio`/`prop`/`median` return
-  identical standard errors across runs.
-
-- **Stale design cache could return silently wrong results.** Estimation design
-  caches were keyed on the identity of the data frame without holding a
-  reference to it; after an in-place mutation freed and reallocated the frame,
-  identity reuse could make a stale entry look current and serve design arrays
-  for the old data. Caches are now keyed on a monotonic per-`Sample` data version
-  bumped on every rebind, so every mutation, weighting, selection, and fork path
-  invalidates correctly.
-
-- **Replication-design crashes and related correctness fixes.** Clone, column
-  keep/remove/rename, and singleton handling now work on replication designs
-  (previously hit stale replicate-weight API usage and could crash). `Expr` now
-  raises `TypeError` on boolean use (`and`/`or`/`not`/chained comparisons) so a
-  malformed `where=` predicate fails loudly instead of silently filtering wrong,
-  and derived samples deep-copy metadata/warnings/design so they no longer share
-  mutable state with the original.
-
-<!-- Also available when needed: ### Deprecated, ### Removed, ### Security -->
+- **Taylor standard errors are now bit-reproducible.** The stratified variance summed each stratum's PSUs in the iteration order of a randomized hash set, so a repeated estimate on identical data could differ in its last digits run-to-run (far below reporting precision, but not reproducible). PSUs are now summed in a canonical order, so `mean`/`total`/`ratio`/`prop`/`median` return identical standard errors across runs.
+- **Stale design cache could return silently wrong results.** Estimation design caches were keyed on the identity of the data frame without holding a reference to it; after an in-place mutation freed and reallocated the frame, identity reuse could make a stale entry look current and serve design arrays for the old data. Caches are now keyed on a monotonic per-`Sample` data version bumped on every rebind, so every mutation, weighting, selection, and fork path invalidates correctly.
+- **Replication-design crashes and related correctness fixes.** Clone, column keep/remove/rename, and singleton handling now work on replication designs (previously hit stale replicate-weight API usage and could crash). `Expr` now raises `TypeError` on boolean use (`and`/`or`/`not`/chained comparisons) so a malformed `where=` predicate fails loudly instead of silently filtering wrong, and derived samples deep-copy metadata/warnings/design so they no longer share mutable state with the original.
 
 ## [0.18.2] — 2026-05-20
 
-First release tracked in this changelog. For the history prior to 0.18.2, see the
-[Git tags](https://github.com/samplics-org/svy/tags) and
-[GitHub Releases](https://github.com/samplics-org/svy/releases).
+First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-<!-- Optional: backfill a few notable 0.18.2 highlights here. -->
-
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.18.2...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.19.0...HEAD
+[0.19.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.19.0
 [0.18.2]: https://github.com/samplics-org/svy/releases/tag/svy-v0.18.2

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.18.2"
+version = "0.19.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -25,9 +25,16 @@ dependencies = [
   "msgspec>=0.19.0",
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
-  "svy-io>=0.1.0,<0.2.0",
-  "svy-rs>=0.9.0,<0.10.0",
+  "svy-io>=0.1.1,<0.2.0",
+  "svy-rs>=0.10.0,<0.11.0",
 ]
+
+[project.urls]
+Homepage = "https://svylab.com/docs/svy"
+Documentation = "https://svylab.com/docs/svy"
+Changelog = "https://github.com/samplics-org/svy/blob/main/packages/svy/CHANGELOG.md"
+Source = "https://github.com/samplics-org/svy"
+Issues = "https://github.com/samplics-org/svy/issues"
 
 [tool.uv.sources]
 svy-io = { workspace = true } # overrides the above during dev

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -126,7 +126,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.18.2"
+__version__ = "0.19.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2298,7 +2298,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.18.2"
+version = "0.19.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bundles the svy 0.19.0 release with the changelog restructure and CI dependency config (grouped to keep main's CI cycles down).

## Release — svy 0.19.0
- Bump `svy` 0.18.2 → 0.19.0 (`pyproject.toml`, `__init__.py`, `uv.lock`).
- Fix dependency pins: require `svy-rs>=0.10.0` (the batched estimation API lives there — the old `<0.10.0` cap excluded it) and `svy-io>=0.1.1` (SAS datetime + FFI fixes).
- Add `[project.urls]` (Homepage, Documentation, Changelog, Source, Issues) — `svy` had none.

## Changelog — per-package + content
- Move root `CHANGELOG.md` → `packages/svy/CHANGELOG.md`; rename its `[Unreleased]` section to `[0.19.0]`, including the previously-missing entries (by=/where=, serialization, single-stage/PopSize, stale-cache fix, replication-design fixes).
- Add `packages/svy-io/CHANGELOG.md` (through 0.1.1) and `packages/svy-rs/CHANGELOG.md` (through 0.10.0), each self-contained and cross-linked.
- Package-specific intros; unwrapped prose; authoring workflow moved to `CONTRIBUTING.md`.

## CI — dependabot
- Add `.github/dependabot.yml` covering `uv`, `cargo` (svy-rs + both svy-io native crates — previously unmonitored), and `github-actions`. Grouped minor/patch to reduce PR noise.

## Follow-ups (not in this PR)
- pyo3 0.26 → 0.29 (GHSA-36hh-v3qg-5jq4): assessed **not exposed** (neither crate constructs or `nth`-indexes PyList/PyTuple iterators). Bundle the bump into the next svy-rs/svy-io release as routine maintenance.
- Merge the 5 open Python Dependabot PRs (#23–27, dev/transitive) after this lands.
- After the release, tag `svy-v0.19.0` to trigger the PyPI publish.