### PR TITLE
docs: add JOSS paper and refresh root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Modern Python tools for **complex survey analysis**, built for real-world statistical workflows.
 
-**svy** is a rigorously design-based yet production-oriented ecosystem for survey design, weighting, estimation, and small area estimation — without sacrificing transparency or scalability.
+**svy** is a rigorously design-based, production-oriented ecosystem for survey design, weighting, estimation, and small area estimation, without sacrificing transparency or scalability.
 
 🌐 Website: https://svylab.com  
 📘 Documentation: https://svylab.com/docs
@@ -13,137 +13,96 @@ Modern Python tools for **complex survey analysis**, built for real-world statis
 > **Validation**: Want to assess the correctness of svy?  
 > See our [comparison with R’s survey package](https://svylab.com/learn/notes/posts/svy-vs-r-comparison/), showing numerically identical results across Taylor linearization, replication methods, and complex survey designs.
 
-## ⚠️ Current Status (Read This First)
-
-**The svy libraries are not yet publicly downloadable.**
-
-This repository is intentionally public **before the code release** so that early users can:
-
-- ask questions,
-- report documentation gaps,
-- suggest features,
-- discuss real-world survey use cases,
-- help shape stable APIs.
-
-📘 **Documentation is live**  
-🧪 **Code is under finalization**  
-🐞 **Issues & discussions are open**
-
-When the first public releases are ready, this repository will become the main code home.
-
----
-
 ## What is svy?
 
 svy is designed for people who **actually work with complex survey data**, including:
 
 - National statistical offices
 - Public health and development programs
-- Survey methodologists
+- Opinion polling and market research organizations
+- Survey methodologists and social science researchers
 - Data scientists working with complex samples
 
 The guiding principle is:
 
-> **Correct inference first — without hiding assumptions or sacrificing usability.**
+> **Correct inference first, without hiding assumptions or sacrificing usability.**
 
 svy prioritizes statistical validity while remaining compatible with modern Python workflows.
 
 ---
 
-## Planned Capabilities
+## Installation
 
-The svy ecosystem is being built to support:
+```bash
+pip install svy # svy[report] for rich outputs
+```
 
-- Complex survey design (strata, clusters, weights)
-- Design-based estimation with valid standard errors
-- Replication methods (BRR, bootstrap, jackknife)
-- Small Area Estimation (area- and unit-level models)
-- Explicit, inspectable, reproducible outputs
-- Integration with Polars, NumPy, SciPy, and JAX-based tooling
+or
+
+```bash
+uv add svy
+```
+
+---
+
+## Quick Start
+
+```python
+import svy
+
+# Load example data
+hld_data = svy.datasets.load("hld_sample_wb_2023")
+
+# Define the survey design
+hld_design = svy.Design(stratum=("geo1", "urbrur"), psu="ea", wgt="hhweight")
+
+# Create a sample object
+hld_sample = svy.Sample(data=hld_data, design=hld_design)
+
+# Estimate the mean of total expenditure
+tot_exp_mean = hld_sample.estimation.mean(y="tot_exp")
+print(tot_exp_mean)
+```
+
+---
+
+## Capabilities
+
+- **Sample size calculation** for estimation and comparison objectives
+- **Sample selection** including SRS, systematic, PPS, and multi-stage designs
+- **Weight adjustments**: nonresponse, poststratification, calibration (GREG), raking, trimming
+- **Design-based estimation** with valid standard errors (Taylor linearization)
+- **Replication methods**: BRR, bootstrap, jackknife, SDR
+- **Categorical data analysis**: tabulation, crosstabulation, t-test, rank tests, Rao-Scott test
+- **Generalized linear models**: linear, logistic, Poisson, Gamma with survey weights
+- **Explicit, inspectable, reproducible outputs**
+- **Built on Polars, NumPy, SciPy, and msgspec**, with a Rust computational engine
 
 All methods are grounded in established survey methodology.
 
 ---
 
-## Example (Illustrative API)
+## Ecosystem Packages
 
-The example below shows the **intended public API**.
-It reflects the current design but **cannot yet be run** until the first release.
+| Package                                     | Purpose                                 | Install                  |
+| ------------------------------------------- | --------------------------------------- | ------------------------ |
+| **svy**                                     | Core survey design & estimation         | `pip install svy`        |
+| [svy-sae](https://svylab.com/docs/svy-sae/) | Small Area Estimation                   | `pip install svy-sae`    |
+| [svy-io](https://svylab.com/docs/svy-io/)   | SPSS / Stata / SAS I/O                  | `pip install svy-io`     |
+| [svy-rs](https://pypi.org/project/svy-rs/)  | Rust computational engine used by svy   | installed automatically  |
 
-### Design-based estimation
-
-```python
-pip install svy
-```
-
-```python
-import svy
-
-hld_data = svy.load_dataset(name="hld_sample_wb_2023", limit=None)
-
-hld_design = svy.Design(stratum=("geo1", "urbrur"), psu="ea", wgt="hhweight")
-
-hld_sample = svy.Sample(data=hld_data, design=hld_design)
-
-tot_exp_mean = hld_sample.estimation.mean(y="tot_exp")
-
-print(tot_exp_mean)
-```
-
-### Fay Herriot Model - SAE
-
-```python
-pip install svy-sae
-```
-
-```python
-import svy_sae as sae
-
-milk = svy.load_dataset(name="milk", limit=None)
-
-milk_model = sae.AreaLevel(milk)
-
-milk_preds = milk_model.fh(
-    y="yi",
-    x=svy.Cat("MajorArea", ref=1),
-    variance="variance",
-    area="SmallArea",
-    method="REML",
-    mse="prasad_rao",
-)
-
-print(milk_preds)
-```
-
-No shortcuts.  
-No hidden assumptions.  
-Just correct survey inference.
+This repository is a monorepo: the Python package lives in [`packages/svy`](packages/svy), the Rust engine in [`packages/svy-rs`](packages/svy-rs), and the I/O library in [`packages/svy-io`](packages/svy-io).
 
 ---
 
-## Ecosystem Packages (Upcoming)
+## Documentation
 
-| Package | Purpose                         | Status      |
-| ------- | ------------------------------- | ----------- |
-| svy     | Core survey design & estimation | In progress |
-| svy-sae | Small Area Estimation           | In progress |
-| svy-io  | SPSS / Stata / SAS I/O          | In progress |
-
-Installation instructions will be added once packages are published.
-
----
-
-## Documentation (Available Now)
-
+Full documentation, tutorials, and methodological notes:
 👉 https://svylab.com/docs
 
-Includes conceptual guides, tutorials, and methodological notes reflecting the intended stable APIs.
-
 ---
 
-## Feedback & Early Engagement
-
-Early feedback is strongly encouraged.
+## Feedback
 
 - Issues: https://github.com/samplics-org/svy/issues
 - Discussions: https://github.com/samplics-org/svy/discussions

--- a/packages/svy/joss/.gitignore
+++ b/packages/svy/joss/.gitignore
@@ -1,0 +1,2 @@
+paper.pdf
+jats/

--- a/packages/svy/joss/paper.bib
+++ b/packages/svy/joss/paper.bib
@@ -1,0 +1,179 @@
+@book{kish1965,
+  author    = {Kish, Leslie},
+  title     = {{Survey Sampling}},
+  publisher = {John Wiley \& Sons},
+  year      = {1965},
+  address   = {New York},
+  isbn      = {978-0-471-10949-5}
+}
+
+@book{lohr2021,
+  author    = {Lohr, Sharon L.},
+  title     = {{Sampling: Design and Analysis}},
+  edition   = {3rd},
+  publisher = {Chapman and Hall/CRC},
+  year      = {2021},
+  address   = {Boca Raton},
+  doi       = {10.1201/9780429298899}
+}
+
+@article{lumley2004,
+  title   = {Analysis of Complex Survey Samples},
+  author  = {Lumley, Thomas},
+  journal = {Journal of Statistical Software},
+  year    = {2004},
+  volume  = {9},
+  number  = {8},
+  pages   = {1--19},
+  doi     = {10.18637/jss.v009.i08}
+}
+
+@book{lumley2010,
+  title     = {Complex Surveys: A Guide to Analysis Using {R}},
+  author    = {Lumley, Thomas},
+  year      = {2010},
+  publisher = {John Wiley \& Sons},
+  address   = {Hoboken}
+}
+
+@article{diallo2021,
+  doi       = {10.21105/joss.03376},
+  year      = {2021},
+  publisher = {The Open Journal},
+  volume    = {6},
+  number    = {68},
+  pages     = {3376},
+  author    = {Diallo, Mamadou S.},
+  title     = {samplics: a {P}ython Package for Selecting, Weighting and Analyzing Data from Complex Sampling Designs},
+  journal   = {Journal of Open Source Software}
+}
+
+@article{diallo2022,
+  author    = {Diallo, Mamadou S.},
+  title     = {Samplics: A Comprehensive Library for Survey Sampling in {P}ython},
+  journal   = {The Survey Statistician},
+  year      = {2022},
+  volume    = {86},
+  pages     = {32--43},
+  publisher = {International Association of Survey Statisticians}
+}
+
+@article{deville1992,
+  author  = {Deville, Jean-Claude and S\"arndal, Carl-Erik},
+  title   = {Calibration Estimators in Survey Sampling},
+  journal = {Journal of the American Statistical Association},
+  year    = {1992},
+  volume  = {87},
+  number  = {418},
+  pages   = {376--382}
+}
+
+@book{sarndal1992,
+  author    = {S\"arndal, Carl-Erik and Swensson, Bengt and Wretman, Jan},
+  title     = {Model Assisted Survey Sampling},
+  publisher = {Springer-Verlag},
+  address   = {New York},
+  year      = {1992}
+}
+
+@book{valliant2018,
+  author    = {Valliant, Richard and Dever, Jill A.},
+  title     = {{Survey Weights: A Step-by-Step Guide to Calculation}},
+  publisher = {Stata Press},
+  year      = {2018},
+  isbn      = {9781597182607}
+}
+
+@book{wolter2007,
+  author    = {Wolter, Kirk M.},
+  title     = {{Introduction to Variance Estimation}},
+  edition   = {2nd},
+  publisher = {Springer},
+  address   = {New York},
+  year      = {2007},
+  isbn      = {9780387350998}
+}
+
+@article{rao1981,
+  title   = {On the Approximation of Distributions of Sample Survey Statistics},
+  author  = {Rao, J. N. K. and Scott, Alastair J.},
+  journal = {The Annals of Statistics},
+  year    = {1981},
+  volume  = {9},
+  number  = {4},
+  pages   = {727--748},
+  doi     = {10.1214/aos/1176345514}
+}
+
+@article{rao1984,
+  title   = {On Chi-Squared Tests for Multiway Contingency Tables with Cell Proportions Estimated from Survey Data},
+  author  = {Rao, J. N. K. and Scott, Alastair J.},
+  journal = {The Annals of Statistics},
+  year    = {1984},
+  volume  = {12},
+  number  = {1},
+  pages   = {46--60},
+  doi     = {10.1214/aos/1176346391}
+}
+
+@article{binder1983,
+  author  = {Binder, David A.},
+  title   = {On the Variances of Asymptotically Normal Estimators from Complex Surveys},
+  journal = {International Statistical Review},
+  year    = {1983},
+  volume  = {51},
+  number  = {3},
+  pages   = {279--292}
+}
+
+@article{harris2020,
+  author  = {Harris, Charles R. and Millman, K. Jarrod and van der Walt, St\'efan J. and Gommers, Ralf and Virtanen, Pauli and Cournapeau, David and Wieser, Eric and Taylor, Julian and Berg, Sebastian and Smith, Nathaniel J. and Kern, Robert and Picus, Matti and Hoyer, Stephan and van Kerkwijk, Marten H. and Brett, Matthew and Haldane, Allan and del R\'io, Jaime Fern\'andez and Wiebe, Mark and Peterson, Pearu and G\'erard-Marchant, Pierre and Sheppard, Kevin and Reddy, Tyler and Weckesser, Warren and Abbasi, Hameer and Gohlke, Christoph and Oliphant, Travis E.},
+  title   = {Array Programming with {NumPy}},
+  journal = {Nature},
+  year    = {2020},
+  volume  = {585},
+  pages   = {357--362},
+  doi     = {10.1038/s41586-020-2649-2}
+}
+
+@article{virtanen2020,
+  author  = {Virtanen, Pauli and Gommers, Ralf and Oliphant, Travis E. and Haberland, Matt and Reddy, Tyler and Cournapeau, David and Burovski, Evgeni and Peterson, Pearu and Weckesser, Warren and Bright, Jonathan and van der Walt, St\'efan J. and Brett, Matthew and Wilson, Joshua and Millman, K. Jarrod and Mayorov, Nikolay and Nelson, Andrew R. J. and Jones, Eric and Kern, Robert and Larson, Eric and Carey, C. J. and Polat, {\.I}lhan and Feng, Yu and Moore, Eric W. and VanderPlas, Jake and Laxalde, Denis and Perktold, Josef and Cimrman, Robert and Henriksen, Ian and Quintero, E. A. and Harris, Charles R. and Archibald, Anne M. and Ribeiro, Ant\^onio H. and Pedregosa, Fabian and van Mulbregt, Paul},
+  title   = {{SciPy} 1.0: Fundamental Algorithms for Scientific Computing in {Python}},
+  journal = {Nature Methods},
+  year    = {2020},
+  volume  = {17},
+  pages   = {261--272},
+  doi     = {10.1038/s41592-020-0772-5}
+}
+
+@misc{polars2025,
+  author = {{Polars contributors}},
+  title  = {{Polars}: A Fast Multi-Threaded, Hybrid-Out-of-Core {DataFrame} Library},
+  year   = {2025},
+  url    = {https://pola.rs},
+  note   = {Version 1.x}
+}
+
+@misc{worldbank2023-cen,
+  doi       = {10.48529/78M1-AE09},
+  author    = {{World Bank}},
+  title     = {Synthetic Data for an Imaginary Country, Full Population, 2023},
+  publisher = {World Bank, Development Data Group},
+  year      = {2023}
+}
+
+@misc{worldbank2023-svy,
+  doi       = {10.48529/MC1F-QH23},
+  author    = {{World Bank}},
+  title     = {Synthetic Data for an Imaginary Country, Sample, 2023},
+  publisher = {World Bank, Development Data Group},
+  year      = {2023}
+}
+
+@inproceedings{solatorio2023,
+  author    = {Solatorio, Aivin V. and Dupriez, Olivier},
+  title     = {{REaLTabFormer}: Generating Realistic Relational and Tabular Data Using Transformers},
+  booktitle = {Proceedings of the 2023 AAAI Workshop on AI for Social Good},
+  year      = {2023},
+  url       = {https://arxiv.org/abs/2302.02041}
+}

--- a/packages/svy/joss/paper.md
+++ b/packages/svy/joss/paper.md
@@ -1,0 +1,141 @@
+---
+title: "svy: A Python package for end-to-end design and analysis of complex survey data"
+tags:
+  - Python
+  - survey sampling
+  - complex surveys
+  - design-based inference
+  - official statistics
+  - sampling weights
+  - calibration
+  - variance estimation
+  - Rust
+authors:
+  - name: Mamadou S. Diallo
+    orcid: 0000-0002-0376-3631
+    corresponding: true
+    affiliation: 1
+affiliations:
+  - name: Samplics, United States
+    index: 1
+date: 22 July 2026
+bibliography: paper.bib
+---
+
+# Summary
+
+Probability-based surveys are one of the main tools used by governments, international organizations, and researchers to produce statistics that guide decision-making. For example, national household surveys inform policy on poverty, health, education, and employment for hundreds of millions of people each year. Similarly, opinion polling and market research surveys inform corporations, media, and other organizations on populations' views and preferences, and social science researchers rely on complex samples to study behaviors and living conditions. To be efficient and operationally feasible, these surveys rely on stratification, multi-stage cluster sampling, unequal probabilities of selection, and post-collection weight adjustments. As a result, standard statistical methods, which assume independent and identically distributed observations, produce incorrect variance estimates and invalid confidence intervals when applied directly to survey data [@kish1965; @lohr2021]. Design-based inference, which uses the known sampling mechanism, is the standard framework for analyzing such data.
+
+`svy` is an open-source Python package for the design and analysis of complex survey samples. It covers the full survey workflow: sample size calculation, sample selection (simple random, systematic, and probability proportional to size methods, including multi-stage designs), weight adjustment (nonresponse adjustment, poststratification, GREG calibration, raking, and trimming), estimation of means, totals, proportions, ratios, and medians with Taylor linearization or replication-based variance (BRR, Fay-BRR, jackknife, bootstrap, and SDR), design-adjusted categorical analysis (tabulation, t-tests, rank tests, and Rao-Scott tests), and generalized linear models with design-adjusted standard errors. The package is built on Polars [@polars2025], NumPy [@harris2020], and SciPy [@virtanen2020], and its performance-critical routines are implemented in Rust.
+
+`svy` is the successor of `samplics` [@diallo2021; @diallo2022], an earlier Python package for complex survey analysis by the same author. `samplics` has been retired, and `svy`, a ground-up redesign informed by several years of `samplics` usage, is its replacement and the recommended migration target.
+
+# Statement of need
+
+Software support for design-based inference is mature in several environments: the `survey` package for R [@lumley2004; @lumley2010], the survey procedures in SAS, the `svy` prefix in Stata, the SPSS Complex Samples module, and specialized tools such as SUDAAN. However, Python, despite being a leading language for data science and increasingly the primary language of analysts at national statistical offices, public health programs, and research organizations, has lacked a comprehensive and production-oriented equivalent. In practice, analysts working in Python had to move their data to R or Stata for design-based inference, or apply weighted but design-naive methods that understate uncertainty.
+
+`samplics` [@diallo2021] was the first Python package to offer a broad set of design-based methods, and it demonstrated the demand for survey methodology tools in the Python ecosystem. Experience with `samplics` in production settings also revealed structural limitations that could not be addressed incrementally. For example, design information had to be passed manually to each function, weight adjustments were disconnected from the replicate weights, and performance was a constraint on large surveys. `svy` is a ground-up redesign built around five goals:
+
+1. Coverage of the full survey lifecycle. A single coherent API spans planning (sample size calculation for estimation and comparison objectives), selection (including multi-stage designs where inclusion probabilities are chained across stages automatically), weighting, estimation, testing, and modeling.
+
+2. Correctness by construction. The central `Sample` object binds the data to a `Design` object (strata, sampling units, weights, and replicate weights) once, validates the combination, and is immutable; every transformation returns a new `Sample` with the design metadata propagated automatically. Furthermore, subpopulation analysis via the `where` argument retains the full design structure for variance estimation, matching the behavior of `subset()` on a survey design object in R. This matters because filtering the rows before analysis, a common practice, generally understates the standard errors.
+
+3. Replicate-weight fidelity. When replicate weights are created from the design weights, every subsequent adjustment (nonresponse, poststratification, calibration, raking, and trimming) is applied to the replicate weights in the same pass as the full-sample weights. Hence, replication-based standard errors reflect the variability of the entire weighting process, not just sampling variability, without additional effort from the analyst [@valliant2018; @wolter2007].
+
+4. Performance. Variance estimation and other computational bottlenecks are implemented in Rust and distributed as the companion wheel `svy-rs`, while data operations use Polars. A full pipeline consisting of selection, weighting with 500 bootstrap replicates, and estimation runs in under a quarter of a second on a standard laptop. This makes the package practical for national-scale surveys and for simulation studies.
+
+5. Reproducibility and automation. An `svy` analysis is expressed entirely in code: data transformations are performed through the built-in `wrangling` namespace rather than ad hoc outside the package, random operations accept explicit seeds, and the `Sample` object manages its metadata internally, i.e., the design roles, variable and category labels, and the full weight history travel with the data instead of living in external documentation. Every analytical method returns a typed result object (e.g., `Estimate`, `Table`, `TTest`, and the GLM fit objects), and the `serialize` module converts these results to stable, versioned, machine-readable structures. Hence, `svy` pipelines can be rerun, audited, and integrated into automated production systems, and the typed, validated interfaces provide a reliable contract for emerging AI-assisted workflows, where generated analysis code must be checked and reproduced rather than trusted.
+
+The primary target audiences are survey statisticians, national statistical offices, public health and development programs, opinion polling and market research organizations, and social science researchers and data scientists working with complex samples from large survey programs such as ACS and NHANES in the United States, EU-SILC in Europe, and DHS and LSMS internationally.
+
+# State of the field
+
+The `survey` package for R [@lumley2004] is the reference open-source implementation of design-based inference, and it served as the primary benchmark for `svy`. Across design specification, Taylor linearization, replication methods, calibration, categorical analysis, and generalized linear models, `svy` and `survey` produce numerically identical results to at least six significant digits. The few intentional differences are documented and align with the conventions used in Stata. The full side-by-side comparison, with reproducible R and Python code, is available at <https://svylab.com/learn/notes/posts/svy-vs-r-comparison/>.
+
+Within Python, `samplics` [@diallo2021; @diallo2022] was previously the most comprehensive option; it is now retired in favor of `svy`. Other Python tools address individual pieces of the workflow, e.g., weighting adjustments or weighted descriptive statistics, but not design-based variance estimation across the full analysis lifecycle. Relative to the R `survey` package itself, `svy` also integrates the pre-collection stages (sample size calculation and multi-stage sample selection) into the same object model used for analysis. Hence, a survey can be planned, drawn, weighted, and analyzed without leaving the package.
+
+The statistical methodology follows the established literature: calibration and model-assisted estimation [@deville1992; @sarndal1992], replication variance estimation [@wolter2007], Rao-Scott corrections for categorical tests [@rao1981; @rao1984], and design-adjusted GLMs via linearization of the estimating equations [@binder1983].
+
+# Software design
+
+`svy` exposes two primary objects. `Design` is a lightweight, frozen descriptor that maps dataset columns to their roles in the sampling design, i.e., strata, primary and secondary sampling units, weights, selection probabilities, measures of size, and the replicate weight configuration. `Sample` binds a Polars `DataFrame` to a `Design`, validates the combination at construction, and organizes the functionality into focused namespaces: `sampling` for selection, `weighting`, `estimation`, `categorical`, `glm`, and `wrangling` for design-aware data transformations. The `wrangling` methods keep the design, weights, and replicate weights synchronized; for example, when a design column is renamed, the `Design` object is updated automatically.
+
+Both objects are immutable, so analytical pipelines are auditable and reproducible by construction. Each weighting step adds a named weight column and preserves the full weight history, and there is no risk of silently overwriting the design or losing track of the active weights. Every estimation call returns a typed result object that renders as a formatted table and can be exported to a Polars `DataFrame`.
+
+The following example gives a taste of the API. It loads one of the bundled datasets, binds the data to its sampling design, creates a literacy indicator and a simulated response status, adjusts the weights for nonresponse, trims extreme weights, and estimates the adult literacy rate by urban and rural areas with design-based standard errors. Each step returns a new `Sample` object, hence the chained style:
+
+```python
+import svy
+import numpy as np
+
+rng = np.random.default_rng(147)
+
+# A bundled example survey (runs offline)
+data = svy.datasets.load("ind_sample_wb_2023", source="bundled")
+info = svy.datasets.describe("ind_sample_wb_2023", source="bundled")
+
+# Bind the data to its sampling design
+sample = svy.Sample(data, svy.Design(**info.design))
+
+literacy_rate = (
+    sample
+    # 1. Wrangle: a 1/0 literacy indicator, plus a response status
+    .wrangling.mutate({
+        "literate": svy.when(svy.col("literacy") == "Yes").then(1)
+                       .when(svy.col("literacy") == "No").then(0)
+                       .otherwise(None),
+        # simulated for illustration; the example data has 100% response
+        "resp_status": rng.choice(
+            ["respondent", "non-respondent"], p=[0.85, 0.15],
+            size=sample.n_records,
+        ),
+    })
+    # 2. Adjust the weights for nonresponse, within urban/rural classes
+    .weighting.adjust(
+        resp_status="resp_status",
+        by="urbrur",
+        resp_mapping={"rr": "respondent", "nr": "non-respondent"},
+        wgt_name="nr_wgt",
+    )
+    # 3. Trim extreme weights to reduce variance
+    .weighting.trim(upper=3.0)
+    # 4. Adult (15+) literacy rate by area, with design-based SEs
+    .estimation.mean(
+        "literate",
+        by="urbrur",
+        where=svy.col("age") >= 15,
+        drop_nulls=True,
+    )
+)
+
+print(literacy_rate)
+```
+
+```
+Estimate: MEAN (TAYLOR)
+where: age >= 15
+
+urbrur      est       se      lci      uci   cv (%)
+Rural    0.7516   0.0466   0.6558   0.8474     6.20
+Urban    0.9183   0.0188   0.8797   0.9570     2.05
+```
+
+The result reports, for each domain, the point estimate, its standard error, the 95% confidence interval, and the coefficient of variation, all computed under the survey design that was declared once at the start of the pipeline. The `by` argument produces domain estimates with standard errors that follow the sample domain estimation theory, and the `where` argument restricts the estimation to a subpopulation while keeping the full sample for variance estimation, rather than filtering the rows.
+
+The package is distributed on PyPI (`pip install svy`) under the MIT license, with the Rust engine `svy-rs` shipped as a separate wheel. `svy` is also the core of a growing ecosystem of survey packages that share its design conventions: `svy-io` reads and writes SPSS, Stata, and SAS files, and `svy-sae` provides small area estimation. Additional extensions are under development. For documentation and teaching, `svy` bundles an offline-complete synthetic country derived from the World Bank synthetic census and survey data [@worldbank2023-cen; @worldbank2023-svy; @solatorio2023]. Hence, every example in the documentation is reproducible without network access.
+
+# Research impact statement
+
+`svy` inherits and extends the user base of `samplics`, which has been used since 2020 in applied survey work and research across public health, official statistics, and international development settings. `samplics` has been downloaded more than 278,000 times from PyPI, including an estimated 33,000 direct user installs after excluding known mirrors and continuous integration systems, and its usage has kept growing through 2026. `svy` was first released on PyPI in July 2025 and has been downloaded nearly 50,000 times in its first thirteen months, with direct user installs increasing month over month and exceeding 1,500 in July 2026 alone. With the retirement of `samplics`, `svy` is the maintained, comprehensive package for design-based survey inference in Python. The published numerical validation against the R `survey` package provides the correctness evidence that organizations require before adopting a new tool for the production of official statistics. The ambition, first stated for `samplics` [@diallo2022], remains the same: a robust, comprehensive, and easy to use Python ecosystem for survey sampling and the production of official statistics, with `svy` at its core. Documentation, tutorials, and methodological notes are maintained at <https://svylab.com/docs/svy>.
+
+# AI usage disclosure
+
+`samplics` was developed before the mainstream use of generative AI for software development, and none of its code was written by AI. The development of `svy` began by porting the `samplics` implementation to the new API design described in this paper: the author fully designed the software and used the `samplics` code base to build an initial working prototype of `svy`. At that point, generative AI tools were introduced to polish the code, fix bugs, and improve performance, and they played a critical role in the development of the Rust engine `svy-rs`. All AI-assisted code was reviewed and tested by the author, and the numerical validation against the R `survey` package applies to the final code regardless of how it was produced.
+
+This manuscript was prepared with the assistance of Claude Fable 5 (Anthropic), drawing on the author's previously written manuscripts and documentation, and was revised and finalized through several rounds of review and editing by the author.
+
+# Acknowledgements
+
+The author thanks the World Bank Development Data Group for making the synthetic household survey data publicly available, and Thomas Lumley, whose `survey` package for R has set the standard for design-based inference in statistical software and served as the reference implementation for validating `svy`. The author is also grateful to the users of `samplics` and `svy` who reported issues, suggested features, and contributed in many ways to the development of both packages over the years.
+
+# References


### PR DESCRIPTION
## Summary

- Add the JOSS paper (`packages/svy/joss/paper.md` + `paper.bib`) for the submission of svy to the Journal of Open Source Software. The paper compiles cleanly with the official `openjournals/inara` container; the generated PDF is gitignored.
- Rewrite the root README to reflect the released state of the packages: the pre-release "not yet publicly downloadable" notice, the illustrative (non-runnable) example, and the "Upcoming" ecosystem table are replaced with the current installation instructions, a runnable quick start, the released capabilities, and the monorepo layout.

## Notes

- The JOSS editorial bot discovers `paper.md` by cloning `main`, so this needs to be merged for the review to proceed.