### PR TITLE
docs(readme): revamp root README

### DIFF
--- a/.github/assets/readme_estimate.svg
+++ b/.github/assets/readme_estimate.svg
@@ -1,0 +1,85 @@
+<svg class="rich-terminal" viewBox="0 0 628 220.79999999999998" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-1041376987-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-1041376987-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-1041376987-r1 { fill: #68a0b3 }
+.terminal-1041376987-r2 { fill: #68a0b3;font-weight: bold }
+.terminal-1041376987-r3 { fill: #c5c8c6 }
+.terminal-1041376987-r4 { fill: #c5c8c6;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-1041376987-clip-terminal">
+      <rect x="0" y="0" width="609.0" height="169.79999999999998" />
+    </clipPath>
+    <clipPath id="terminal-1041376987-line-0">
+    <rect x="0" y="1.5" width="610" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1041376987-line-1">
+    <rect x="0" y="25.9" width="610" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1041376987-line-2">
+    <rect x="0" y="50.3" width="610" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1041376987-line-3">
+    <rect x="0" y="74.7" width="610" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1041376987-line-4">
+    <rect x="0" y="99.1" width="610" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-1041376987-line-5">
+    <rect x="0" y="123.5" width="610" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="626" height="218.8" rx="8"/><text class="terminal-1041376987-title" fill="#c5c8c6" text-anchor="middle" x="313" y="27">svy</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-1041376987-clip-terminal)">
+    
+    <g class="terminal-1041376987-matrix">
+    <text class="terminal-1041376987-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-1041376987-line-0)">╭─</text><text class="terminal-1041376987-r1" x="24.4" y="20" textLength="109.8" clip-path="url(#terminal-1041376987-line-0)">─────────</text><text class="terminal-1041376987-r1" x="134.2" y="20" textLength="134.2" clip-path="url(#terminal-1041376987-line-0)">&#160;Estimate:&#160;</text><text class="terminal-1041376987-r2" x="268.4" y="20" textLength="48.8" clip-path="url(#terminal-1041376987-line-0)">MEAN</text><text class="terminal-1041376987-r1" x="317.2" y="20" textLength="122" clip-path="url(#terminal-1041376987-line-0)">&#160;(TAYLOR)&#160;</text><text class="terminal-1041376987-r1" x="439.2" y="20" textLength="122" clip-path="url(#terminal-1041376987-line-0)">──────────</text><text class="terminal-1041376987-r1" x="561.2" y="20" textLength="24.4" clip-path="url(#terminal-1041376987-line-0)">─╮</text><text class="terminal-1041376987-r3" x="610" y="20" textLength="12.2" clip-path="url(#terminal-1041376987-line-0)">
+</text><text class="terminal-1041376987-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-1041376987-line-1)">│</text><text class="terminal-1041376987-r1" x="573.4" y="44.4" textLength="12.2" clip-path="url(#terminal-1041376987-line-1)">│</text><text class="terminal-1041376987-r3" x="610" y="44.4" textLength="12.2" clip-path="url(#terminal-1041376987-line-1)">
+</text><text class="terminal-1041376987-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-1041376987-line-2)">│</text><text class="terminal-1041376987-r4" x="36.6" y="68.8" textLength="73.2" clip-path="url(#terminal-1041376987-line-2)">&#160;&#160;&#160;est</text><text class="terminal-1041376987-r4" x="146.4" y="68.8" textLength="73.2" clip-path="url(#terminal-1041376987-line-2)">&#160;&#160;&#160;&#160;se</text><text class="terminal-1041376987-r4" x="256.2" y="68.8" textLength="73.2" clip-path="url(#terminal-1041376987-line-2)">&#160;&#160;&#160;lci</text><text class="terminal-1041376987-r4" x="366" y="68.8" textLength="73.2" clip-path="url(#terminal-1041376987-line-2)">&#160;&#160;&#160;uci</text><text class="terminal-1041376987-r4" x="475.8" y="68.8" textLength="73.2" clip-path="url(#terminal-1041376987-line-2)">cv&#160;(%)</text><text class="terminal-1041376987-r1" x="573.4" y="68.8" textLength="12.2" clip-path="url(#terminal-1041376987-line-2)">│</text><text class="terminal-1041376987-r3" x="610" y="68.8" textLength="12.2" clip-path="url(#terminal-1041376987-line-2)">
+</text><text class="terminal-1041376987-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-1041376987-line-3)">│</text><text class="terminal-1041376987-r3" x="24.4" y="93.2" textLength="536.8" clip-path="url(#terminal-1041376987-line-3)">&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;</text><text class="terminal-1041376987-r1" x="573.4" y="93.2" textLength="12.2" clip-path="url(#terminal-1041376987-line-3)">│</text><text class="terminal-1041376987-r3" x="610" y="93.2" textLength="12.2" clip-path="url(#terminal-1041376987-line-3)">
+</text><text class="terminal-1041376987-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-1041376987-line-4)">│</text><text class="terminal-1041376987-r3" x="36.6" y="117.6" textLength="73.2" clip-path="url(#terminal-1041376987-line-4)">0.8231</text><text class="terminal-1041376987-r3" x="146.4" y="117.6" textLength="73.2" clip-path="url(#terminal-1041376987-line-4)">0.0212</text><text class="terminal-1041376987-r3" x="256.2" y="117.6" textLength="73.2" clip-path="url(#terminal-1041376987-line-4)">0.7796</text><text class="terminal-1041376987-r3" x="366" y="117.6" textLength="73.2" clip-path="url(#terminal-1041376987-line-4)">0.8667</text><text class="terminal-1041376987-r3" x="475.8" y="117.6" textLength="73.2" clip-path="url(#terminal-1041376987-line-4)">&#160;&#160;2.57</text><text class="terminal-1041376987-r1" x="573.4" y="117.6" textLength="12.2" clip-path="url(#terminal-1041376987-line-4)">│</text><text class="terminal-1041376987-r3" x="610" y="117.6" textLength="12.2" clip-path="url(#terminal-1041376987-line-4)">
+</text><text class="terminal-1041376987-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-1041376987-line-5)">│</text><text class="terminal-1041376987-r1" x="573.4" y="142" textLength="12.2" clip-path="url(#terminal-1041376987-line-5)">│</text><text class="terminal-1041376987-r3" x="610" y="142" textLength="12.2" clip-path="url(#terminal-1041376987-line-5)">
+</text><text class="terminal-1041376987-r1" x="0" y="166.4" textLength="585.6" clip-path="url(#terminal-1041376987-line-6)">╰──────────────────────────────────────────────╯</text><text class="terminal-1041376987-r3" x="610" y="166.4" textLength="12.2" clip-path="url(#terminal-1041376987-line-6)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/.github/assets/readme_glm.svg
+++ b/.github/assets/readme_glm.svg
@@ -1,0 +1,130 @@
+<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+    <!-- Generated with Rich https://www.textualize.io -->
+    <style>
+
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Regular"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Regular.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Regular.woff") format("woff");
+        font-style: normal;
+        font-weight: 400;
+    }
+    @font-face {
+        font-family: "Fira Code";
+        src: local("FiraCode-Bold"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff2/FiraCode-Bold.woff2") format("woff2"),
+                url("https://cdnjs.cloudflare.com/ajax/libs/firacode/6.2.0/woff/FiraCode-Bold.woff") format("woff");
+        font-style: bold;
+        font-weight: 700;
+    }
+
+    .terminal-432364856-matrix {
+        font-family: Fira Code, monospace;
+        font-size: 20px;
+        line-height: 24.4px;
+        font-variant-east-asian: full-width;
+    }
+
+    .terminal-432364856-title {
+        font-size: 18px;
+        font-weight: bold;
+        font-family: arial;
+    }
+
+    .terminal-432364856-r1 { fill: #68a0b3 }
+.terminal-432364856-r2 { fill: #c5c8c6 }
+.terminal-432364856-r3 { fill: #868887 }
+.terminal-432364856-r4 { fill: #c5c8c6;font-weight: bold }
+.terminal-432364856-r5 { fill: #cc555a;font-weight: bold }
+    </style>
+
+    <defs>
+    <clipPath id="terminal-432364856-clip-terminal">
+      <rect x="0" y="0" width="975.0" height="438.2" />
+    </clipPath>
+    <clipPath id="terminal-432364856-line-0">
+    <rect x="0" y="1.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-1">
+    <rect x="0" y="25.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-2">
+    <rect x="0" y="50.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-3">
+    <rect x="0" y="74.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-4">
+    <rect x="0" y="99.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-5">
+    <rect x="0" y="123.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-6">
+    <rect x="0" y="147.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-7">
+    <rect x="0" y="172.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-8">
+    <rect x="0" y="196.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-9">
+    <rect x="0" y="221.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-10">
+    <rect x="0" y="245.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-11">
+    <rect x="0" y="269.9" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-12">
+    <rect x="0" y="294.3" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-13">
+    <rect x="0" y="318.7" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-14">
+    <rect x="0" y="343.1" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-15">
+    <rect x="0" y="367.5" width="976" height="24.65"/>
+            </clipPath>
+<clipPath id="terminal-432364856-line-16">
+    <rect x="0" y="391.9" width="976" height="24.65"/>
+            </clipPath>
+    </defs>
+
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-432364856-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">svy</text>
+            <g transform="translate(26,22)">
+            <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
+            <circle cx="22" cy="0" r="7" fill="#febc2e"/>
+            <circle cx="44" cy="0" r="7" fill="#28c840"/>
+            </g>
+        
+    <g transform="translate(9, 41)" clip-path="url(#terminal-432364856-clip-terminal)">
+    
+    <g class="terminal-432364856-matrix">
+    <text class="terminal-432364856-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-432364856-line-0)">╭─</text><text class="terminal-432364856-r1" x="24.4" y="20" textLength="292.8" clip-path="url(#terminal-432364856-line-0)">────────────────────────</text><text class="terminal-432364856-r1" x="317.2" y="20" textLength="317.2" clip-path="url(#terminal-432364856-line-0)">&#160;GLM:&#160;Gaussian&#160;(identity)&#160;</text><text class="terminal-432364856-r1" x="634.4" y="20" textLength="292.8" clip-path="url(#terminal-432364856-line-0)">────────────────────────</text><text class="terminal-432364856-r1" x="927.2" y="20" textLength="24.4" clip-path="url(#terminal-432364856-line-0)">─╮</text><text class="terminal-432364856-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-432364856-line-0)">
+</text><text class="terminal-432364856-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">│</text><text class="terminal-432364856-r3" x="24.4" y="44.4" textLength="244" clip-path="url(#terminal-432364856-line-1)">Modeling:&#160;yrs_school</text><text class="terminal-432364856-r1" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">│</text><text class="terminal-432364856-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">
+</text><text class="terminal-432364856-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">│</text><text class="terminal-432364856-r1" x="939.4" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">│</text><text class="terminal-432364856-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">
+</text><text class="terminal-432364856-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">│</text><text class="terminal-432364856-r4" x="24.4" y="93.2" textLength="146.4" clip-path="url(#terminal-432364856-line-3)">Observations</text><text class="terminal-432364856-r2" x="195.2" y="93.2" textLength="122" clip-path="url(#terminal-432364856-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;2900</text><text class="terminal-432364856-r4" x="341.6" y="93.2" textLength="146.4" clip-path="url(#terminal-432364856-line-3)">AIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="93.2" textLength="122" clip-path="url(#terminal-432364856-line-3)">75030.4420</text><text class="terminal-432364856-r1" x="939.4" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">│</text><text class="terminal-432364856-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">
+</text><text class="terminal-432364856-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">│</text><text class="terminal-432364856-r4" x="24.4" y="117.6" textLength="146.4" clip-path="url(#terminal-432364856-line-4)">DF&#160;Residuals</text><text class="terminal-432364856-r2" x="195.2" y="117.6" textLength="122" clip-path="url(#terminal-432364856-line-4)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;24</text><text class="terminal-432364856-r4" x="341.6" y="117.6" textLength="146.4" clip-path="url(#terminal-432364856-line-4)">BIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="117.6" textLength="122" clip-path="url(#terminal-432364856-line-4)">75048.3594</text><text class="terminal-432364856-r1" x="939.4" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">│</text><text class="terminal-432364856-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">
+</text><text class="terminal-432364856-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">│</text><text class="terminal-432364856-r4" x="24.4" y="142" textLength="146.4" clip-path="url(#terminal-432364856-line-5)">Deviance&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="195.2" y="142" textLength="122" clip-path="url(#terminal-432364856-line-5)">75024.4420</text><text class="terminal-432364856-r4" x="341.6" y="142" textLength="146.4" clip-path="url(#terminal-432364856-line-5)">Scale&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="142" textLength="122" clip-path="url(#terminal-432364856-line-5)">&#160;2885.5555</text><text class="terminal-432364856-r1" x="939.4" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">│</text><text class="terminal-432364856-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">
+</text><text class="terminal-432364856-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">│</text><text class="terminal-432364856-r4" x="24.4" y="166.4" textLength="146.4" clip-path="url(#terminal-432364856-line-6)">R-squared&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="195.2" y="166.4" textLength="122" clip-path="url(#terminal-432364856-line-6)">&#160;&#160;&#160;0.00407</text><text class="terminal-432364856-r4" x="341.6" y="166.4" textLength="146.4" clip-path="url(#terminal-432364856-line-6)">R-sq&#160;(adj)&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="166.4" textLength="122" clip-path="url(#terminal-432364856-line-6)">&#160;&#160;&#160;0.00338</text><text class="terminal-432364856-r1" x="939.4" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">│</text><text class="terminal-432364856-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">
+</text><text class="terminal-432364856-r1" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">│</text><text class="terminal-432364856-r4" x="341.6" y="190.8" textLength="146.4" clip-path="url(#terminal-432364856-line-7)">Iterations&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="190.8" textLength="122" clip-path="url(#terminal-432364856-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;2</text><text class="terminal-432364856-r1" x="939.4" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">│</text><text class="terminal-432364856-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">
+</text><text class="terminal-432364856-r1" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">│</text><text class="terminal-432364856-r4" x="24.4" y="215.2" textLength="146.4" clip-path="url(#terminal-432364856-line-8)">F-stat&#160;(adj)</text><text class="terminal-432364856-r2" x="195.2" y="215.2" textLength="122" clip-path="url(#terminal-432364856-line-8)">&#160;&#160;&#160;4.97738</text><text class="terminal-432364856-r4" x="341.6" y="215.2" textLength="146.4" clip-path="url(#terminal-432364856-line-8)">Prob&#160;(F-adj)</text><text class="terminal-432364856-r2" x="512.4" y="215.2" textLength="122" clip-path="url(#terminal-432364856-line-8)">&#160;&#160;&#160;&#160;0.0160</text><text class="terminal-432364856-r1" x="939.4" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">│</text><text class="terminal-432364856-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">
+</text><text class="terminal-432364856-r1" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">│</text><text class="terminal-432364856-r1" x="939.4" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">│</text><text class="terminal-432364856-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">
+</text><text class="terminal-432364856-r1" x="0" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">│</text><text class="terminal-432364856-r1" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">│</text><text class="terminal-432364856-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">
+</text><text class="terminal-432364856-r1" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">│</text><text class="terminal-432364856-r4" x="36.6" y="288.4" textLength="134.2" clip-path="url(#terminal-432364856-line-11)">Term&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r4" x="207.4" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;Coef.</text><text class="terminal-432364856-r4" x="329.4" y="288.4" textLength="97.6" clip-path="url(#terminal-432364856-line-11)">Std.Err.</text><text class="terminal-432364856-r4" x="463.6" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;t</text><text class="terminal-432364856-r4" x="585.6" y="288.4" textLength="73.2" clip-path="url(#terminal-432364856-line-11)">&#160;P&gt;|t|</text><text class="terminal-432364856-r4" x="695.4" y="288.4" textLength="97.6" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;[0.025</text><text class="terminal-432364856-r4" x="829.6" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;0.975]</text><text class="terminal-432364856-r1" x="939.4" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">│</text><text class="terminal-432364856-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">
+</text><text class="terminal-432364856-r1" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">│</text><text class="terminal-432364856-r2" x="24.4" y="312.8" textLength="902.8" clip-path="url(#terminal-432364856-line-12)">&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;</text><text class="terminal-432364856-r1" x="939.4" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">│</text><text class="terminal-432364856-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">
+</text><text class="terminal-432364856-r1" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">│</text><text class="terminal-432364856-r2" x="36.6" y="337.2" textLength="134.2" clip-path="url(#terminal-432364856-line-13)">_intercept_</text><text class="terminal-432364856-r2" x="207.4" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">4.22276</text><text class="terminal-432364856-r2" x="329.4" y="337.2" textLength="97.6" clip-path="url(#terminal-432364856-line-13)">&#160;0.45871</text><text class="terminal-432364856-r2" x="463.6" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">9.20566</text><text class="terminal-432364856-r5" x="585.6" y="337.2" textLength="73.2" clip-path="url(#terminal-432364856-line-13)">&lt;0.001</text><text class="terminal-432364856-r2" x="695.4" y="337.2" textLength="97.6" clip-path="url(#terminal-432364856-line-13)">&#160;3.27602</text><text class="terminal-432364856-r2" x="829.6" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">5.16950</text><text class="terminal-432364856-r1" x="939.4" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">│</text><text class="terminal-432364856-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">
+</text><text class="terminal-432364856-r1" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">│</text><text class="terminal-432364856-r2" x="36.6" y="361.6" textLength="134.2" clip-path="url(#terminal-432364856-line-14)">age&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="207.4" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.01023</text><text class="terminal-432364856-r2" x="329.4" y="361.6" textLength="97.6" clip-path="url(#terminal-432364856-line-14)">&#160;0.01129</text><text class="terminal-432364856-r2" x="463.6" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.90674</text><text class="terminal-432364856-r2" x="585.6" y="361.6" textLength="73.2" clip-path="url(#terminal-432364856-line-14)">0.3736</text><text class="terminal-432364856-r2" x="695.4" y="361.6" textLength="97.6" clip-path="url(#terminal-432364856-line-14)">-0.01306</text><text class="terminal-432364856-r2" x="829.6" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.03352</text><text class="terminal-432364856-r1" x="939.4" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">│</text><text class="terminal-432364856-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">
+</text><text class="terminal-432364856-r1" x="0" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">│</text><text class="terminal-432364856-r2" x="36.6" y="386" textLength="134.2" clip-path="url(#terminal-432364856-line-15)">sex_Male&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="207.4" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">0.50667</text><text class="terminal-432364856-r2" x="329.4" y="386" textLength="97.6" clip-path="url(#terminal-432364856-line-15)">&#160;0.15917</text><text class="terminal-432364856-r2" x="463.6" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">3.18325</text><text class="terminal-432364856-r5" x="585.6" y="386" textLength="73.2" clip-path="url(#terminal-432364856-line-15)">0.0040</text><text class="terminal-432364856-r2" x="695.4" y="386" textLength="97.6" clip-path="url(#terminal-432364856-line-15)">&#160;0.17816</text><text class="terminal-432364856-r2" x="829.6" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">0.83518</text><text class="terminal-432364856-r1" x="939.4" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">│</text><text class="terminal-432364856-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">
+</text><text class="terminal-432364856-r1" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">│</text><text class="terminal-432364856-r1" x="939.4" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">│</text><text class="terminal-432364856-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">
+</text><text class="terminal-432364856-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-432364856-line-17)">╰────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-432364856-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-432364856-line-17)">
+</text>
+    </g>
+    </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,120 +1,164 @@
 # svy
 
-Modern Python tools for **complex survey analysis**, built for real-world statistical workflows.
+**Design, analyze, and report complex surveys in Python.**
 
-**svy** is a rigorously design-based, production-oriented ecosystem for survey design, weighting, estimation, and small area estimation, without sacrificing transparency or scalability.
+[![PyPI](https://img.shields.io/pypi/v/svy?color=blue)](https://pypi.org/project/svy/)
+[![Python](https://img.shields.io/pypi/pyversions/svy)](https://pypi.org/project/svy/)
+[![Downloads](https://img.shields.io/pypi/dm/svy)](https://pypi.org/project/svy/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Docs](https://img.shields.io/badge/docs-svylab.com-0b7285)](https://svylab.com/docs/svy)
 
-🌐 Website: https://svylab.com  
-📘 Documentation: https://svylab.com/docs
+svy is a design-based, production-oriented library covering the full survey workflow: sample size, selection, weighting, estimation, testing, and modeling. It is [validated against R's `survey` package](https://svylab.com/learn/notes/posts/svy-vs-r-comparison/) to six significant digits and powered by a Rust engine.
 
----
-
-> [!TIP]
-> **Validation**: Want to assess the correctness of svy?  
-> See our [comparison with R’s survey package](https://svylab.com/learn/notes/posts/svy-vs-r-comparison/), showing numerically identical results across Taylor linearization, replication methods, and complex survey designs.
-
-## What is svy?
-
-svy is designed for people who **actually work with complex survey data**, including:
-
-- National statistical offices
-- Public health and development programs
-- Opinion polling and market research organizations
-- Survey methodologists and social science researchers
-- Data scientists working with complex samples
-
-The guiding principle is:
-
-> **Correct inference first, without hiding assumptions or sacrificing usability.**
-
-svy prioritizes statistical validity while remaining compatible with modern Python workflows.
+🌐 [svylab.com](https://svylab.com) · 📘 [Documentation](https://svylab.com/docs/svy) · 🚀 [Quick Tour](https://svylab.com/docs/svy/tutorials/sample_quicktour.html)
 
 ---
+
+## Why svy?
+
+- **One object, whole workflow.** A `Sample` binds your data to its sampling design once; `.wrangling`, `.weighting`, `.estimation`, `.categorical`, and `.glm` all hang off it, and the design metadata travels through every step.
+- **Correct by construction.** `Sample` is immutable: every transformation returns a new object, and subpopulation analysis (`where=`) keeps the full design for variance estimation instead of filtering rows, which understates standard errors.
+- **Replicate weights done right.** Nonresponse adjustment, calibration, raking, and trimming are applied to the replicate weights in the same pass as the full-sample weights, so replication standard errors reflect the whole weighting process.
+- **Fast.** Variance estimation and other hot paths run in Rust ([svy-rs](https://pypi.org/project/svy-rs/)); data operations run on Polars. A full pipeline with 500 bootstrap replicates completes in under a quarter of a second on a laptop.
+- **Reproducible and automation-ready.** Explicit seeds, typed result objects (`Estimate`, `Table`, `TTest`, GLM fits), and a versioned serialization module make pipelines easy to rerun, audit, and wire into production systems.
 
 ## Installation
 
 ```bash
-pip install svy # svy[report] for rich outputs
+pip install svy             # or: uv add svy
+pip install "svy[report]"   # adds rich terminal and HTML reporting
 ```
 
-or
+## The whole workflow as one chain
 
-```bash
-uv add svy
-```
-
----
-
-## Quick Start
+Every transformation returns a new `Sample`, so an entire workflow reads as one fluent pipeline. Load a bundled survey (runs offline), create an indicator, adjust the weights for nonresponse, trim extreme weights, and estimate the population literacy rate with a design-based standard error:
 
 ```python
 import svy
+import numpy as np
 
-# Load example data
-hld_data = svy.datasets.load("hld_sample_wb_2023")
+rng = np.random.default_rng(42)
 
-# Define the survey design
-hld_design = svy.Design(stratum=("geo1", "urbrur"), psu="ea", wgt="hhweight")
+# A bundled example survey; its metadata carries the sampling design
+data = svy.datasets.load("ind_sample_wb_2023", source="bundled")
+info = svy.datasets.describe("ind_sample_wb_2023", source="bundled")
+sample = svy.Sample(data, svy.Design(**info.design))
 
-# Create a sample object
-hld_sample = svy.Sample(data=hld_data, design=hld_design)
+literacy_rate = (
+    sample
+    # 1. Wrangle: a 1/0 literacy indicator, plus a simulated response status
+    .wrangling.mutate({
+        "literate": svy.when(svy.col("literacy") == "Yes").then(1)
+                       .when(svy.col("literacy") == "No").then(0)
+                       .otherwise(None),
+        # simulated for illustration; the example data has 100% response
+        "resp_status": rng.choice(
+            ["respondent", "non-respondent"], p=[0.85, 0.15],
+            size=sample.n_records,
+        ),
+    })
+    # 2. Adjust the weights for nonresponse, within urban/rural classes
+    .weighting.adjust(
+        resp_status="resp_status",
+        by="urbrur",
+        resp_mapping={"rr": "respondent", "nr": "non-respondent"},
+        wgt_name="nr_wgt",
+    )
+    # 3. Trim extreme weights to reduce variance
+    .weighting.trim(upper=3.0)
+    # 4. Estimate the population literacy rate, with a design-based SE
+    .estimation.mean("literate", drop_nulls=True)
+)
 
-# Estimate the mean of total expenditure
-tot_exp_mean = hld_sample.estimation.mean(y="tot_exp")
-print(tot_exp_mean)
+print(literacy_rate)
 ```
 
----
+![svy Estimate output: mean literacy rate with standard error, confidence interval, and CV](.github/assets/readme_estimate.svg)
 
-## Capabilities
+## More analysis
 
-- **Sample size calculation** for estimation and comparison objectives
-- **Sample selection** including SRS, systematic, PPS, and multi-stage designs
-- **Weight adjustments**: nonresponse, poststratification, calibration (GREG), raking, trimming
-- **Design-based estimation** with valid standard errors (Taylor linearization)
-- **Replication methods**: BRR, bootstrap, jackknife, SDR
-- **Categorical data analysis**: tabulation, crosstabulation, t-test, rank tests, Rao-Scott test
-- **Generalized linear models**: linear, logistic, Poisson, Gamma with survey weights
-- **Explicit, inspectable, reproducible outputs**
-- **Built on Polars, NumPy, SciPy, and msgspec**, with a Rust computational engine
+The same `Sample` reaches every other kind of analysis through an accessor.
 
-All methods are grounded in established survey methodology.
+**Domain estimation** with correct within-domain standard errors:
 
----
+```python
+print(sample.estimation.mean("age", by="urbrur"))
+```
 
-## Ecosystem Packages
+```
+╭──────────────── Estimate: MEAN (TAYLOR) ─────────────────╮
+│                                                          │
+│  urbrur       est       se       lci       uci   cv (%)  │
+│  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  │
+│  Rural    27.4893   3.1681   20.9771   34.0015    11.53  │
+│  Urban    29.7557   2.5016   24.6135   34.8978     8.41  │
+│                                                          │
+╰──────────────────────────────────────────────────────────╯
+```
 
-| Package                                     | Purpose                                 | Install                  |
-| ------------------------------------------- | --------------------------------------- | ------------------------ |
-| **svy**                                     | Core survey design & estimation         | `pip install svy`        |
-| [svy-sae](https://svylab.com/docs/svy-sae/) | Small Area Estimation                   | `pip install svy-sae`    |
-| [svy-io](https://svylab.com/docs/svy-io/)   | SPSS / Stata / SAS I/O                  | `pip install svy-io`     |
-| [svy-rs](https://pypi.org/project/svy-rs/)  | Rust computational engine used by svy   | installed automatically  |
+**Tabulation** with design-based standard errors (two-way tables add Rao-Scott tests automatically):
+
+```python
+print(sample.categorical.tabulate("educ_attain", units="percent"))
+```
+
+**Regression** with design-adjusted standard errors (Gaussian, binomial, Poisson, and Gamma families):
+
+```python
+model = sample.glm.fit(y="yrs_school", x=["age", svy.Cat("sex")], family="gaussian")
+print(model)
+```
+
+![svy GLM output: Gaussian model of years of schooling with design-adjusted standard errors](.github/assets/readme_glm.svg)
+
+The [Quick Tour](https://svylab.com/docs/svy/tutorials/sample_quicktour.html) runs this whole workflow in five minutes, every block offline on the bundled data.
+
+## Capabilities across the survey lifecycle
+
+| Stage | What svy provides |
+| --- | --- |
+| **Plan** | Sample size for estimation and comparison objectives, with design effects and nonresponse |
+| **Select** | SRS, systematic, PPS methods; multi-stage designs with automatic probability chaining |
+| **Weight** | Nonresponse adjustment, poststratification, GREG calibration, raking, trimming, normalization |
+| **Estimate** | Means, totals, proportions, ratios, medians; Taylor linearization and replication (BRR, Fay, jackknife, bootstrap, SDR) |
+| **Test** | Tabulations, t-tests, rank tests, Rao-Scott chi-squared tests, all design-adjusted |
+| **Model** | GLMs (linear, logistic, Poisson, Gamma) with design-adjusted standard errors |
+
+All methods are grounded in established survey methodology, with domain estimation (`by=`) and subpopulation analysis (`where=`) throughout.
+
+## Validation
+
+svy is validated against R's `survey` package across design specification, Taylor linearization, replication methods, calibration, categorical analysis, and GLMs, producing numerically identical results to at least six significant digits. The few intentional differences follow Stata conventions and are documented. See the [full comparison with reproducible code](https://svylab.com/learn/notes/posts/svy-vs-r-comparison/).
+
+## Ecosystem
+
+| Package | Purpose | Install |
+| --- | --- | --- |
+| **svy** | Core survey design & estimation | `pip install svy` |
+| [svy-sae](https://svylab.com/docs/svy-sae/) | Small Area Estimation | `pip install svy-sae` |
+| [svy-io](https://svylab.com/docs/svy-io/) | SPSS / Stata / SAS I/O | `pip install svy-io` |
+| [svy-rs](https://pypi.org/project/svy-rs/) | Rust computational engine used by svy | installed automatically |
 
 This repository is a monorepo: the Python package lives in [`packages/svy`](packages/svy), the Rust engine in [`packages/svy-rs`](packages/svy-rs), and the I/O library in [`packages/svy-io`](packages/svy-io).
 
----
-
 ## Documentation
 
-Full documentation, tutorials, and methodological notes:
-👉 https://svylab.com/docs
+Guides, tutorials, and methodological notes: [svylab.com/docs/svy](https://svylab.com/docs/svy). Start with the [Quick Tour](https://svylab.com/docs/svy/tutorials/sample_quicktour.html).
 
----
+## Citation
+
+A software paper for svy is under review at the Journal of Open Source Software. Until it is published, please cite this repository. The predecessor package, samplics, is described in [Diallo (2021), JOSS 6(68):3376](https://doi.org/10.21105/joss.03376).
 
 ## Feedback
 
-- Issues: https://github.com/samplics-org/svy/issues
-- Discussions: https://github.com/samplics-org/svy/discussions
+- Issues: [github.com/samplics-org/svy/issues](https://github.com/samplics-org/svy/issues)
+- Discussions: [github.com/samplics-org/svy/discussions](https://github.com/samplics-org/svy/discussions)
 
 If you work with complex surveys and want to influence the design of a modern Python survey stack, this is the right place to engage.
 
----
-
 ## License
 
-MIT License  
-Copyright © 2026 Samplics LLC
+MIT License. Copyright © 2026 Samplics LLC.
 
 ---
 


### PR DESCRIPTION
## Summary

Reworks the root README from a spec sheet into a proper landing page:

- **Hero section with badges**: PyPI version, Python versions, monthly downloads, license, and docs, plus a one-line pitch leading with the R `survey` validation and the Rust engine.
- **Pipeline example front and center**: the "whole workflow as one chain" example from the Quick Tour (wrangle -> nonresponse adjustment -> trimming -> design-based estimate), replacing the minimal load-and-mean snippet.
- **Rendered output as SVG**: the `Estimate` and GLM panels are embedded as SVG screenshots generated with Rich's recorder from real svy output (`.github/assets/`), so visitors see the terminal output before installing. Reproducible: same seed and data as the Quick Tour.
- **"More analysis" section** mirroring the Quick Tour: domain estimation, tabulation, and design-adjusted GLM.
- **Capabilities as a lifecycle table** (plan / select / weight / estimate / test / model) instead of a flat bullet list.
- **New sections**: Why svy (five differentiators), Validation, Citation (JOSS paper under review; samplics 2021 paper linked).

Numbers in the embedded outputs match the published Quick Tour exactly.