### PR TITLE
fix(svy-rs): stratified jackknife — per-stratum rscales, df, mse centering (round 3, part B)

### DIFF
--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -85,7 +85,7 @@ pub fn replicate_coefficients(method: RepMethod, n_reps: usize, fay_coef: f64) -
 /// * `rep_coefs` - Replicate coefficients
 /// * `center` - Centering method (ReplicateMean or FullSample)
 pub fn variance_from_replicates(
-    method: RepMethod,
+    _method: RepMethod,
     theta_full: f64,
     theta_reps: &[f64],
     rep_coefs: &[f64],
@@ -96,71 +96,31 @@ pub fn variance_from_replicates(
         return 0.0;
     }
 
-    match method {
-        RepMethod::Jackknife => {
-            // Jackknife pseudo-value approach (unchanged)
-            // For JK1 with coef = (n-1)/n:
-            // factor = 1 / (1 - coef) = n
-            // pseudo = factor * theta_full - (factor - 1) * theta_rep
+    // One formula for every replication method (R's svrVar):
+    //   v = sum_r c_r * (theta_r - center)^2
+    // with c_r the per-replicate coefficient (scale * rscales_r) and the
+    // center either the replicate mean (mse=FALSE) or the full-sample
+    // estimate (mse=TRUE).
+    //
+    // The jackknife previously went through an equivalent pseudo-value
+    // construction that (a) silently ignored `center`, so requesting R's
+    // mse=TRUE returned the mse=FALSE estimator, and (b) degenerated for
+    // any coefficient >= 1 (factor -> inf contributed 0), which broke
+    // per-stratum JKn/JK2 rscales. For uniform coefficients and
+    // replicate-mean centering the two are algebraically identical.
+    let center_value = match center {
+        VarianceCenter::ReplicateMean => theta_reps.iter().sum::<f64>() / n_reps as f64,
+        VarianceCenter::FullSample => theta_full,
+    };
 
-            let factors: Vec<f64> = rep_coefs
-                .iter()
-                .map(|&c| {
-                    if c < 1.0 {
-                        1.0 / (1.0 - c)
-                    } else {
-                        f64::INFINITY
-                    }
-                })
-                .collect();
-
-            // Compute pseudo values
-            let pseudo: Vec<f64> = theta_reps
-                .iter()
-                .zip(factors.iter())
-                .map(|(&rep, &f)| f * theta_full - (f - 1.0) * rep)
-                .collect();
-
-            // Center (mean of pseudo values)
-            let center: f64 = pseudo.iter().sum::<f64>() / n_reps as f64;
-
-            // Variance = sum(c * ((pseudo - center) / (factor - 1))^2)
-            let var: f64 = pseudo
-                .iter()
-                .zip(rep_coefs.iter())
-                .zip(factors.iter())
-                .map(|((&p, &c), &f)| {
-                    let denom = f - 1.0;
-                    if denom > 0.0 {
-                        let diff = (p - center) / denom;
-                        c * diff * diff
-                    } else {
-                        0.0
-                    }
-                })
-                .sum();
-
-            var
-        }
-        RepMethod::SDR | RepMethod::BRR | RepMethod::Bootstrap => {
-            // Choose centering point based on parameter
-            let center_value = match center {
-                VarianceCenter::ReplicateMean => theta_reps.iter().sum::<f64>() / n_reps as f64,
-                VarianceCenter::FullSample => theta_full,
-            };
-
-            let var: f64 = theta_reps
-                .iter()
-                .zip(rep_coefs.iter())
-                .map(|(&rep, &c)| {
-                    let diff = rep - center_value;
-                    c * diff * diff
-                })
-                .sum();
-
-            var
-        }
-    }
+    theta_reps
+        .iter()
+        .zip(rep_coefs.iter())
+        .map(|(&rep, &c)| {
+            let diff = rep - center_value;
+            c * diff * diff
+        })
+        .sum()
 }
 
 // ============================================================================

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -86,7 +86,7 @@ fn parse_variance_center(center: &str) -> PyResult<VarianceCenter> {
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_mean(
     _py: Python,
     data: PyDataFrame,
@@ -95,6 +95,7 @@ pub fn replicate_mean(
     rep_weight_cols: Vec<String>,
     method: String,
     fay_coef: f64,
+    rscales: Option<Vec<f64>>,
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
@@ -104,15 +105,24 @@ pub fn replicate_mean(
     let n_reps = rep_weight_cols.len();
     let rep_method       = parse_rep_method(&method)?;
     let variance_center  = parse_variance_center(center)?;
+    if let Some(r) = &rscales {
+        if r.len() != n_reps {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "rscales has {} entries but there are {} replicate weight columns",
+                r.len(),
+                n_reps
+            )));
+        }
+    }
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_mean_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_mean_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, by_col.as_ref().unwrap())
         }
     });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
@@ -121,7 +131,8 @@ pub fn replicate_mean(
 fn compute_replicate_mean_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -142,7 +153,8 @@ fn compute_replicate_mean_ungrouped(
             matrix_mean_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();
 
@@ -153,7 +165,8 @@ fn compute_replicate_mean_ungrouped(
 fn compute_replicate_mean_grouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     by_col: &str,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -174,7 +187,8 @@ fn compute_replicate_mean_grouped(
             matrix_mean_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);
     let mut estimates: Vec<f64> = Vec::with_capacity(n_domains);
@@ -201,7 +215,7 @@ fn compute_replicate_mean_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_total(
     _py: Python,
     data: PyDataFrame,
@@ -210,6 +224,7 @@ pub fn replicate_total(
     rep_weight_cols: Vec<String>,
     method: String,
     fay_coef: f64,
+    rscales: Option<Vec<f64>>,
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
@@ -219,15 +234,24 @@ pub fn replicate_total(
     let n_reps = rep_weight_cols.len();
     let rep_method      = parse_rep_method(&method)?;
     let variance_center = parse_variance_center(center)?;
+    if let Some(r) = &rscales {
+        if r.len() != n_reps {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "rscales has {} entries but there are {} replicate weight columns",
+                r.len(),
+                n_reps
+            )));
+        }
+    }
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_total_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_total_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, by_col.as_ref().unwrap())
         }
     });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
@@ -236,7 +260,8 @@ pub fn replicate_total(
 fn compute_replicate_total_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -255,7 +280,8 @@ fn compute_replicate_total_ungrouped(
             matrix_total_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();
 
@@ -266,7 +292,8 @@ fn compute_replicate_total_ungrouped(
 fn compute_replicate_total_grouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     by_col: &str,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -287,7 +314,8 @@ fn compute_replicate_total_grouped(
             matrix_total_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);
     let mut estimates: Vec<f64> = Vec::with_capacity(n_domains);
@@ -314,7 +342,7 @@ fn compute_replicate_total_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, numerator_col, denominator_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
+#[pyo3(signature = (data, numerator_col, denominator_col, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_ratio(
     _py: Python,
     data: PyDataFrame,
@@ -324,6 +352,7 @@ pub fn replicate_ratio(
     rep_weight_cols: Vec<String>,
     method: String,
     fay_coef: f64,
+    rscales: Option<Vec<f64>>,
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
@@ -333,16 +362,25 @@ pub fn replicate_ratio(
     let n_reps = rep_weight_cols.len();
     let rep_method      = parse_rep_method(&method)?;
     let variance_center = parse_variance_center(center)?;
+    if let Some(r) = &rscales {
+        if r.len() != n_reps {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "rscales has {} entries but there are {} replicate weight columns",
+                r.len(),
+                n_reps
+            )));
+        }
+    }
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_ratio_ungrouped(&df, &numerator_col, &denominator_col, &weight_col,
-                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
+                &rep_weight_cols, rep_method, fay_coef, rscales.as_deref(), variance_center, df_val,
                 domain_mask_col.as_deref())
         } else {
             compute_replicate_ratio_grouped(&df, &numerator_col, &denominator_col, &weight_col,
-                &rep_weight_cols, rep_method, fay_coef, variance_center, df_val,
+                &rep_weight_cols, rep_method, fay_coef, rscales.as_deref(), variance_center, df_val,
                 by_col.as_ref().unwrap())
         }
     });
@@ -353,7 +391,8 @@ fn compute_replicate_ratio_ungrouped(
     df: &DataFrame,
     numerator_col: &str, denominator_col: &str, weight_col: &str,
     rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(numerator_col)?.f64()?;
@@ -374,7 +413,8 @@ fn compute_replicate_ratio_ungrouped(
             matrix_ratio_estimates(&y_arr, &x_arr, &w_arr, &rep_w_matrix, n, n_reps, mask)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();
 
@@ -386,7 +426,8 @@ fn compute_replicate_ratio_grouped(
     df: &DataFrame,
     numerator_col: &str, denominator_col: &str, weight_col: &str,
     rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     by_col: &str,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(numerator_col)?.f64()?;
@@ -409,7 +450,8 @@ fn compute_replicate_ratio_grouped(
             matrix_ratio_by_domain(&y_arr, &x_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps)
         }
     };
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     let mut by_vals: Vec<String> = Vec::with_capacity(n_domains);
     let mut estimates: Vec<f64> = Vec::with_capacity(n_domains);
@@ -436,7 +478,7 @@ fn compute_replicate_ratio_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
 pub fn replicate_prop(
     _py: Python,
     data: PyDataFrame,
@@ -445,6 +487,7 @@ pub fn replicate_prop(
     rep_weight_cols: Vec<String>,
     method: String,
     fay_coef: f64,
+    rscales: Option<Vec<f64>>,
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
@@ -454,15 +497,24 @@ pub fn replicate_prop(
     let n_reps = rep_weight_cols.len();
     let rep_method      = parse_rep_method(&method)?;
     let variance_center = parse_variance_center(center)?;
+    if let Some(r) = &rscales {
+        if r.len() != n_reps {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "rscales has {} entries but there are {} replicate weight columns",
+                r.len(),
+                n_reps
+            )));
+        }
+    }
     let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
 
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_prop_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, domain_mask_col.as_deref())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, domain_mask_col.as_deref())
         } else {
             compute_replicate_prop_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap())
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, by_col.as_ref().unwrap())
         }
     });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
@@ -471,7 +523,8 @@ pub fn replicate_prop(
 fn compute_replicate_prop_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     domain_mask_col: Option<&str>,
 ) -> PolarsResult<DataFrame> {
     let y_series = df.column(value_col)?;
@@ -482,7 +535,8 @@ fn compute_replicate_prop_ungrouped(
     let cont_cols = get_cont_rep_cols(df, rep_weight_cols)?;
     let domain_mask = get_domain_mask(df, domain_mask_col)?;
     let mask = domain_mask.as_deref();
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     // String/Categorical: use string-keyed level functions so level labels are
     // preserved as-is without any numeric cast.
@@ -547,7 +601,8 @@ fn compute_replicate_prop_ungrouped(
 fn compute_replicate_prop_grouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     by_col: &str,
 ) -> PolarsResult<DataFrame> {
     let y_series = df.column(value_col)?;
@@ -559,7 +614,8 @@ fn compute_replicate_prop_grouped(
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     let is_string = matches!(y_series.dtype(), DataType::String | DataType::Categorical(_, _));
 
@@ -626,7 +682,7 @@ fn compute_replicate_prop_grouped(
 // ============================================================================
 
 #[pyfunction]
-#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, center="rep_mean", degrees_of_freedom=None, by_col=None, quantile_method=None))]
+#[pyo3(signature = (data, value_col, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, quantile_method=None))]
 pub fn replicate_median(
     _py: Python,
     data: PyDataFrame,
@@ -635,6 +691,7 @@ pub fn replicate_median(
     rep_weight_cols: Vec<String>,
     method: String,
     fay_coef: f64,
+    rscales: Option<Vec<f64>>,
     center: &str,
     degrees_of_freedom: Option<u32>,
     by_col: Option<String>,
@@ -644,6 +701,15 @@ pub fn replicate_median(
     let n_reps = rep_weight_cols.len();
     let rep_method      = parse_rep_method(&method)?;
     let variance_center = parse_variance_center(center)?;
+    if let Some(r) = &rscales {
+        if r.len() != n_reps {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "rscales has {} entries but there are {} replicate weight columns",
+                r.len(),
+                n_reps
+            )));
+        }
+    }
     let q_method = quantile_method
         .as_deref()
         .map(SvyQuantileMethod::from_str)
@@ -653,10 +719,10 @@ pub fn replicate_median(
     let result = _py.detach(|| {
         if by_col.is_none() {
             compute_replicate_median_ungrouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, q_method)
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, q_method)
         } else {
             compute_replicate_median_grouped(&df, &value_col, &weight_col, &rep_weight_cols,
-                rep_method, fay_coef, variance_center, df_val, by_col.as_ref().unwrap(), q_method)
+                rep_method, fay_coef, rscales.as_deref(), variance_center, df_val, by_col.as_ref().unwrap(), q_method)
         }
     });
     result.map(PyDataFrame).map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
@@ -665,7 +731,8 @@ pub fn replicate_median(
 fn compute_replicate_median_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     q_method: SvyQuantileMethod,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -678,7 +745,8 @@ fn compute_replicate_median_ungrouped(
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
     let (theta_full, theta_reps) =
         matrix_median_estimates(&y_arr, &w_arr, &rep_w_matrix, n, n_reps, q_method);
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
     let variance  = variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
     let se = variance.sqrt();
 
@@ -689,7 +757,8 @@ fn compute_replicate_median_ungrouped(
 fn compute_replicate_median_grouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str, rep_weight_cols: &[String],
-    method: RepMethod, fay_coef: f64, center: VarianceCenter, df_val: u32,
+    method: RepMethod, fay_coef: f64, rscales: Option<&[f64]>,
+    center: VarianceCenter, df_val: u32,
     by_col: &str, q_method: SvyQuantileMethod,
 ) -> PolarsResult<DataFrame> {
     let y = df.column(value_col)?.f64()?;
@@ -704,7 +773,8 @@ fn compute_replicate_median_grouped(
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
     let (theta_full_vec, theta_reps_vec, counts) =
         matrix_median_by_domain(&y_arr, &w_arr, &rep_w_matrix, &domain_ids, n_domains, n, n_reps, q_method);
-    let rep_coefs = replicate_coefficients(method, n_reps, fay_coef);
+    let rep_coefs = rscales.map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
 
     let mut by_vals:   Vec<String> = Vec::with_capacity(n_domains);
     let mut estimates: Vec<f64>    = Vec::with_capacity(n_domains);

--- a/packages/svy-rs/src/weighting/api.rs
+++ b/packages/svy-rs/src/weighting/api.rs
@@ -221,14 +221,14 @@ pub fn create_jk_wgts(
     stratum: Option<PyReadonlyArray1<i64>>,
     paired: bool,
     seed: Option<u64>,
-) -> PyResult<(Py<PyArray2<f64>>, f64)> {
+) -> PyResult<(Py<PyArray2<f64>>, f64, Vec<f64>)> {
     let stratum_view = stratum.as_ref().map(|s| s.as_array());
-    let (result, df) = crate::weighting::replication::create_jk_weights(
+    let (result, df, rscales) = crate::weighting::replication::create_jk_weights(
         wgt.as_array(), stratum_view, psu.as_array(), paired, seed,
     )
     .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
 
-    Ok((result.into_pyarray(py).to_owned().into(), df))
+    Ok((result.into_pyarray(py).to_owned().into(), df, rscales))
 }
 
 #[pyfunction]

--- a/packages/svy-rs/src/weighting/replication.rs
+++ b/packages/svy-rs/src/weighting/replication.rs
@@ -301,7 +301,7 @@ pub fn create_jk_weights(
     psu: ArrayView1<i64>,
     paired: bool,
     seed: Option<u64>,
-) -> Result<(Array2<f64>, f64)> {
+) -> Result<(Array2<f64>, f64, Vec<f64>)> {
     if paired {
         create_jk2_weights(wgt, stratum, psu, seed)
     } else {
@@ -309,12 +309,20 @@ pub fn create_jk_weights(
     }
 }
 
-/// JKn: delete-one-PSU-at-a-time
+/// JKn: delete-one-PSU-at-a-time.
+///
+/// Returns (replicate weights, design df, per-replicate rscales).
+/// df is the stratified-jackknife convention #PSUs - #strata (n - 1 for
+/// unstratified JK1); the previous total-PSU df was anti-conservative.
+/// rscales[r] = (n_h - 1)/n_h for the stratum whose PSU replicate r
+/// deletes — R's svrepdesign(type="JKn") convention. The estimation layer
+/// previously applied a global (R-1)/R to every replicate, which is only
+/// correct for unstratified JK1.
 pub fn create_jkn_weights(
     wgt: ArrayView1<f64>,
     stratum: Option<ArrayView1<i64>>,
     psu: ArrayView1<i64>,
-) -> Result<(Array2<f64>, f64)> {
+) -> Result<(Array2<f64>, f64, Vec<f64>)> {
     let n_obs = wgt.len();
     if psu.len() != n_obs {
         return Err(ReplicationError::DimensionMismatch {
@@ -384,16 +392,31 @@ pub fn create_jkn_weights(
     for (r, col) in rep_weights.into_iter().enumerate() {
         result.column_mut(r).assign(&col);
     }
-    Ok((result, n_reps as f64))
+
+    let n_strata = stratum_psus.len();
+    let df = (n_reps - n_strata) as f64;
+    let rscales: Vec<f64> = rep_to_stratum
+        .iter()
+        .map(|s| {
+            let nh = stratum_nh[s];
+            (nh - 1.0) / nh
+        })
+        .collect();
+    Ok((result, df, rscales))
 }
 
 /// JK2: paired jackknife (one replicate per stratum)
+/// Returns (replicate weights, design df, per-replicate rscales).
+/// One random delete-one replicate per stratum with the surviving PSUs
+/// reweighted by n_h/(n_h-1): the single-replicate-per-stratum jackknife,
+/// whose variance coefficient is 1.0 per replicate (a global (R-1)/R
+/// would understate the variance by that factor).
 fn create_jk2_weights(
     wgt: ArrayView1<f64>,
     stratum: Option<ArrayView1<i64>>,
     psu: ArrayView1<i64>,
     seed: Option<u64>,
-) -> Result<(Array2<f64>, f64)> {
+) -> Result<(Array2<f64>, f64, Vec<f64>)> {
     let n_obs = wgt.len();
     if psu.len() != n_obs {
         return Err(ReplicationError::DimensionMismatch {
@@ -472,7 +495,7 @@ fn create_jk2_weights(
     for (r, col) in rep_weights.into_iter().enumerate() {
         result.column_mut(r).assign(&col);
     }
-    Ok((result, n_reps as f64))
+    Ok((result, n_reps as f64, vec![1.0; n_reps]))
 }
 
 // ============================================================================
@@ -711,10 +734,13 @@ mod tests {
         let wgt = array![1.0, 1.0, 1.0, 1.0, 1.0, 1.0];
         let stratum = array![1, 1, 1, 2, 2, 2];
         let psu = array![1, 2, 3, 1, 2, 3];
-        let (rep_wgt, df) =
+        let (rep_wgt, df, rscales) =
             create_jkn_weights(wgt.view(), Some(stratum.view()), psu.view()).unwrap();
         assert_eq!(rep_wgt.dim(), (6, 6));
-        assert_eq!(df, 6.0);
+        // Stratified jackknife df = #PSUs - #strata (was: total PSUs).
+        assert_eq!(df, 4.0);
+        // R's JKn rscales: (n_h - 1)/n_h per replicate; 3 PSUs per stratum.
+        assert_eq!(rscales, vec![2.0 / 3.0; 6]);
     }
 
     #[test]
@@ -722,11 +748,12 @@ mod tests {
         let wgt = array![1.0, 1.0, 1.0, 1.0];
         let stratum = array![1, 1, 2, 2];
         let psu = array![1, 2, 1, 2];
-        let (rep_wgt, df) =
+        let (rep_wgt, df, rscales) =
             create_jk_weights(wgt.view(), Some(stratum.view()), psu.view(), true, Some(42))
                 .unwrap();
         assert_eq!(rep_wgt.dim(), (4, 2)); // 2 strata = 2 replicates
         assert_eq!(df, 2.0);
+        assert_eq!(rscales, vec![1.0; 2]);
     }
 
     #[test]

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -105,6 +105,13 @@ class RepWeights(msgspec.Struct, frozen=True):
     fay_coef: float = 0.0
     df: int | None = None  # None = "Calculate from data", Int = "User Override"
     padding: int | None = None  # None = auto-detect, 0 = no padding, >0 = zero-pad width
+    # Per-replicate variance coefficients (R's scale*rscales combined), e.g.
+    # (n_h-1)/n_h per deleted-PSU replicate for stratified JKn. None = the
+    # method's global default — correct for BRR/bootstrap/SDR/JK1, but for
+    # user-supplied stratified-JKn weights pass the file's documented
+    # rscales, or the variance uses (R-1)/R uniformly. svy-generated
+    # jackknife weights (create_jk_wgts) fill this automatically.
+    rscales: tuple[float, ...] | None = None
 
     def __post_init__(self):
         """
@@ -613,6 +620,7 @@ class Design:
         fay_coef: float | _MissingType = _MISSING,
         df: int | None | _MissingType = _MISSING,
         padding: int | None | _MissingType = _MISSING,
+        rscales: tuple[float, ...] | None | _MissingType = _MISSING,
     ) -> Self:
         """
         Return a new Design with selected RepWeights fields updated.
@@ -627,6 +635,7 @@ class Design:
             and isinstance(fay_coef, _MissingType)
             and isinstance(df, _MissingType)
             and isinstance(padding, _MissingType)
+            and isinstance(rscales, _MissingType)
         ):
             return self
 
@@ -663,6 +672,9 @@ class Design:
         if isinstance(padding, _MissingType):
             padding = cur.padding if cur else None
 
+        if isinstance(rscales, _MissingType):
+            rscales = cur.rscales if cur else None
+
         # 5. Create new RepWeights object
         _resolved_method = (
             _normalize_rep_method(resolved_method)
@@ -676,6 +688,7 @@ class Design:
             fay_coef=fay_coef,
             df=df,
             padding=padding,
+            rscales=rscales,
         )
 
         return self.update(rep_wgts=updated_rep_wgts)

--- a/packages/svy/src/svy/estimation/replication.py
+++ b/packages/svy/src/svy/estimation/replication.py
@@ -17,6 +17,7 @@ import polars as pl
 import svy_rs as rs
 
 from svy.core.enumerations import EstimationMethod, PopParam, QuantileMethod
+from svy.errors import DimensionError
 from svy.estimation.estimate import Estimate
 
 
@@ -109,7 +110,21 @@ def _get_rep_params(est: Estimation, fay_coef: float = 0.0):
     n_reps = len(rep_weight_cols)
     df_val = int(rw.df) if rw.df and rw.df > 0 else max(1, n_reps - 1)
     final_fay = float(fay_coef) if fay_coef != 0.0 else float(rw.fay_coef)
-    return rep_weight_cols, df_val, final_fay
+    # Per-replicate variance coefficients (e.g. stratified-JKn rscales).
+    # None -> the kernel's per-method global default.
+    rscales = list(rw.rscales) if rw.rscales is not None else None
+    if rscales is not None and len(rscales) != n_reps:
+        raise DimensionError(
+            title="rscales length mismatch",
+            detail=f"RepWeights.rscales has {len(rscales)} entries but "
+            f"{n_reps} replicate weight columns were resolved.",
+            code="RSCALES_LENGTH_MISMATCH",
+            where="estimation.replication",
+            param="rep_wgts.rscales",
+            expected=n_reps,
+            got=len(rscales),
+        )
+    return rep_weight_cols, df_val, final_fay, rscales
 
 
 # ---------------------------------------------------------------------------
@@ -201,7 +216,7 @@ def replicate_mean(
     variance_center: str = "rep_mean",
     alpha: float = 0.05,
 ) -> Estimate:
-    rep_weight_cols, df_val, final_fay = _get_rep_params(est, fay_coef)
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
     data = est._ensure_float64(prep.df, rep_weight_cols)
     result_df = rs.replicate_mean(
         data,
@@ -210,6 +225,7 @@ def replicate_mean(
         rep_weight_cols=rep_weight_cols,
         method=get_rep_method_str(method),
         fay_coef=final_fay,
+        rscales=rscales,
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
@@ -240,7 +256,7 @@ def replicate_total(
     variance_center: str = "rep_mean",
     alpha: float = 0.05,
 ) -> Estimate:
-    rep_weight_cols, df_val, final_fay = _get_rep_params(est, fay_coef)
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
     data = est._ensure_float64(prep.df, rep_weight_cols)
     result_df = rs.replicate_total(
         data,
@@ -249,6 +265,7 @@ def replicate_total(
         rep_weight_cols=rep_weight_cols,
         method=get_rep_method_str(method),
         fay_coef=final_fay,
+        rscales=rscales,
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
@@ -280,7 +297,7 @@ def replicate_ratio(
     variance_center: str = "rep_mean",
     alpha: float = 0.05,
 ) -> Estimate:
-    rep_weight_cols, df_val, final_fay = _get_rep_params(est, fay_coef)
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
     data = est._ensure_float64(prep.df, rep_weight_cols)
     result_df = rs.replicate_ratio(
         data,
@@ -290,6 +307,7 @@ def replicate_ratio(
         rep_weight_cols=rep_weight_cols,
         method=get_rep_method_str(method),
         fay_coef=final_fay,
+        rscales=rscales,
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
@@ -328,7 +346,7 @@ def replicate_prop(
     alpha: float = 0.05,
     ci_method: str = "logit",
 ) -> Estimate:
-    rep_weight_cols, df_val, final_fay = _get_rep_params(est, fay_coef)
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
     data = est._ensure_float64(prep.df, rep_weight_cols)
     data = est._coerce_y_for_prop(data, y)
     result_df = rs.replicate_prop(
@@ -338,6 +356,7 @@ def replicate_prop(
         rep_weight_cols=rep_weight_cols,
         method=get_rep_method_str(method),
         fay_coef=final_fay,
+        rscales=rscales,
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,
@@ -376,7 +395,7 @@ def replicate_median(
     variance_center: str = "rep_mean",
     alpha: float = 0.05,
 ) -> Estimate:
-    rep_weight_cols, df_val, final_fay = _get_rep_params(est, fay_coef)
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
     data = est._ensure_float64(prep.df, rep_weight_cols)
     q_method_str = q_method.value if hasattr(q_method, "value") else str(q_method).lower()
     result_df = rs.replicate_median(
@@ -386,6 +405,7 @@ def replicate_median(
         rep_weight_cols=rep_weight_cols,
         method=get_rep_method_str(method),
         fay_coef=final_fay,
+        rscales=rscales,
         center=variance_center,
         degrees_of_freedom=df_val,
         by_col=prep.by_col,

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -337,7 +337,7 @@ def create_jk_wgts(
     stratum_int = _to_int_array(data, design.stratum)
 
     assert rust_create_jk_wgts is not None  # noqa: S101
-    rep_mat, df_val = rust_create_jk_wgts(
+    rep_mat, df_val, rscales = rust_create_jk_wgts(
         main_weights,
         psu_int,
         stratum_int,
@@ -359,6 +359,9 @@ def create_jk_wgts(
             prefix=rep_prefix,
             n_reps=n_reps,
             df=df_val,
+            # Per-replicate (n_h-1)/n_h coefficients: exact stratified-JKn
+            # variance instead of the global (R-1)/R approximation.
+            rscales=tuple(rscales),
         )
     )
 

--- a/packages/svy/tests/svy/estimation/test_jackknife_r_validation.py
+++ b/packages/svy/tests/svy/estimation/test_jackknife_r_validation.py
@@ -1,0 +1,102 @@
+# tests/svy/estimation/test_jackknife_r_validation.py
+"""
+End-to-end validation of svy-GENERATED stratified jackknife (JKn) weights
+against R's survey package.
+
+The pre-existing golden replication tests use user-supplied replicate
+weights and therefore never exercised create_jk_wgts' own scale/df
+conventions — which is how a global (R-1)/R scale (exactly 7/6 off vs R
+on this design), a total-PSU df, and an ignored variance_center survived.
+
+Reference values from R survey 4.5 on domain_nulls_20260722.csv
+(2 strata x 4 clusters, income null for non-employed + 2 MAR nulls):
+
+    options(digits = 15)
+    library(survey)
+    d <- read.csv("tests/test_data/domain_nulls_20260722.csv")
+    des <- svydesign(id = ~cluster, strata = ~stratum, weights = ~wgt, data = d)
+    rdes     <- as.svrepdesign(des, type = "JKn")
+    rdes_mse <- as.svrepdesign(des, type = "JKn", mse = TRUE)
+    degf(rdes)                                # 6
+    svymean(~income, rdes, na.rm = TRUE)      # 42949.3221906951, SE 1718.17426740466
+    svymean(~income, rdes_mse, na.rm = TRUE)  # SE 1720.80068178043
+    svytotal(~income, rdes, na.rm = TRUE)     # 114554002.6538, SE 18830996.1797964
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from svy import Design, Sample
+
+
+BASE_DIR = Path(__file__).parents[2]
+
+REL = 1e-9
+
+
+@pytest.fixture
+def jk_sample() -> Sample:
+    df = pl.read_csv(BASE_DIR / "test_data" / "domain_nulls_20260722.csv")
+    s = Sample(df, Design(stratum="stratum", psu="cluster", wgt="wgt"))
+    return s.weighting.create_jk_wgts()
+
+
+class TestGeneratedJknMatchesR:
+    def test_df_and_rscales(self, jk_sample):
+        rw = jk_sample.design.rep_wgts
+        assert rw.n_reps == 8
+        # Stratified jackknife df = #PSUs - #strata (R degf; was total PSUs)
+        assert rw.df == 6
+        # (n_h - 1)/n_h per deleted-PSU replicate; 4 clusters per stratum
+        assert rw.rscales == (0.75,) * 8
+
+    def test_mean_matches_r(self, jk_sample):
+        r = jk_sample.estimation.mean("income", method="replication", drop_nulls=True)
+        e = r.estimates[0]
+        assert e.est == pytest.approx(42949.3221906951, rel=REL)
+        # Global (R-1)/R scale gave 1855.84 here — exactly sqrt(7/6) off
+        assert e.se == pytest.approx(1718.17426740466, rel=REL)
+
+    def test_mse_centering_matches_r(self, jk_sample):
+        """variance_center='estimate' == R's mse=TRUE. The jackknife branch
+        previously ignored the parameter and always centered on the
+        replicate mean."""
+        r = jk_sample.estimation.mean(
+            "income", method="replication", drop_nulls=True, variance_center="estimate"
+        )
+        assert r.estimates[0].se == pytest.approx(1720.80068178043, rel=REL)
+
+    def test_total_matches_r(self, jk_sample):
+        t = jk_sample.estimation.total("income", method="replication", drop_nulls=True)
+        assert t.estimates[0].est == pytest.approx(114554002.6538, rel=1e-9)
+        assert t.estimates[0].se == pytest.approx(18830996.1797964, rel=REL)
+
+    def test_user_rscales_override(self, jk_sample):
+        """User-supplied rscales flow through: doubling them scales the
+        variance by 2 (SE by sqrt 2)."""
+        import math
+
+        base = jk_sample.estimation.mean("income", method="replication", drop_nulls=True)
+        rw = jk_sample.design.rep_wgts
+        boosted = Sample(
+            jk_sample.data,
+            jk_sample.design.update_rep_weights(
+                method=rw.method,
+                prefix=rw.prefix,
+                n_reps=rw.n_reps,
+                df=rw.df,
+                rscales=tuple(2.0 * r for r in rw.rscales),
+            ),
+        )
+        r2 = boosted.estimation.mean("income", method="replication", drop_nulls=True)
+        assert r2.estimates[0].se == pytest.approx(
+            base.estimates[0].se * math.sqrt(2.0), rel=1e-12
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
The jackknife cluster from Round 3: items 3.4, 3.5, and the JKn scale
defect discovered during the domain-nulls (2.4) work.

## Per-stratum rscales (3.9)

Jackknife replicate variance used a global (R−1)/R coefficient for every
replicate — correct only for unstratified JK1. Stratified JKn needs
(n_h−1)/n_h per deleted-PSU replicate (measured exactly 7/6 off in
variance vs R on a 2-strata × 4-cluster design); paired JK2 needs 1.0
(its variance was understated by (L−1)/L).

- `create_jkn_weights` / `create_jk2_weights` now return the correct
  per-replicate rscales alongside the weights, and the replicate
  estimation kernels accept an optional `rscales` argument.
- `RepWeights` gains an optional `rscales` tuple. `create_jk_wgts`
  fills it automatically; for **user-supplied** replicate weights the
  method defaults are unchanged (there is no universal scale for
  external weights — pass the file's documented rscales to get exact
  variances, as with R's `svrepdesign(rscales=)`).

## mse centering (3.5)

`variance_from_replicates` routed jackknife through a pseudo-value
construction that silently ignored `variance_center` (R's `mse=TRUE`)
and degenerated for coefficients ≥ 1. Replaced with the direct svrVar
formula `Σ c_r (θ_r − center)²` — algebraically identical to the old
path for uniform coefficients with replicate-mean centering, and honors
`center=full_sample` for every method.

## df (3.4)

`create_jkn_weights` returned df = total PSUs; the standard stratified
jackknife df is #PSUs − #strata (n−1 for JK1), matching R's `degf`.
Applies to svy-generated weights; a user-specified `RepWeights.df`
still overrides.

## Why no existing test caught this

The golden replication tests use user-supplied CSV replicate weights
with an explicit df, so `create_jk_wgts`' own scale/df conventions were
never exercised — and the goldens themselves were generated by telling R
to use the implemented global scale (`svrepdesign(type="other",
scale=(R−1)/R)` reproduces the golden SE to all digits, while
`type="JKn"` gives a very different one). New end-to-end validation:
svy-generated JKn weights now reproduce R's `as.svrepdesign(type="JKn")`
mean/total SEs, `mse=TRUE`, and `degf` to 13+ digits, plus an
rscales-override propagation test.

## Testing

- svy-rs: cargo test 68 passed (JKn/JK2 tests updated to the new
  df/rscales contract)
- svy: 2622 passed, 1 skipped (5 new R-validated tests in
  `test_jackknife_r_validation.py`)
- Golden replication suites pass unchanged (user-supplied weights,
  uniform coefficients — bit-identical through the new formula)