### PR TITLE
chore(ci): reduce dependabot PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,64 +1,99 @@
 # Dependabot configuration.
 # Keeps Python (uv), Rust (cargo), and GitHub Actions dependencies patched and
-# opens security PRs for all ecosystems. Updates are grouped to reduce PR noise.
+# opens security PRs for all ecosystems (security updates ignore the schedule
+# and are raised immediately).
+#
+# Noise controls:
+# - monthly cadence for routine version updates
+# - majors are grouped into one PR per ecosystem, minors/patches into another
+# - cooldown lets new releases bake before a PR is opened
+# - Python updates are lockfile-only so pyproject.toml ranges stay wide
 version: 2
 updates:
   # --- Python workspace (root uv.lock) ---
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    versioning-strategy: "lockfile-only"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     groups:
       python-minor-patch:
         update-types:
           - "minor"
           - "patch"
+      python-major:
+        update-types:
+          - "major"
 
   # --- Rust: svy-rs extension ---
   - package-ecosystem: "cargo"
     directory: "/packages/svy-rs"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     groups:
       cargo-minor-patch:
         update-types:
           - "minor"
           - "patch"
+      cargo-major:
+        update-types:
+          - "major"
 
   # --- Rust: svy-io ReadStat binding ---
   - package-ecosystem: "cargo"
     directory: "/packages/svy-io/native/svyreadstat_rs"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     groups:
       cargo-minor-patch:
         update-types:
           - "minor"
           - "patch"
+      cargo-major:
+        update-types:
+          - "major"
 
   # --- Rust: svy-io ReadStat -sys crate ---
   - package-ecosystem: "cargo"
     directory: "/packages/svy-io/native/readstat-sys"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
     groups:
       cargo-minor-patch:
         update-types:
           - "minor"
           - "patch"
+      cargo-major:
+        update-types:
+          - "major"
 
   # --- GitHub Actions (workflows pin actions by SHA) ---
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-    open-pull-requests-limit: 10
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 14
     groups:
       actions:
         update-types:
+          - "major"
           - "minor"
           - "patch"


### PR DESCRIPTION
## Summary

Tunes the Dependabot configuration to cut down the volume of routine version-bump PRs:

- **Monthly cadence** instead of weekly for version updates. Security PRs are unaffected: they ignore the schedule and are raised immediately.
- **Majors are now grouped** into one PR per ecosystem (`cargo-major`, `python-major`); previously every major bump opened its own PR, which is where most of the noise came from. Actions updates are consolidated into a single grouped PR including majors.
- **Cooldown** (7 days default, 30 days for majors, 14 for actions) so fresh releases bake before a PR opens.
- **`versioning-strategy: lockfile-only` for Python**, so updates bump `uv.lock` without narrowing the `pyproject.toml` requirement ranges (e.g. #50/#51 rewrote library install ranges, which we do not want).
- **PR cap lowered** from 10 to 5 per ecosystem.

## Note on existing open PRs

Existing Dependabot PRs are not auto-closed by a config change. The open ones are all non-security; they can be closed and the next monthly run will re-raise anything still relevant in grouped form.