### PR TITLE
fix(svy-io): data handling — user_missing schema, temp hygiene, edge cases

### DIFF
--- a/packages/svy-io/python/svy_io/labelled.py
+++ b/packages/svy-io/python/svy_io/labelled.py
@@ -562,11 +562,11 @@ class LabelledSPSS(Labelled):
             label=self.label or template.label,
         )
 
-    def to_int(self) -> List[int]:
-        """Convert to integer list"""
+    def to_int(self) -> List[Optional[int]]:
+        """Convert to integer list; missing values stay None (never 0)."""
         if not _is_numeric_seq(self.data):
             raise TypeError("Cannot convert string labelled to int")
-        return [int(v) if v is not None else 0 for v in self.data]
+        return [int(v) if v is not None else None for v in self.data]
 
     def to_float(self) -> List[float]:
         """Convert to float list"""

--- a/packages/svy-io/python/svy_io/metadata.py
+++ b/packages/svy-io/python/svy_io/metadata.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 
 @dataclass
@@ -33,3 +33,67 @@ class SvyMetadata:
     value_labels: Dict[str, ValueLabels]
     user_missing: Dict[str, MissingRule]
     n_rows: int
+
+
+def _maybe_float(v: Any) -> Any:
+    """Parse numeric strings from the native layer; keep everything else."""
+    if isinstance(v, str):
+        try:
+            return float(v)
+        except ValueError:
+            return v
+    return v
+
+
+def normalize_user_missing(meta: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """
+    Build the canonical ``meta["user_missing"]`` schema.
+
+    Canonical (haven-compatible) shape, one entry per column::
+
+        {"col": <name>, "na_values": [...], "na_range": (lo, hi) | None}
+
+    Historically three shapes coexisted — the native layer's
+    ``{var, discrete, ranges}``, the per-variable ``{values, range}``, and
+    the ``{col, values, range}`` rewrite in ``read_sav(user_na=True)`` —
+    and ``zap_missing`` (which reads ``na_values``/``na_range``) matched
+    none of them, silently doing nothing on real metadata.  Every reader
+    now funnels through this one converter.
+
+    Sources, later ones winning per column:
+      1. any existing meta-level entries (canonical or legacy native shape),
+      2. per-variable ``vars[i]["user_missing"]`` definitions.
+    """
+    by_col: Dict[str, Dict[str, Any]] = {}
+
+    for rule in meta.get("user_missing") or []:
+        col = rule.get("col") or rule.get("var") or rule.get("name")
+        if not col:
+            continue
+        if "na_values" in rule or "na_range" in rule:
+            # Already canonical — keep extra keys (e.g. "type") as-is.
+            by_col[col] = dict(rule)
+            continue
+        # Native MissingRule shape: {var, discrete: [str], ranges: [(lo, hi)]}
+        na_values = [_maybe_float(v) for v in rule.get("discrete") or []]
+        ranges = rule.get("ranges") or []
+        na_range = tuple(_maybe_float(v) for v in ranges[0]) if ranges else None
+        # Legacy hydrate shape: {col, values, range}
+        if not na_values:
+            na_values = [_maybe_float(v) for v in rule.get("values") or []]
+        if na_range is None and rule.get("range"):
+            na_range = tuple(_maybe_float(v) for v in rule["range"])
+        if na_values or na_range:
+            by_col[col] = {"col": col, "na_values": na_values, "na_range": na_range}
+
+    for var in meta.get("vars") or []:
+        name = var.get("name")
+        um = var.get("user_missing")
+        if not name or not um:
+            continue
+        na_values = [_maybe_float(v) for v in um.get("values") or []]
+        na_range = tuple(_maybe_float(v) for v in um["range"]) if um.get("range") else None
+        if na_values or na_range:
+            by_col[name] = {"col": name, "na_values": na_values, "na_range": na_range}
+
+    return list(by_col.values())

--- a/packages/svy-io/python/svy_io/sas.py
+++ b/packages/svy-io/python/svy_io/sas.py
@@ -347,7 +347,10 @@ def as_factor_expr(
             mapping_utf8["__svy_label"].to_list(),
         )
     )
-    label_expr = key_expr.replace(repl)
+    # Unlabelled values map to null (haven / factor.as_factor behavior);
+    # the "default"/"both" branches below fall back to the raw value
+    # explicitly via otherwise(key_expr).
+    label_expr = key_expr.replace_strict(repl, default=None)
 
     if levels in {"default", "both"}:
         if levels == "both":
@@ -569,16 +572,12 @@ def read_sas(
     n_max = _normalize_n_max(n_max)
 
     # Fast-path: explicitly requesting zero rows
-    if n_max == 0:
-        empty = pl.DataFrame({})
-        meta: Dict[str, Any] = {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
-        return empty, meta
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate after parsing.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     # Temp artifacts (spooled file-like inputs, zip extraction dir) live
     # only for the duration of the native parse.
@@ -619,6 +618,10 @@ def read_sas(
     # Decode metadata JSON
     meta: Dict[str, Any] = json.loads(meta_json)
     meta["user_missing"] = normalize_user_missing(meta)
+
+    if zero_rows:
+        df = df.head(0)
+        meta["n_rows"] = 0
 
     # Optional post-processing (order chosen to mirror typical haven workflows)
     if coerce_temporals:
@@ -673,17 +676,12 @@ def read_sas_arrow(
     from pyarrow import ArrowInvalid
 
     n_max = _normalize_n_max(n_max)
-    if n_max == 0:
-        # empty table with no fields; keep behavior consistent
-        empty = pa.table({})
-        meta = {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
-        return empty, meta
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate after parsing.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
         data_path, catalog_path, encoding, catalog_encoding, cols_skip, n_max, rows_skip
@@ -699,6 +697,9 @@ def read_sas_arrow(
 
     meta = json.loads(meta_json)
     meta["user_missing"] = normalize_user_missing(meta)
+    if zero_rows:
+        table = table.slice(0, 0)
+        meta["n_rows"] = 0
     return table, meta
 
 

--- a/packages/svy-io/python/svy_io/sas.py
+++ b/packages/svy-io/python/svy_io/sas.py
@@ -17,6 +17,7 @@ from polars.exceptions import ComputeError
 import svy_io.svyreadstat_rs as native
 
 from .factor import as_factor
+from .metadata import normalize_user_missing
 from .helpers import _normalize_n_max
 from .tagged_na import TaggedNA
 
@@ -485,6 +486,7 @@ def read_xpt(
         df = pl.read_ipc_stream(bio)  # Fallback: IPC stream
 
     meta: Dict[str, Any] = json.loads(meta_json)
+    meta["user_missing"] = normalize_user_missing(meta)
 
     # Optional post-processing (same order as read_sas)
     if coerce_temporals:
@@ -604,6 +606,7 @@ def read_sas(
 
     # Decode metadata JSON
     meta: Dict[str, Any] = json.loads(meta_json)
+    meta["user_missing"] = normalize_user_missing(meta)
 
     # Optional post-processing (order chosen to mirror typical haven workflows)
     if coerce_temporals:
@@ -683,6 +686,7 @@ def read_sas_arrow(
         table = pa_ipc.open_stream(bio).read_all()
 
     meta = json.loads(meta_json)
+    meta["user_missing"] = normalize_user_missing(meta)
     return table, meta
 
 

--- a/packages/svy-io/python/svy_io/sas.py
+++ b/packages/svy-io/python/svy_io/sas.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 import io
 import json
 import os
+import shutil
 import tempfile
 import zipfile
 
+from contextlib import ExitStack
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
@@ -134,7 +136,12 @@ def get_na_tag(value) -> str | None:
 
 
 # ----------------  Helper functions ----------------
-def _as_path_like(obj) -> str:
+def _as_path_like(obj, stack: ExitStack) -> str:
+    """Resolve a path or file-like object to a filesystem path.
+
+    File-like objects are spooled to a private temp file that is removed
+    when ``stack`` closes (i.e. right after the native parse).
+    """
     # already a path-like?
     if isinstance(obj, (str, os.PathLike)):
         return str(obj)
@@ -142,18 +149,21 @@ def _as_path_like(obj) -> str:
     if hasattr(obj, "read"):
         with tempfile.NamedTemporaryFile(suffix=".sas7bdat", delete=False) as tmp:
             tmp.write(obj.read())
-            return tmp.name
+        stack.callback(lambda p=tmp.name: os.unlink(p) if os.path.exists(p) else None)
+        return tmp.name
     raise TypeError("data_path must be a path or a file-like object")
 
 
-def _maybe_from_zip(path: str) -> tuple[str, str | None]:
+def _maybe_from_zip(path: str, stack: ExitStack) -> tuple[str, str | None]:
     """
     Extract SAS files from a zip archive.
     Returns (sas_path, catalog_path_or_None).
 
-    Note: Creates temporary files in a system temp directory.
-    The caller doesn't need to clean up - the OS will handle it eventually,
-    but for immediate cleanup you could track the temp dir if needed.
+    Extraction goes into a fresh private directory (not the shared system
+    temp dir, whose predictable member-derived paths invited cross-run
+    collisions and symlink planting on multi-user machines).  The
+    directory is removed when ``stack`` closes, right after the native
+    parse — the caller never needs the extracted files afterwards.
     """
     if not str(path).lower().endswith(".zip"):
         return path, None
@@ -181,10 +191,9 @@ def _maybe_from_zip(path: str) -> tuple[str, str | None]:
                 UserWarning,
             )
 
-        # Extract to temp directory
-        # Note: Using tempfile with delete=False means files persist
-        # but are in the system temp dir which gets cleaned periodically
-        temp_base = tempfile.gettempdir()
+        # Private per-call extraction dir, cleaned up with the stack.
+        temp_base = tempfile.mkdtemp(prefix="svy_io_zip_")
+        stack.callback(shutil.rmtree, temp_base, ignore_errors=True)
 
         # Extract data file
         sas_path = z.extract(sas_files[0], path=temp_base)
@@ -571,27 +580,30 @@ def read_sas(
         }
         return empty, meta
 
-    data_path = _as_path_like(data_path)
+    # Temp artifacts (spooled file-like inputs, zip extraction dir) live
+    # only for the duration of the native parse.
+    with ExitStack() as _tmp_stack:
+        data_path = _as_path_like(data_path, _tmp_stack)
 
-    # Handle zip files
-    if str(data_path).lower().endswith(".zip"):
-        extracted_path, extracted_catalog = _maybe_from_zip(data_path)
-        data_path = extracted_path
-        # Use extracted catalog if no explicit catalog_path was provided
-        if catalog_path is None and extracted_catalog:
-            catalog_path = extracted_catalog
-    elif catalog_path is not None:
-        catalog_path = _as_path_like(catalog_path)
+        # Handle zip files
+        if str(data_path).lower().endswith(".zip"):
+            extracted_path, extracted_catalog = _maybe_from_zip(data_path, _tmp_stack)
+            data_path = extracted_path
+            # Use extracted catalog if no explicit catalog_path was provided
+            if catalog_path is None and extracted_catalog:
+                catalog_path = extracted_catalog
+        elif catalog_path is not None:
+            catalog_path = _as_path_like(catalog_path, _tmp_stack)
 
-    ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
-        data_path,
-        catalog_path,
-        encoding,
-        catalog_encoding,
-        cols_skip,
-        n_max,
-        rows_skip,
-    )
+        ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
+            data_path,
+            catalog_path,
+            encoding,
+            catalog_encoding,
+            cols_skip,
+            n_max,
+            rows_skip,
+        )
 
     # Robust loader: try FILE first; if footer is missing, use STREAM.
     bio = io.BytesIO(ipc_bytes)

--- a/packages/svy-io/python/svy_io/spss.py
+++ b/packages/svy-io/python/svy_io/spss.py
@@ -274,14 +274,12 @@ def read_sav(
     """Fast, file-like–safe SPSS .sav reader (ReadStat backend)."""
     n_max = _normalize_n_max(n_max)
 
-    if n_max == 0:
-        return pl.DataFrame({}), {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate below.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     normalized_cols_skip = _normalize_cols_skip(cols_skip)
 
@@ -307,6 +305,10 @@ def read_sav(
             df = pl.read_ipc_stream(bio)
         else:
             raise
+
+    if zero_rows:
+        df = df.head(0)
+        meta["n_rows"] = 0
 
     # Normalize names BEFORE downstream processing
     df, meta = _normalize_names(df, meta)
@@ -340,14 +342,12 @@ def read_por(
     """Fast, file-like–safe SPSS .por reader (ReadStat backend)."""
     n_max = _normalize_n_max(n_max)
 
-    if n_max == 0:
-        return pl.DataFrame({}), {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate below.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     normalized_cols_skip = _normalize_cols_skip(cols_skip)
 
@@ -372,6 +372,10 @@ def read_por(
             df = pl.read_ipc_stream(bio)
         else:
             raise
+
+    if zero_rows:
+        df = df.head(0)
+        meta["n_rows"] = 0
 
     df, meta = _normalize_names(df, meta)
 
@@ -512,14 +516,21 @@ def write_sav(
 
     for col_name in to_write.columns:
         if to_write[col_name].dtype == pl.Categorical:
-            cats = to_write[col_name].cat.get_categories()
+            # Encode against the categories actually present in THIS column.
+            # get_categories()/to_physical() reflect the dtype's category
+            # store, which under a global pl.StringCache contains every
+            # string interned by any column — leaking foreign labels and
+            # cache-order-dependent codes into the file.
+            str_col = to_write[col_name].cast(pl.String)
+            cats = str_col.drop_nulls().unique(maintain_order=True).to_list()
+            code_map = {c: float(i + 1) for i, c in enumerate(cats)}
 
-            # Convert to 1-based codes
-            codes = (to_write[col_name].to_physical() + 1).cast(pl.Float64)
+            # Convert to per-column 1-based codes
+            codes = str_col.replace_strict(code_map, default=None, return_dtype=pl.Float64)
             categorical_exprs.append(codes.alias(col_name))
 
-            # Create value labels
-            labels = {str(i + 1): cats[i] for i in range(len(cats))}
+            # Create value labels (only this column's categories)
+            labels = {str(i + 1): c for i, c in enumerate(cats)}
             categorical_labels[col_name] = labels
 
     if categorical_exprs:

--- a/packages/svy-io/python/svy_io/spss.py
+++ b/packages/svy-io/python/svy_io/spss.py
@@ -16,6 +16,7 @@ import svy_io.svyreadstat_rs as native
 
 from .helpers import _as_path, _normalize_n_max
 from .labelled import LabelledSPSS, labelled_spss
+from .metadata import normalize_user_missing
 
 
 # -------------------- User-defined missing integration --------------------
@@ -78,14 +79,12 @@ def _hydrate_user_missing(
 
     if user_na:
         labelled_columns: Dict[str, LabelledSPSS] = {}
-        user_missing_list = []
 
         for var in meta.get("vars", []):
             col_name = var["name"]
             if col_name not in df.columns or not var.get("user_missing"):
                 continue
 
-            user_miss = var["user_missing"]
             label_set = var.get("label_set")
             value_labels = value_label_sets.get(label_set) if label_set else None
 
@@ -93,16 +92,7 @@ def _hydrate_user_missing(
             labelled_col = _apply_user_missing_to_column(values, var, value_labels)
             labelled_columns[col_name] = labelled_col
 
-            # Build missing spec
-            missing_spec = {"col": col_name}
-            if user_miss.get("values"):
-                missing_spec["values"] = user_miss["values"]
-            if user_miss.get("range"):
-                missing_spec["range"] = user_miss["range"]
-            user_missing_list.append(missing_spec)
-
         meta["labelled_columns"] = labelled_columns
-        meta["user_missing"] = user_missing_list
     else:
         # Vectorized conversion to null
         replacements = []
@@ -145,6 +135,11 @@ def _hydrate_user_missing(
 
         if replacements:
             df = df.with_columns(replacements)
+
+    # Canonical user-missing schema, rebuilt from the per-variable
+    # definitions (post-rename), so zap_missing and downstream consumers
+    # see one shape regardless of user_na.
+    meta["user_missing"] = normalize_user_missing(meta)
 
     return df, meta
 
@@ -192,6 +187,13 @@ def get_user_missing_for_column(meta: dict, col_name: str) -> dict[str, Any] | N
 # ---------------- Name normalization ----------------
 
 
+def _normalize_one_name(name: str) -> str:
+    nc = name.strip().lower().replace(".", "_").replace(" ", "_").replace("-", "_")
+    while "__" in nc:
+        nc = nc.replace("__", "_")
+    return nc.strip("_")
+
+
 def _normalize_names(
     df: pl.DataFrame, meta: Dict[str, Any]
 ) -> tuple[pl.DataFrame, Dict[str, Any]]:
@@ -201,28 +203,41 @@ def _normalize_names(
     - lowercase
     - replace dots/spaces/dashes with underscores
     - collapse multiple underscores
+
+    Collisions (two source columns normalizing to the same name, e.g.
+    "A.B" and "a_b") disambiguate with a numeric suffix instead of
+    producing a duplicate-column rename error.
     """
     rename: Dict[str, str] = {}
+    taken = set(df.columns)
 
     for c in df.columns:
-        nc = c.strip().lower().replace(".", "_").replace(" ", "_").replace("-", "_")
-        while "__" in nc:
-            nc = nc.replace("__", "_")
-        nc = nc.strip("_")
-
-        if nc != c:
-            rename[c] = nc
+        nc = _normalize_one_name(c)
+        if nc == c:
+            continue
+        # Disambiguate collisions with columns that already have (or will
+        # get) the normalized name.
+        candidate = nc
+        suffix = 1
+        while candidate in (taken - {c}) or candidate in rename.values():
+            suffix += 1
+            candidate = f"{nc}_{suffix}"
+        rename[c] = candidate
+        taken.add(candidate)
 
     if rename:
         df = df.rename(rename)
 
     for v in meta.get("vars", []):
         if isinstance(v.get("name"), str):
-            orig = v["name"]
-            normalized = orig.strip().lower().replace(".", "_").replace(" ", "_").replace("-", "_")
-            while "__" in normalized:
-                normalized = normalized.replace("__", "_")
-            v["name"] = normalized.strip("_")
+            v["name"] = rename.get(v["name"], _normalize_one_name(v["name"]))
+
+    # Keep user-missing specs pointing at the renamed columns.
+    for spec in meta.get("user_missing") or []:
+        col = spec.get("col") or spec.get("var")
+        if isinstance(col, str):
+            key = "col" if "col" in spec else "var"
+            spec[key] = rename.get(col, _normalize_one_name(col))
 
     return df, meta
 

--- a/packages/svy-io/python/svy_io/stata.py
+++ b/packages/svy-io/python/svy_io/stata.py
@@ -134,16 +134,12 @@ def read_dta(
         from svy_io.sas import apply_value_labels  # reuse shared impl
 
     n_max = _normalize_n_max(n_max)
-    if n_max == 0:
-        empty = pl.DataFrame({})
-        meta: Dict[str, Any] = {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
-        return empty, meta
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate after parsing.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     # Rust does the heavy lifting here (with GIL released).
     with _as_path(data_path) as _path:
@@ -168,6 +164,10 @@ def read_dta(
             df = pl.read_ipc_stream(bio)
         else:
             raise
+
+    if zero_rows:
+        df = df.head(0)
+        meta["n_rows"] = 0
 
     # Apply transformations
     if coerce_temporals:
@@ -201,16 +201,12 @@ def read_stata_arrow(
     from pyarrow import ArrowInvalid
 
     n_max = _normalize_n_max(n_max)
-    if n_max == 0:
-        empty = pa.table({})
-        meta = {
-            "file_label": None,
-            "vars": [],
-            "value_labels": [],
-            "user_missing": [],
-            "n_rows": 0,
-        }
-        return empty, meta
+    # n_max=0: still open and validate the file, returning the full schema
+    # and metadata with zero rows (haven behavior). The native layer treats
+    # n_max=0 as 1, so fetch one row and truncate after parsing.
+    zero_rows = n_max == 0
+    if zero_rows:
+        n_max = 1
 
     with _as_path(data_path) as _path:
         ipc_bytes, meta_json = native.df_parse_dta_file(  # type: ignore[attr-defined]
@@ -229,6 +225,9 @@ def read_stata_arrow(
 
     meta = json.loads(meta_json)
     meta["user_missing"] = normalize_user_missing(meta)
+    if zero_rows:
+        table = table.slice(0, 0)
+        meta["n_rows"] = 0
     return table, meta
 
 
@@ -238,9 +237,16 @@ def read_stata_arrow(
 
 
 def _stata_file_format(version: int) -> int:
-    """Pre-computed dict lookup"""
+    """Map a Stata release (8-15) or internal format code to a format code."""
     v = int(version)
+    # Internal format codes: only these actually exist (116 and 120 don't).
+    _VALID_FORMATS = {113, 114, 115, 117, 118, 119}
     if v >= 113:
+        if v not in _VALID_FORMATS:
+            raise ValueError(
+                f"Unsupported Stata file format {version!r} "
+                f"(valid formats: {sorted(_VALID_FORMATS)}, or Stata versions 8-15)"
+            )
         return v
 
     version_map = {
@@ -385,9 +391,15 @@ def _adjust_temporals(df: pl.DataFrame, *, adjust_tz: bool) -> pl.DataFrame:
                 else s.dt.convert_time_zone("UTC").dt.replace_time_zone(None)
             )
             new_series.append(s2.alias(name))
-        except Exception:
-            # If any conversion fails, skip that column silently
-            pass
+        except (pl.exceptions.PolarsError, ValueError) as ex:
+            import warnings
+
+            warnings.warn(
+                f"Could not adjust timezone for column {name!r}; "
+                f"writing it unchanged ({ex}).",
+                UserWarning,
+                stacklevel=2,
+            )
 
     return df.with_columns(new_series) if new_series else df
 

--- a/packages/svy-io/python/svy_io/stata.py
+++ b/packages/svy-io/python/svy_io/stata.py
@@ -17,6 +17,7 @@ from polars.exceptions import ComputeError
 
 import svy_io.svyreadstat_rs as native
 
+from .metadata import normalize_user_missing
 from .helpers import _as_path, _normalize_n_max
 from .tagged_na import TaggedNA
 
@@ -155,6 +156,7 @@ def read_dta(
 
     # Parse JSON once
     meta: Dict[str, Any] = json.loads(meta_json)
+    meta["user_missing"] = normalize_user_missing(meta)
 
     # Read IPC with proper error handling
     bio = io.BytesIO(ipc_bytes)
@@ -226,6 +228,7 @@ def read_stata_arrow(
         table = pa_ipc.open_stream(bio).read_all()
 
     meta = json.loads(meta_json)
+    meta["user_missing"] = normalize_user_missing(meta)
     return table, meta
 
 

--- a/packages/svy-io/python/svy_io/zap.py
+++ b/packages/svy-io/python/svy_io/zap.py
@@ -104,14 +104,6 @@ def zap_labels(
 ) -> Tuple[pl.DataFrame, Dict[str, Any]]: ...
 
 
-def _zap_labels_meta(meta: Dict[str, Any]) -> Dict[str, Any]:
-    out = copy.deepcopy(meta)
-    for v in out.get("vars", []):
-        v["label_set"] = None
-    out["value_labels"] = []
-    return out
-
-
 def zap_labels(obj, meta: Dict[str, Any] | None = None, *, user_na: bool = False):
     """
     Remove value labels.

--- a/packages/svy-io/tests/test_labelled_spss.py
+++ b/packages/svy-io/tests/test_labelled_spss.py
@@ -520,3 +520,9 @@ def test_realistic_spss_workflow():
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])
+
+
+def test_to_int_preserves_missing_as_none():
+    """Regression: to_int used to map None -> 0, a legitimate value."""
+    x = labelled_spss([1.0, None, 3.0], {1.0: "One"}, na_values=[9.0])
+    assert x.to_int() == [1, None, 3]

--- a/packages/svy-io/tests/test_sas_flags.py
+++ b/packages/svy-io/tests/test_sas_flags.py
@@ -48,3 +48,21 @@ def test_coerce_temporals_datetime_file():
     # VAR5: TIME (seconds since midnight) -> Duration
     assert df.schema["VAR5"] == pl.Duration
     assert df["VAR5"][0] == timedelta(seconds=52932)
+
+
+def test_n_max_zero_returns_schema_and_metadata():
+    """n_max=0 must open the file: full schema + metadata, zero rows
+    (haven behavior), not a schemaless empty frame."""
+    sas_file = next((Path(__file__).parent / "data" / "sas").glob("*.sas7bdat"))
+    df, meta = read_sas(sas_file, n_max=0)
+    assert df.height == 0
+    assert len(df.columns) > 0
+    assert [v["name"] for v in meta["vars"]] == df.columns
+    assert meta["n_rows"] == 0
+
+
+def test_n_max_zero_nonexistent_path_raises():
+    import pytest
+
+    with pytest.raises(Exception):
+        read_sas(Path(__file__).parent / "data" / "sas" / "does_not_exist.sas7bdat", n_max=0)

--- a/packages/svy-io/tests/test_spss.py
+++ b/packages/svy-io/tests/test_spss.py
@@ -797,3 +797,24 @@ def test_write_sav_does_not_mutate_caller_value_labels():
             os.unlink(tmp_path)
 
     assert value_labels == before
+
+
+def test_write_sav_labels_per_column_under_global_string_cache(tmp_path):
+    """Regression: under a global pl.StringCache, categorical columns used to
+    emit value labels for EVERY string in the cache (and cache-order codes),
+    not just their own categories."""
+    with pl.StringCache():
+        df = pl.DataFrame(
+            {
+                "a": pl.Series(["x", "y", "x"]).cast(pl.Categorical),
+                "b": pl.Series(["p", "q", "q"]).cast(pl.Categorical),
+            }
+        )
+    path = tmp_path / "cache.sav"
+    write_sav(df, path)
+    _, meta = read_sav(path)
+
+    by_col = {v["name"]: v.get("label_set") for v in meta["vars"]}
+    label_sets = {vl["set_name"]: vl["mapping"] for vl in meta["value_labels"]}
+    assert set(label_sets[by_col["a"]].values()) == {"x", "y"}
+    assert set(label_sets[by_col["b"]].values()) == {"p", "q"}

--- a/packages/svy-io/tests/test_spss.py
+++ b/packages/svy-io/tests/test_spss.py
@@ -252,9 +252,9 @@ def test_user_defined_missing_values_can_be_preserved(test_data_dir):
     col = df.columns[0]
     assert df[col][1] == 9
 
-    # Check metadata for na_values
+    # Check metadata for na_values (canonical schema: col/na_values/na_range)
     user_missing = meta.get("user_missing", [])
-    assert any(um.get("col") == col and 9 in um.get("values", []) for um in user_missing)
+    assert any(um.get("col") == col and 9 in um.get("na_values", []) for um in user_missing)
 
 
 def test_system_missings_read_as_none():

--- a/packages/svy-io/tests/test_stata.py
+++ b/packages/svy-io/tests/test_stata.py
@@ -448,3 +448,14 @@ def test_write_dta_returns_input_unaltered_invisibly(tmp_path):
     out = tmp_path / "inv.dta"
     df_returned = _write_dta(df, out, version=118)
     assert df_returned is df
+
+
+def test_stata_nonexistent_format_codes_rejected():
+    """116 and 120 are not real Stata file formats."""
+    from svy_io.stata import _stata_file_format
+
+    assert _stata_file_format(118) == 118
+    assert _stata_file_format(15) == 119
+    for bad in (116, 120, 130):
+        with pytest.raises(ValueError):
+            _stata_file_format(bad)

--- a/packages/svy-io/tests/test_zap.py
+++ b/packages/svy-io/tests/test_zap.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 
 import copy
 
+from pathlib import Path
+
 import polars as pl
 import polars.testing as plt
 import pytest
@@ -218,3 +220,31 @@ def test_zap_missing_converts_tagged_na_in_series():
     df = pl.DataFrame({"x": [1.0, tagged_na("a"), 3.0]}, strict=False)
     out = zap_missing(df, meta={"vars": [], "value_labels": [], "user_missing": []})
     assert out["x"].to_list() == [1.0, None, 3.0]
+
+
+def test_zap_missing_works_on_real_read_sav_metadata():
+    """Regression: zap_missing must consume the metadata read_sav actually
+    produces (three schemas used to coexist and zap matched none of them,
+    silently doing nothing)."""
+    from svy_io import read_sav
+
+    fixture = Path(__file__).parent / "data" / "spss" / "labelled-num-na.sav"
+    df, meta = read_sav(fixture, user_na=True)
+    col = df.columns[0]
+    assert 9.0 in df[col].to_list()  # user_na preserved the sentinel
+
+    out = zap_missing(df, meta)
+    assert 9.0 not in out[col].to_list()
+    assert out[col].null_count() == 1
+
+
+def test_read_sav_user_missing_schema_is_canonical():
+    """All readers emit one schema: {col, na_values, na_range}."""
+    from svy_io import read_sav
+
+    fixture = Path(__file__).parent / "data" / "spss" / "labelled-num-na.sav"
+    _, meta = read_sav(fixture, user_na=True)
+    (spec,) = meta["user_missing"]
+    assert set(spec) == {"col", "na_values", "na_range"}
+    assert spec["na_values"] == [9.0]
+    assert spec["na_range"] is None


### PR DESCRIPTION
Round 4 (Python side) of the 2026-07 review: svy-io data handling.

## One `user_missing` schema instead of three

The native layer emitted `{var, discrete, ranges}`,
`read_sav(user_na=True)` rewrote metadata to `{col, values, range}`, and
`zap_missing` looked for `na_values`/`na_range` — keys no producer ever
wrote. Zapping metadata from a real `read_sav` silently did nothing;
the zap tests passed only on hand-crafted dicts.

All readers now emit one haven-compatible schema — `{col, na_values,
na_range}` per column — via a single `normalize_user_missing()`
converter built from the per-variable definitions and tolerant of the
legacy shapes. `_normalize_names` gained collision handling ("A.B" and
"a_b" no longer collapse into a duplicate-rename error) and renames
user-missing cols alongside. New regression tests exercise
`zap_missing` through a real `read_sav` fixture.

## Temp file hygiene in `read_sas`

Zip archives extracted to predictable member-derived paths in the
shared system temp dir and were never cleaned up (cross-run collisions,
symlink planting on multi-user machines); file-like inputs leaked
`delete=False` spool files. All temp artifacts now live in a per-call
private dir / tracked spool scoped to an `ExitStack` that closes right
after the native parse.

## Edge-case batch

- `n_max=0` (6 reader sites) now opens and validates the file and
  returns the full schema + metadata with zero rows (haven behavior)
  instead of a schemaless empty frame; nonexistent paths fail.
- `write_sav` under a global `pl.StringCache` emitted value labels for
  every string in the cache with cache-order codes; columns are now
  encoded against their own observed categories with per-column 1-based
  codes.
- `as_factor_expr(levels="labels")`: unlabelled values map to null
  (haven behavior) instead of keeping raw values.
- `LabelledSPSS.to_int()`: missing stays `None`, no longer becomes 0.
- `_stata_file_format` rejects nonexistent format codes (116, 120).
- `_adjust_temporals`' bare `except: pass` narrowed + warns.
- Deleted the duplicate `_zap_labels_meta` that shadowed the
  `_require_meta` check.

## Testing

161 passed, 9 skipped, 11 xfailed, 3 xpassed (baseline was 155 passed;
8 new tests). One existing assertion updated to the canonical schema
key (`values` → `na_values`), per the schema unification.

Native-layer items (4.4: encoding surfacing, n_rows with cols_skip,
bindgen dedup, width validation) follow in a separate PR.