### PR TITLE
fix(datasets): harden the downloader against a hostile catalog

### DIFF
--- a/packages/svy/src/svy/datasets/_cache.py
+++ b/packages/svy/src/svy/datasets/_cache.py
@@ -19,12 +19,14 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 import shutil
 import tempfile
 import threading
 
 from pathlib import Path
 from typing import Final
+from urllib.parse import urlsplit
 
 import httpx
 
@@ -67,14 +69,63 @@ def _lock_for(slug_version: str) -> threading.Lock:
         return lock
 
 
+# --- Validation ------------------------------------------------------------ #
+
+# Slugs come from the (untrusted) backend registry and are interpolated into
+# cache paths, glob patterns and tempfile prefixes.  Allowlist them strictly:
+# a permissive slug like "../../foo" would write attacker-controlled bytes
+# outside CACHE_DIR.
+_SLUG_RE: Final = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+# Hosts for which plain http is acceptable (local development / tests).
+_LOCAL_HOSTS: Final = frozenset({"localhost", "127.0.0.1", "::1"})
+
+
+def validate_slug(slug: str, *, where: str) -> str:
+    """Return ``slug`` if it is safe to use in filesystem paths; raise otherwise."""
+    if not _SLUG_RE.fullmatch(slug) or ".." in slug:
+        raise DatasetError.invalid_slug(where=where, slug=slug)
+    return slug
+
+
+def _require_https(url: str, *, slug: str, where: str) -> None:
+    """Reject non-https download URLs (plain http allowed for localhost only)."""
+    parts = urlsplit(url)
+    if parts.scheme == "https":
+        return
+    if parts.scheme == "http" and (parts.hostname or "").lower() in _LOCAL_HOSTS:
+        return
+    raise DatasetError.insecure_url(where=where, slug=slug, url=url)
+
+
 # --- Public API ----------------------------------------------------------- #
 
 
 def path_for(slug: str, version: str) -> Path:
     """Return the on-disk path for ``{slug}@{version}.parquet``."""
+    validate_slug(slug, where="datasets._cache.path_for")
     # Version is part of the filename so old versions coexist until evicted.
     safe_version = version.replace("/", "_").replace("\\", "_")
     return CACHE_DIR / f"{slug}@{safe_version}.parquet"
+
+
+def _pin_path(local_path: Path) -> Path:
+    """Sidecar file holding the first-seen (TOFU) sha256 for a cache entry."""
+    return local_path.with_name(local_path.name + ".sha256")
+
+
+def _read_pin(local_path: Path) -> str:
+    """Return the pinned hex digest for ``local_path``, or '' if none."""
+    try:
+        pin = _pin_path(local_path).read_text(encoding="utf-8").strip().lower()
+    except OSError:
+        return ""
+    # A corrupt/truncated pin must not silently disable verification forever.
+    return pin if re.fullmatch(r"[0-9a-f]{64}", pin) else ""
+
+
+def _write_pin(local_path: Path, digest: str) -> None:
+    _pin_path(local_path).write_text(digest + "\n", encoding="utf-8")
 
 
 def ensure_cached(
@@ -96,28 +147,35 @@ def ensure_cached(
     slug, version : str
         Cache key components.
     url : str
-        Where to download if the file is missing.
+        Where to download if the file is missing.  Must be https (plain
+        http is allowed for localhost only), including after redirects.
     sha256 : str
-        Expected hex digest.  Verified after download and on first use.
-        If empty, integrity checks are skipped (a warning is logged).
+        Expected hex digest from the catalog.  Verified after download and
+        on first use.  If empty, the digest of the first successful download
+        is pinned on disk (trust-on-first-use) and enforced from then on.
     force : bool
-        If True, re-download even if a valid cached copy exists.
+        If True, re-download even if a valid cached copy exists.  The
+        re-downloaded bytes must still match the catalog hash or TOFU pin.
 
     Raises
     ------
     DatasetError
-        With code ``DATASET_SHA_MISMATCH`` if the hash check fails, or
-        ``DATASET_DOWNLOAD_FAILED`` on network/filesystem errors during
-        download.
+        With code ``DATASET_SHA_MISMATCH`` if the hash check fails,
+        ``DATASET_INVALID_SLUG`` / ``DATASET_INSECURE_URL`` on unsafe
+        metadata, or ``DATASET_DOWNLOAD_FAILED`` on network/filesystem
+        errors during download.
     """
+    _WHERE = "datasets._cache.ensure_cached"
+    validate_slug(slug, where=_WHERE)
     local_path = path_for(slug, version)
 
-    # Empty sha256 → catalog doesn't expose one yet.  Skip verification.
-    verify = bool(sha256)
-    if not verify:
-        log.warning("No sha256 provided for %r; integrity check skipped.", slug)
+    # Effective expected hash: the catalog's, or the TOFU pin from an
+    # earlier download.  Empty only before the very first download.
+    expected = sha256.lower() if sha256 else _read_pin(local_path)
+    tofu = not sha256
+    verify = bool(expected)
 
-    cache_key = (str(local_path), sha256)
+    cache_key = (str(local_path), expected)
 
     # Fast path: already validated this session (only meaningful when we
     # actually verified something).
@@ -130,33 +188,55 @@ def ensure_cached(
         # Re-check after acquiring the lock — another thread may have done it.
         if verify and not force and cache_key in _verified and local_path.exists():
             return str(local_path)
+        # Another thread may have just created the first TOFU pin.
+        if tofu and not expected:
+            expected = _read_pin(local_path)
+            verify = bool(expected)
+            cache_key = (str(local_path), expected)
 
         if local_path.exists() and not force:
             if not verify:
-                # No hash to check; trust the cache entry.
-                log.debug("Cache hit (unverified): %s", local_path)
+                # Cached file predating TOFU pinning: adopt its digest as
+                # the pin rather than trusting it silently forever.
+                digest = _sha256_of(local_path)
+                _write_pin(local_path, digest)
+                _mark_verified((str(local_path), digest))
+                log.info("Pinned sha256 for cached %r: %s", slug, digest)
                 return str(local_path)
             # File exists but hasn't been verified this session.  Verify
             # once, then cache the fact.  If hash mismatches, treat as a
-            # corrupted cache entry: delete and re-download.
-            if _sha256_of(local_path) == sha256.lower():
+            # corrupted cache entry: delete and re-download (the fresh
+            # download is verified against the same expected hash).
+            if _sha256_of(local_path) == expected:
                 _mark_verified(cache_key)
                 log.debug("Cache hit (validated): %s", local_path)
                 return str(local_path)
             log.warning("Cached file %s failed hash check; re-downloading.", local_path)
             local_path.unlink(missing_ok=True)
 
-        _download(url=url, dest=local_path, sha256=sha256, slug=slug)
-        if verify:
-            _mark_verified(cache_key)
+        _require_https(url, slug=slug, where=_WHERE)
+        digest = _download(url=url, dest=local_path, sha256=expected, slug=slug)
+        if tofu and not expected:
+            # First-ever download without a catalog hash: pin what we got.
+            _write_pin(local_path, digest)
+            log.info(
+                "No catalog sha256 for %r; pinned first-download hash %s "
+                "(future downloads must match).",
+                slug,
+                digest,
+            )
+        _mark_verified((str(local_path), digest))
         return str(local_path)
 
 
 def clear(slug: str | None = None) -> int:
     """
-    Remove cached files.  If ``slug`` is given, only that dataset's files
-    (all versions) are removed.  Returns the number of files deleted.
+    Remove cached files (parquet + TOFU hash pins).  If ``slug`` is given,
+    only that dataset's files (all versions) are removed.  Returns the
+    number of parquet files deleted.
     """
+    if slug is not None:
+        validate_slug(slug, where="datasets._cache.clear")
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     pattern = f"{slug}@*.parquet" if slug else "*.parquet"
     removed = 0
@@ -166,6 +246,7 @@ def clear(slug: str | None = None) -> int:
             removed += 1
         except OSError:
             log.warning("Could not remove %s", f)
+        _pin_path(f).unlink(missing_ok=True)
     with _verified_lock:
         if slug is None:
             _verified.clear()
@@ -192,13 +273,16 @@ def _sha256_of(path: Path) -> str:
     return h.hexdigest()
 
 
-def _download(*, url: str, dest: Path, sha256: str, slug: str) -> None:
-    """Stream ``url`` into ``dest`` atomically.
+def _download(*, url: str, dest: Path, sha256: str, slug: str) -> str:
+    """Stream ``url`` into ``dest`` atomically; return the actual hex digest.
 
-    Verifies the SHA-256 in-line when ``sha256`` is non-empty; otherwise
-    downloads without integrity verification (a warning is logged by the
-    caller).
+    Verifies the SHA-256 in-line when ``sha256`` is non-empty.  The digest
+    is always computed and returned so the caller can TOFU-pin it.  The
+    final URL after redirects must still satisfy the https policy — a
+    compromised catalog must not be able to downgrade an https download to
+    plain http via a redirect.
     """
+    _WHERE = "datasets._cache._download"
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
     log.info("Downloading dataset %r -> %s", slug, dest)
 
@@ -209,39 +293,37 @@ def _download(*, url: str, dest: Path, sha256: str, slug: str) -> None:
     tmp_path = Path(tmp_name)
 
     expected = sha256.lower()
-    verify = bool(expected)
-    h = hashlib.sha256() if verify else None
+    h = hashlib.sha256()
 
     try:
         with httpx.Client(timeout=_DOWNLOAD_TIMEOUT, follow_redirects=True) as client:
             with client.stream("GET", url) as r:
                 r.raise_for_status()
+                _require_https(str(r.url), slug=slug, where=_WHERE)
                 with os.fdopen(tmp_fd, "wb") as f:
                     for chunk in r.iter_bytes(chunk_size=_DOWNLOAD_CHUNK):
-                        if h is not None:
-                            h.update(chunk)
+                        h.update(chunk)
                         f.write(chunk)
 
-        if verify:
-            assert h is not None  # for type checkers
-            actual = h.hexdigest()
-            if actual != expected:
-                tmp_path.unlink(missing_ok=True)
-                raise DatasetError.sha_mismatch(
-                    where="datasets._cache._download",
-                    slug=slug,
-                    expected=expected,
-                    got=actual,
-                )
+        actual = h.hexdigest()
+        if expected and actual != expected:
+            tmp_path.unlink(missing_ok=True)
+            raise DatasetError.sha_mismatch(
+                where=_WHERE,
+                slug=slug,
+                expected=expected,
+                got=actual,
+            )
 
         # Atomic rename within the same filesystem.
         shutil.move(str(tmp_path), str(dest))
         log.info("Download complete: %s", dest)
+        return actual
 
     except DatasetError:
         raise
     except Exception as ex:
         tmp_path.unlink(missing_ok=True)
         raise DatasetError.download_failed(
-            where="datasets._cache._download", slug=slug, url=url, reason=str(ex)
+            where=_WHERE, slug=slug, url=url, reason=str(ex)
         ) from ex

--- a/packages/svy/src/svy/datasets/api.py
+++ b/packages/svy/src/svy/datasets/api.py
@@ -39,6 +39,7 @@ from typing import Any, Final
 import httpx
 import msgspec
 
+from svy.datasets._cache import validate_slug
 from svy.datasets.types import Dataset, DatasetCatalog
 from svy.errors.dataset_errors import DatasetError
 
@@ -147,7 +148,9 @@ def _from_backend(entry: dict[str, Any]) -> Dataset:
             "subpath": "..."
         }
     """
-    slug = entry["slug"]
+    # The slug flows into cache paths, glob patterns and tempfile prefixes;
+    # the registry is untrusted input, so validate before anything else.
+    slug = validate_slug(entry["slug"], where="datasets.api._from_backend")
 
     # Prefer a URL the backend constructs; fall back to synthesizing one.
     src = entry.get("source") or {}
@@ -252,7 +255,15 @@ def catalog(*, use_cache: bool = True) -> DatasetCatalog:
 
     raw = _fetch(_REGISTRY_PATH)
     entries = _RAW_LIST_DECODER.decode(raw)
-    datasets = DatasetCatalog(_from_backend(e) for e in entries)
+    # One malformed/hostile registry entry must not take down the whole
+    # catalog: skip it (with a warning) and list the valid ones.
+    translated: list[Dataset] = []
+    for e in entries:
+        try:
+            translated.append(_from_backend(e))
+        except (DatasetError, KeyError, TypeError) as ex:
+            log.warning("Skipping invalid registry entry %r: %s", e.get("slug", "<no slug>"), ex)
+    datasets = DatasetCatalog(translated)
     _cache_put_list(datasets)
 
     # Populate per-slug cache too — saves a round-trip on the next describe().

--- a/packages/svy/src/svy/errors/dataset_errors.py
+++ b/packages/svy/src/svy/errors/dataset_errors.py
@@ -165,6 +165,52 @@ class DatasetError(SvyError):
     # ---- Integrity --------------------------------------------------------
 
     @classmethod
+    def invalid_slug(
+        cls,
+        *,
+        where: Optional[str],
+        slug: str,
+        hint: Optional[str] = "Slugs may only contain letters, digits, '.', '_' and '-', "
+        "and must start with a letter or digit.",
+        docs_url: Optional[str] = None,
+    ) -> "DatasetError":
+        return cls(
+            title="Invalid dataset slug",
+            detail=f"Dataset slug {slug!r} contains disallowed characters.",
+            code="DATASET_INVALID_SLUG",
+            where=where,
+            param="slug",
+            got=slug,
+            hint=hint,
+            docs_url=docs_url,
+            extra={"slug": slug},
+        )
+
+    @classmethod
+    def insecure_url(
+        cls,
+        *,
+        where: Optional[str],
+        slug: str,
+        url: str,
+        hint: Optional[str] = "Dataset downloads require https (plain http is allowed "
+        "only for localhost).",
+        docs_url: Optional[str] = None,
+    ) -> "DatasetError":
+        return cls(
+            title="Insecure dataset download URL",
+            detail=f"Refusing to download dataset {slug!r} over an insecure URL.",
+            code="DATASET_INSECURE_URL",
+            where=where,
+            param="download_url",
+            expected="https://...",
+            got=url,
+            hint=hint,
+            docs_url=docs_url,
+            extra={"slug": slug, "url": url},
+        )
+
+    @classmethod
     def sha_mismatch(
         cls,
         *,

--- a/packages/svy/tests/svy/datasets/conftest.py
+++ b/packages/svy/tests/svy/datasets/conftest.py
@@ -230,7 +230,11 @@ def isolate_module_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, routes
         """Context-manager-compatible replacement for httpx.Client in _cache."""
 
         def __init__(self, *_args, **_kwargs):
-            self._client = real_httpx_client(transport=routes.transport())
+            # Mirror the production client's redirect behavior so tests
+            # exercise the post-redirect https check.
+            self._client = real_httpx_client(
+                transport=routes.transport(), follow_redirects=True
+            )
 
         def __enter__(self):
             return self._client

--- a/packages/svy/tests/svy/datasets/test_api.py
+++ b/packages/svy/tests/svy/datasets/test_api.py
@@ -207,3 +207,30 @@ class TestTTL:
 
         api.describe("a")
         assert len(routes.hits) > n_hits
+
+
+class TestRegistrySlugValidation:
+    def test_catalog_skips_traversal_slug_entry(self, routes, make_backend_entry):
+        """A hostile registry entry must be skipped, not break the catalog."""
+        from svy.datasets import api
+
+        routes.add_json(
+            "/api/data/examples/registry",
+            [
+                make_backend_entry(slug="good"),
+                make_backend_entry(slug="../../evil"),
+            ],
+        )
+        cat = api.catalog(use_cache=False)
+        assert cat.slugs == ("good",)
+
+    def test_describe_traversal_slug_not_found(self, routes, make_backend_entry):
+        from svy.datasets import api
+        from svy.errors.dataset_errors import DatasetError
+
+        routes.add_json(
+            "/api/data/examples/registry",
+            [make_backend_entry(slug="../../evil")],
+        )
+        with pytest.raises(DatasetError):
+            api.describe("../../evil", use_cache=False)

--- a/packages/svy/tests/svy/datasets/test_cache.py
+++ b/packages/svy/tests/svy/datasets/test_cache.py
@@ -329,3 +329,188 @@ class TestClear:
         )
         removed = _cache.clear("s")
         assert removed == 2
+
+
+# --------------------------------------------------------------------------- #
+# Security: slug validation, https enforcement, TOFU pinning
+# --------------------------------------------------------------------------- #
+
+
+class TestSlugValidation:
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "../evil",
+            "..",
+            "a/../../b",
+            "a/b",
+            "a\\b",
+            ".hidden",
+            "*",
+            "toy@1",
+            "",
+            "a b",
+        ],
+    )
+    def test_bad_slugs_rejected(self, bad_slug):
+        with pytest.raises(DatasetError) as exc_info:
+            _cache.ensure_cached(
+                slug=bad_slug,
+                version="1.0",
+                url="https://svylab.test/data/x.parquet",
+                sha256="",
+            )
+        assert exc_info.value.code == "DATASET_INVALID_SLUG"
+
+    def test_traversal_slug_writes_nothing_outside_cache(self, tmp_path):
+        with pytest.raises(DatasetError):
+            _cache.path_for("../outside", "1.0")
+
+    def test_clear_rejects_glob_slug(self):
+        with pytest.raises(DatasetError):
+            _cache.clear("*")
+
+    @pytest.mark.parametrize("good_slug", ["toy", "phia_like", "acs.2023", "a-b_c", "x1"])
+    def test_good_slugs_accepted(self, good_slug):
+        p = _cache.path_for(good_slug, "1.0")
+        assert p.name == f"{good_slug}@1.0.parquet"
+
+
+class TestHttpsEnforcement:
+    def test_http_url_rejected(self):
+        with pytest.raises(DatasetError) as exc_info:
+            _cache.ensure_cached(
+                slug="toy",
+                version="1.0",
+                url="http://svylab.test/data/toy.parquet",
+                sha256="",
+            )
+        assert exc_info.value.code == "DATASET_INSECURE_URL"
+
+    def test_non_http_scheme_rejected(self):
+        with pytest.raises(DatasetError) as exc_info:
+            _cache.ensure_cached(
+                slug="toy",
+                version="1.0",
+                url="ftp://svylab.test/data/toy.parquet",
+                sha256="",
+            )
+        assert exc_info.value.code == "DATASET_INSECURE_URL"
+
+    def test_http_localhost_allowed(self, routes, make_parquet):
+        data, sha = make_parquet(n_rows=5)
+        routes.add_bytes("/data/toy.parquet", data)
+        path = _cache.ensure_cached(
+            slug="toy",
+            version="1.0",
+            url="http://127.0.0.1/data/toy.parquet",
+            sha256=sha,
+        )
+        assert Path(path).exists()
+
+    def test_redirect_downgrade_to_http_rejected(self, routes, make_parquet):
+        """An https download 302'd to plain http must fail, not follow."""
+        import httpx
+
+        data, _sha = make_parquet(n_rows=5)
+        routes.add(
+            "/data/redirect.parquet",
+            lambda req: httpx.Response(
+                302, headers={"location": "http://evil.test/data/payload.parquet"}
+            ),
+        )
+        routes.add_bytes("/data/payload.parquet", data)
+        with pytest.raises(DatasetError) as exc_info:
+            _cache.ensure_cached(
+                slug="toy",
+                version="1.0",
+                url="https://svylab.test/data/redirect.parquet",
+                sha256="",
+            )
+        assert exc_info.value.code == "DATASET_INSECURE_URL"
+        assert not list(_cache.CACHE_DIR.glob("*.parquet"))
+
+
+class TestTofuPinning:
+    def _url(self):
+        return "https://svylab.test/data/toy.parquet"
+
+    def test_first_download_writes_pin(self, routes, make_parquet):
+        data, sha = make_parquet(n_rows=10)
+        routes.add_bytes("/data/toy.parquet", data)
+        path = _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+        pin = _cache._pin_path(Path(path))
+        assert pin.exists()
+        assert pin.read_text().strip() == sha
+
+    def test_pin_enforced_on_redownload(self, routes, make_parquet):
+        """Content change without a version bump must be rejected."""
+        data1, _ = make_parquet(n_rows=10)
+        data2, _ = make_parquet(n_rows=11)  # different content
+        routes.add_bytes("/data/toy.parquet", data1)
+        _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+
+        # Server now returns different bytes for the same slug@version.
+        routes._routes.clear()
+        routes.add_bytes("/data/toy.parquet", data2)
+        with pytest.raises(DatasetError) as exc_info:
+            _cache.ensure_cached(
+                slug="toy", version="1.0", url=self._url(), sha256="", force=True
+            )
+        assert exc_info.value.code == "DATASET_SHA_MISMATCH"
+
+    def test_corrupted_cache_restored_from_pin(self, routes, make_parquet):
+        data, sha = make_parquet(n_rows=10)
+        routes.add_bytes("/data/toy.parquet", data)
+        path = _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+
+        # Corrupt the cached file and wipe the session-verified memo.
+        Path(path).write_bytes(b"corrupted")
+        _cache._verified.clear()
+
+        path2 = _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+        assert Path(path2).read_bytes() == data
+
+    def test_preexisting_cache_entry_gets_pinned(self, routes, make_parquet):
+        """A cache file from before TOFU pinning is adopted, not re-fetched."""
+        data, sha = make_parquet(n_rows=10)
+        dest = _cache.path_for("toy", "1.0")
+        dest.write_bytes(data)
+
+        path = _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+        assert Path(path) == dest
+        assert _cache._read_pin(dest) == sha
+        assert len(routes.hits) == 0  # no network
+
+    def test_catalog_hash_takes_precedence_over_pin(self, routes, make_parquet):
+        """Once the backend serves sha256, it wins over any local pin."""
+        data1, _ = make_parquet(n_rows=10)
+        data2, sha2 = make_parquet(n_rows=11)
+        routes.add_bytes("/data/toy.parquet", data1)
+        _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+
+        routes._routes.clear()
+        routes.add_bytes("/data/toy.parquet", data2)
+        # Catalog-provided hash for the new content: accepted despite old pin.
+        path = _cache.ensure_cached(
+            slug="toy", version="1.0", url=self._url(), sha256=sha2, force=True
+        )
+        assert Path(path).read_bytes() == data2
+
+    def test_clear_removes_pins(self, routes, make_parquet):
+        data, _ = make_parquet(n_rows=10)
+        routes.add_bytes("/data/toy.parquet", data)
+        _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+        assert len(list(_cache.CACHE_DIR.glob("*.sha256"))) == 1
+        _cache.clear("toy")
+        assert not list(_cache.CACHE_DIR.glob("*.sha256"))
+
+    def test_corrupt_pin_is_ignored_and_rewritten(self, routes, make_parquet):
+        data, sha = make_parquet(n_rows=10)
+        routes.add_bytes("/data/toy.parquet", data)
+        dest = _cache.path_for("toy", "1.0")
+        _cache._pin_path(dest).parent.mkdir(parents=True, exist_ok=True)
+        _cache._pin_path(dest).write_text("not-a-hash\n")
+
+        _cache.ensure_cached(slug="toy", version="1.0", url=self._url(), sha256="")
+        assert _cache._read_pin(dest) == sha


### PR DESCRIPTION
Round 5 of the 2026-07 review: dataset downloader integrity. All three
flagged gaps were verified still present after the datasets redesign,
plus two more found in a full module review.

## Path traversal via registry slug

Slugs flow from the (untrusted) registry JSON into cache paths, glob
patterns and tempfile prefixes. A compromised or MITM'd catalog
answering `"slug": "../../foo"` wrote attacker-controlled bytes outside
`~/.svy/datasets`. Slugs are now strictly allowlisted
(`[A-Za-z0-9][A-Za-z0-9._-]*`, no `..`) at the registry-translation
boundary and defensively in `path_for`/`clear`; `catalog()` skips
invalid entries with a warning instead of failing wholesale. This also
closes `clear(slug)` glob injection (a slug containing `*` wiped
unrelated cache entries).

## Integrity verification was always skipped

The backend doesn't serve `sha256`, and an empty hash meant
"skip verification, log a warning" — so every real download was
unverified, forever. Downloads without a catalog hash now pin the
first-seen digest on disk (`{slug}@{version}.parquet.sha256`,
trust-on-first-use) and enforce it on every subsequent use and
re-download (`DATASET_SHA_MISMATCH` on change). A catalog-supplied hash
takes precedence over the pin once the backend starts serving one —
serving hashes server-side remains the end goal. Pre-existing cache
entries are adopted by pinning their current digest rather than being
trusted silently.

## Plain-http downloads and redirect downgrade

Registry-supplied `http://` download URLs were accepted as-is, and both
HTTP clients follow redirects — so even an https URL could be 302'd to
plain http. Downloads now require https on the initial URL **and** on
the final post-redirect URL (`DATASET_INSECURE_URL`), with a localhost
exemption for development setups.

## Testing

- 22 new tests: traversal/glob/charset slug rejection, http and
  redirect-downgrade rejection, localhost http allowance, full TOFU pin
  lifecycle (pin on first download, enforce on re-download, corrupted
  cache restored, corrupt pin rewritten, catalog hash precedence,
  clear() removes pins), catalog skip of hostile entries.
- Full svy suite: 2617 passed, 1 skipped.
- The test mock client now follows redirects, matching the production
  client's configuration.