### PR TITLE
fix(core): polish and API-consistency batch (review round 7)

### DIFF
--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -273,9 +273,11 @@ def _maybe_install_rich() -> None:
         return
     if want in {"1", "true", "yes", "on"}:
         enable = True
+        explicit = True
     else:  # "auto"
         # default: enable on TTY; disable under pytest unless forced
         enable = is_tty and not under_pytest
+        explicit = False
 
     if not enable:
         return
@@ -307,12 +309,17 @@ def _maybe_install_rich() -> None:
         # even though it looks unused after the last install() call.
         svy_console = Console(width=width)
 
+        # Pretty-printing only touches the interactive displayhook.
         pretty_install(console=svy_console)
-        tb_install(
-            console=svy_console,
-            show_locals=False,
-            extra_lines=1,
-        )
+        # Replacing sys.excepthook affects the whole host application (any
+        # program that merely imports svy), so Rich tracebacks are installed
+        # only on explicit opt-in (SVY_RICH=1) — never in "auto" mode.
+        if explicit:
+            tb_install(
+                console=svy_console,
+                show_locals=False,
+                extra_lines=1,
+            )
         sys._svy_rich_installed = True  # type: ignore[attr-defined]
     except Exception:
         # Never make import of svy fail just because Rich init blew up

--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -33,6 +33,7 @@ import polars as pl
 
 from svy.core.constants import _BY_SEP, _INTERNAL_CONCAT_SUFFIX
 from svy.core.types import WhereArg
+from svy.errors import DimensionError
 from svy.utils.checks import assert_no_missing, drop_missing
 from svy.utils.helpers import _colspec_to_list
 
@@ -112,7 +113,10 @@ def _get_design_codes(sample: Sample, design) -> dict[str, pl.Series] | None:
 # catches CPython id-reuse (a new design reusing a freed id), and the
 # data_version — globally unique per Sample mutation — catches the case where
 # the same design object persists while the underlying data columns change.
+# Bounded: cleared when it exceeds _DESIGN_FIELDS_CACHE_MAX so long-lived
+# processes creating many Samples don't pin Design objects forever.
 _design_fields_cache: dict[int, tuple] = {}
+_DESIGN_FIELDS_CACHE_MAX = 512
 
 # Internal column name for the materialized where-clause boolean mask.
 # Created and dropped within prepare_data; never exposed to the caller.
@@ -232,15 +236,28 @@ def _resolve_rep_weight_cols(data: pl.DataFrame, design) -> list[str]:
     data_cols = data.columns
 
     if rw.prefix:
-        prefix_lower = rw.prefix.lower()
+        # Strict `^prefix\d+$` matching (the same rule as
+        # RepWeights.columns_from_data). A loose startswith() absorbed any
+        # column sharing the prefix (e.g. 'repwt_flag' for prefix 'repwt')
+        # into the replicate set, corrupting the variance.
+        pattern = re.compile(rf"^{re.escape(rw.prefix)}\d+$", re.IGNORECASE)
         cols = sorted(
-            [
-                c
-                for c in data_cols
-                if c.lower().startswith(prefix_lower) and c.lower() != prefix_lower
-            ],
+            [c for c in data_cols if pattern.match(c)],
             key=lambda c: _natural_keys(c.lower()),
         )
+        if cols and len(cols) != rw.n_reps:
+            raise DimensionError(
+                title="Replicate weight column count mismatch",
+                detail=f"Found {len(cols)} columns matching '{rw.prefix}<number>' "
+                f"but RepWeights declares n_reps={rw.n_reps}.",
+                code="REP_WEIGHT_COUNT_MISMATCH",
+                where="core.data_prep",
+                param="rep_wgts",
+                expected=rw.n_reps,
+                got=len(cols),
+                hint="Check the replicate weight prefix and n_reps, or drop "
+                "stray columns that match the prefix-number pattern.",
+            )
     elif hasattr(rw, "wgts") and rw.wgts:
         # First-occurrence wins on case-insensitive collision.
         lower_index: dict[str, str] = {}
@@ -380,6 +397,8 @@ def prepare_data(
     cached = _design_fields_cache.get(key)
     if cached is None or cached[0] is not design or cached[1] != data_version:
         fields = design.specified_fields(data_columns=local_data.columns)
+        if len(_design_fields_cache) >= _DESIGN_FIELDS_CACHE_MAX:
+            _design_fields_cache.clear()
         _design_fields_cache[key] = (design, data_version, fields)
     else:
         fields = cached[2]

--- a/packages/svy/src/svy/core/describe_runtime.py
+++ b/packages/svy/src/svy/core/describe_runtime.py
@@ -149,6 +149,34 @@ def _desc_continuous(
             if denom and denom > 0 and s.len():
                 ssum = _to_float((s * w_nonnull).sum())
                 mean = (ssum / denom) if ssum is not None else None
+                # Weighted dispersion and quantiles: previously these kept
+                # their UNWEIGHTED values while the result said
+                # weighted=True. Variance follows the aweight convention
+                # (n/(n-1)) * sum(w (x-mean_w)^2) / sum(w); quantiles use
+                # the weighted inverted-CDF.
+                if mean is not None:
+                    n_eff = s.len()
+                    wss = _to_float(((s - mean) ** 2 * w_nonnull).sum())
+                    if wss is not None and n_eff > 1:
+                        var = (n_eff / (n_eff - 1)) * wss / denom
+                        std = var**0.5
+                    elif wss is not None:
+                        var = 0.0
+                        std = 0.0
+                sort_idx = s.arg_sort()
+                s_sorted = s.gather(sort_idx)
+                w_sorted = w_nonnull.gather(sort_idx)
+                cumw = w_sorted.cum_sum()
+
+                def _wq(p: float) -> float | None:
+                    target = p * denom
+                    ge = (cumw >= target - 1e-12).arg_max()
+                    if ge is None:
+                        return None
+                    return _to_float(s_sorted[int(ge)])
+
+                p25, p50, p75 = _wq(0.25), _wq(0.50), _wq(0.75)
+                q_items = [Quantile(p=float(p), value=_wq(float(p))) for p in percentiles]
 
     return DescribeContinuous(
         name=col,
@@ -202,44 +230,7 @@ def _desc_discrete(
         s = s_base
         w = _weight_series(df, weight_col)
 
-    if s.len() == 0:
-        levels: tuple[Freq, ...] = ()
-    else:
-        if weighted and w is not None:
-            tbl = (
-                pl.DataFrame({col: s, "_w": w})
-                .group_by(col)
-                .agg(pl.col("_w").sum().alias("count"))
-                .sort("count", descending=True)
-                .head(top_k)
-            )
-            denom = _to_float(tbl["count"].sum()) if tbl.height else 0.0
-            levels = tuple(
-                Freq(
-                    level=row[col],
-                    count=float(row["count"]),
-                    prop=(float(row["count"]) / denom if denom and denom > 0 else 0.0),
-                )
-                for row in tbl.iter_rows(named=True)
-            )
-        else:
-            tbl = (
-                pl.DataFrame({col: s})
-                .group_by(col)
-                .len()
-                .rename({"len": "count"})
-                .sort("count", descending=True)
-                .head(top_k)
-            )
-            denom = float(s.len())
-            levels = tuple(
-                Freq(
-                    level=row[col],
-                    count=float(row["count"]),
-                    prop=(float(row["count"]) / denom if denom > 0 else 0.0),
-                )
-                for row in tbl.iter_rows(named=True)
-            )
+    levels, _n_levels = _build_freqs(s, weighted=weighted, w=w, top_k=top_k)
 
     return DescribeDiscrete(
         name=cont.name,
@@ -267,44 +258,43 @@ def _build_freqs(
     weighted: bool,
     w: pl.Series | None,
     top_k: int,
-) -> tuple[Freq, ...]:
+) -> tuple[tuple[Freq, ...], int]:
+    """Return (top-k level frequencies, TRUE number of distinct levels).
+
+    Proportions are computed over ALL levels, not the displayed top-k
+    subset (the previous weighted branch renormalized over the top-k sum,
+    so displayed proportions summed to 1.0 even when levels were cut).
+    """
     if s.len() == 0:
-        return ()
+        return (), 0
     if weighted and w is not None:
-        tbl = (
+        full = (
             pl.DataFrame({"__k": s, "__w": w})
             .group_by("__k")
             .agg(pl.col("__w").sum().alias("count"))
             .sort("count", descending=True)
-            .head(top_k)
         )
-        denom = _to_float(tbl["count"].sum()) if tbl.height else 0.0
-        return tuple(
-            Freq(
-                level=row["__k"],
-                count=float(row["count"]),
-                prop=(float(row["count"]) / denom if denom and denom > 0 else 0.0),
-            )
-            for row in tbl.iter_rows(named=True)
-        )
+        denom = _to_float(full["count"].sum()) if full.height else 0.0
     else:
-        tbl = (
+        full = (
             pl.DataFrame({"__k": s})
             .group_by("__k")
             .len()
             .rename({"len": "count"})
             .sort("count", descending=True)
-            .head(top_k)
         )
         denom = float(s.len())
-        return tuple(
-            Freq(
-                level=row["__k"],
-                count=float(row["count"]),
-                prop=(float(row["count"]) / denom if denom > 0 else 0.0),
-            )
-            for row in tbl.iter_rows(named=True)
+    n_levels = int(full.height)
+    tbl = full.head(top_k)
+    levels = tuple(
+        Freq(
+            level=row["__k"],
+            count=float(row["count"]),
+            prop=(float(row["count"]) / denom if denom and denom > 0 else 0.0),
         )
+        for row in tbl.iter_rows(named=True)
+    )
+    return levels, n_levels
 
 
 def _desc_nominal_or_ordinal(
@@ -332,8 +322,8 @@ def _desc_nominal_or_ordinal(
     n_total = df.height
     n_missing = int(s_base.null_count())
 
-    levels = _build_freqs(s, weighted=weighted, w=w, top_k=top_k)
-    n_levels = int(len(levels))
+    levels, n_levels = _build_freqs(s, weighted=weighted, w=w, top_k=top_k)
+    truncated = n_levels > len(levels)
     mode = levels[0].level if levels else None
 
     if ordinal:
@@ -347,7 +337,7 @@ def _desc_nominal_or_ordinal(
             levels=levels,
             n_levels=n_levels,
             mode=mode,
-            truncated=False,
+            truncated=truncated,
         )
     return DescribeNominal(
         name=col,
@@ -359,7 +349,7 @@ def _desc_nominal_or_ordinal(
         levels=levels,
         n_levels=n_levels,
         mode=mode,
-        truncated=False,
+        truncated=truncated,
     )
 
 
@@ -390,19 +380,25 @@ def _desc_boolean(
         f_false = None
         f_true = None
     else:
+        # Nulls are missing, not False: count over the non-null subset
+        # (n_missing reports them separately). Previously, with
+        # drop_nulls=False every null row inflated the False bucket.
+        nn_mask = ~s.is_null()
+        s_nn = s.filter(nn_mask)
         if weighted and w is not None:
+            w_nn = w.filter(nn_mask)
             c_true = float(
-                pl.DataFrame({"b": s.cast(pl.Int8), "w": w})
+                pl.DataFrame({"b": s_nn.cast(pl.Int8), "w": w_nn})
                 .with_columns((pl.col("b") * pl.col("w")).alias("wt"))
                 .select(pl.col("wt").sum())
                 .item()
             )
-            c_false = float(w.sum()) - c_true
+            c_false = float(w_nn.sum()) - c_true
             denom = c_true + c_false
         else:
-            c_true = float(s.sum())
-            c_false = float(s.len() - s.sum())
-            denom = float(s.len())
+            c_true = float(s_nn.sum())
+            c_false = float(s_nn.len() - s_nn.sum())
+            denom = float(s_nn.len())
 
         p_true = (c_true / denom) if denom > 0 else 0.0
         p_false = (c_false / denom) if denom > 0 else 0.0
@@ -478,7 +474,7 @@ def _desc_string(
     n_total = df.height
     n_missing = int(s_base.null_count())
 
-    top = _build_freqs(s, weighted=weighted, w=w, top_k=top_k)
+    top, _n_levels = _build_freqs(s, weighted=weighted, w=w, top_k=top_k)
     try:
         n_unique = int(s.n_unique())
     except Exception:

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -425,8 +425,10 @@ def _norm_pop_size(
     if isinstance(value, PopSize):
         if not value.psu or not isinstance(value.psu, str):
             raise ValueError("PopSize.psu must be a non-empty string")
-        if not value.ssu or not isinstance(value.ssu, str):
-            raise ValueError("PopSize.ssu must be a non-empty string")
+        # ssu is optional: PopSize(psu=...) alone specifies a PSU-only FPC
+        # (the type signature always allowed it; validation rejected it).
+        if value.ssu is not None and (not value.ssu or not isinstance(value.ssu, str)):
+            raise ValueError("PopSize.ssu must be a non-empty string or None")
         return value
     if isinstance(value, str):
         if not value:

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -185,37 +185,9 @@ class Sample:
         if name == "_data" or name == "_design":
             object.__setattr__(self, "_data_version", _next_data_version())
 
-    def __hash__(self) -> int:
-        _d = (
-            cast(pl.DataFrame, self._data)
-            if not isinstance(self._data, pl.LazyFrame)
-            else cast(pl.DataFrame, self._data.collect())
-        )
-        sorted_data = _d.select(sorted(_d.columns))
-        row_hashes = sorted_data.hash_rows().to_list()
-        design_hash = hash(self._design) if self._design else hash(None)
-        return hash(tuple([design_hash] + row_hashes))
-
     # ════════════════════════════════════════════════════════════════════════
     # INITIALIZATION HELPERS
     # ════════════════════════════════════════════════════════════════════════
-
-    def _calculate_fpc(
-        self, pop_size: dict[Category, Number] | Number
-    ) -> dict[Category, Number] | Number:
-        if isinstance(pop_size, Number):
-            return int(1 - cast(pl.DataFrame, self._data).height / pop_size)
-        elif isinstance(pop_size, dict):
-            fpc: dict[Category, Number] = {}
-            for key, value in pop_size.items():
-                if not isinstance(key, str) or not isinstance(value, Number):
-                    raise TypeError("pop_size must be a Number or a dict[Categoryber, Number]")
-                fpc[key] = int(
-                    1 - cast(pl.DataFrame, self._data).shape[0] / sum(pop_size.values())
-                )
-            return fpc
-        else:
-            raise TypeError("pop_size must be a Number or a dict[Categoryber, Number]")
 
     # ════════════════════════════════════════════════════════════════════════
     # PRIVATE HELPERS FOR DUNDERS
@@ -1249,12 +1221,54 @@ class Sample:
         self._metadata.set_na_as_level(col, flag)
         return self
 
+    def _refresh_internal_state(self) -> None:
+        """Rebuild the internal concat columns, singleton detection and
+        design validation after the data or design is replaced.
+
+        Mirrors the tail of ``__init__``: without this, mutators left the
+        stale (or missing) ``*_svy_internal_cols_concatenated`` columns and
+        skipped singleton/validity checks entirely.
+        """
+        local_data = cast(pl.DataFrame, self._data)
+        if self._design is not None and any(
+            getattr(self._design, f, None) for f in ("stratum", "psu", "ssu")
+        ):
+            local_data, (_, stratum_cols, psu_cols, ssu_cols) = (
+                self._create_concatenated_cols_from_lists(
+                    data=local_data,
+                    design=self._design,
+                    by=None,
+                    null_token="__Null__",
+                    suffix=_INTERNAL_CONCAT_SUFFIX,
+                )
+            )
+            self._internal_design = {
+                "stratum": f"stratum{_INTERNAL_CONCAT_SUFFIX}" if stratum_cols else None,
+                "psu": f"psu{_INTERNAL_CONCAT_SUFFIX}" if psu_cols else None,
+                "ssu": f"ssu{_INTERNAL_CONCAT_SUFFIX}" if ssu_cols else None,
+                "suffix": _INTERNAL_CONCAT_SUFFIX,
+            }
+            self._data = local_data
+        else:
+            self._internal_design = {
+                "stratum": None,
+                "psu": None,
+                "ssu": None,
+                "suffix": _INTERNAL_CONCAT_SUFFIX,
+            }
+        self._check_for_singletons()
+        self._validate_design()
+
     def set_data(self, data: pl.DataFrame) -> Self:
         self._data = data
         if "svy_row_index" not in self._data.columns:
             self._data = self._data.with_row_index(name=SVY_ROW_INDEX)
         # Infer metadata for new columns (don't overwrite existing)
         self._metadata.infer_from_dataframe(self._data, overwrite=False)
+        # New data can change the design's validity and singleton structure;
+        # rebuild internal state exactly as __init__ does (version-keyed
+        # caches are already invalidated by the __setattr__ hook).
+        self._refresh_internal_state()
         return self
 
     def update_data(self, data: pl.DataFrame) -> Self:
@@ -1262,16 +1276,19 @@ class Sample:
         if "svy_row_index" not in self._data.columns:
             self._data = self._data.with_row_index(name=SVY_ROW_INDEX)
         self._metadata.align_to_dataframe(self._data)
+        self._refresh_internal_state()
         return self
 
     def set_design(self, design: Design) -> Self:
         """Replace the entire Design."""
         self._design = design
+        self._refresh_internal_state()
         return self
 
     def update_design(self, **kwargs) -> Self:
         """Update selected Design fields in place."""
         self._design = self._design.update(**kwargs)
+        self._refresh_internal_state()
         return self
 
     # ════════════════════════════════════════════════════════════════════════

--- a/packages/svy/src/svy/core/singleton.py
+++ b/packages/svy/src/svy/core/singleton.py
@@ -982,16 +982,21 @@ class Singleton:
 
         Notes
         -----
-        When variance is computed:
-        1. Singleton strata are excluded from the base variance calculation
-        2. The result is multiplied by: 1 / (1 - n_singletons / n_strata)
+        Singleton strata are excluded from the base variance calculation,
+        then the estimator-specific scaling matching R's
+        ``lonely.psu = "average"`` is applied (R-validated):
 
-        For example, if 20% of strata are singletons:
-        - Base variance is computed on the 80% of non-singleton strata
-        - Then multiplied by 1/0.8 = 1.25
+        - TOTAL: the variance is multiplied by ``1 / (1 - f)`` where
+          ``f = n_singletons / n_strata`` — e.g. with 20% singleton strata,
+          base variance on the other 80% is multiplied by ``1/0.8 = 1.25``.
+        - MEAN / PROP / RATIO: these are ratios of totals, whose linearized
+          variance already reflects the reduced stratum set; the adjustment
+          enters through the ``(1 - f)`` factor in the combined
+          linearization rather than a plain multiplication of the final
+          variance.
 
-        This assumes singleton strata would have contributed "average" variance
-        if they had multiple PSUs.
+        Both paths assume singleton strata would have contributed "average"
+        variance had they held multiple PSUs.
 
         Examples
         --------
@@ -1108,7 +1113,11 @@ class Singleton:
             "center": self.center,
         }
 
-        handler = dispatch.get(method.strip().lower())
+        # Accept both the enum and its string value ('.strip()' on a plain
+        # Enum raised AttributeError, so handle(SingletonHandling.POOL)
+        # crashed while handle("pool") worked).
+        key = method.strip().lower() if isinstance(method, str) else method
+        handler = dispatch.get(key)
         if handler is None:
             raise ValueError(f"Unknown method {method!r}. Use one of: {tuple(dispatch)}.")
 

--- a/packages/svy/src/svy/estimation/_fpc.py
+++ b/packages/svy/src/svy/estimation/_fpc.py
@@ -74,7 +74,9 @@ def compute_fpc_columns(
             data, psu_pop_col, strata_col, psu_col, _FPC_PSU_COL
         )
 
-        if ssu_pop_col in data.columns and psu_col is not None:
+        if ssu_pop_col is None:
+            pass  # PSU-only FPC: PopSize(psu=...) with no SSU stage
+        elif ssu_pop_col in data.columns and psu_col is not None:
             data, fpc_ssu_col_name = build_fpc_ssu_column(
                 data, ssu_pop_col, strata_col, psu_col, ssu_col, _FPC_SSU_COL
             )

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -1049,6 +1049,16 @@ class Estimation:
                 )
             return self._sample._design.rep_wgts.method
 
+        if normalized is None:
+            # Auto-detect, as documented: Taylor when the design carries
+            # structure for linearization; replication when the only
+            # variance information available is the replicate weights.
+            # (Previously None always resolved to Taylor, silently giving a
+            # replication-only design SRS-like variance.)
+            design = self._sample._design
+            if design.rep_wgts is not None and design.stratum is None and design.psu is None:
+                return design.rep_wgts.method
+
         return EstimationMethod.TAYLOR
 
     # ----------------------------------------------------------------

--- a/packages/svy/src/svy/estimation/replication.py
+++ b/packages/svy/src/svy/estimation/replication.py
@@ -49,13 +49,10 @@ def get_rep_weight_cols(est: Estimation) -> list[str]:
         return [int(c) if c.isdigit() else c for c in re.split(r"(\d+)", text)]
 
     if rw.prefix:
-        prefix_lower = rw.prefix.lower()
+        # Strict ^prefix\d+$ matching — see core.data_prep._resolve_rep_weight_cols.
+        pattern = re.compile(rf"^{re.escape(rw.prefix)}\d+$", re.IGNORECASE)
         cols = sorted(
-            [
-                c
-                for c in local_data.columns
-                if c.lower().startswith(prefix_lower) and c.lower() != prefix_lower
-            ],
+            [c for c in local_data.columns if pattern.match(c)],
             key=lambda c: natural_keys(c.lower()),
         )
     elif hasattr(rw, "wgts") and rw.wgts:

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -604,7 +604,12 @@ def polars_mask(col, scheme: CategoryScheme | None, kinds: set[MissingKind] | No
             codes = [code for code, mk in scheme.missing_kinds.items() if mk in kinds]
             if codes:
                 mask = mask | expr.is_in(codes)
-    return mask
+    # Null-safe: under Kleene logic `False | null = null`, and a null mask
+    # entry behaves differently depending on the consumer (when() takes the
+    # otherwise-branch; filter() drops the row). A null in any sub-check can
+    # only arise from a null input, which IS missing-by-policy, so pin the
+    # mask to True there explicitly.
+    return mask.fill_null(True)
 
 
 def polars_to_analysis(

--- a/packages/svy/tests/svy/estimation/test_bootstrap.py
+++ b/packages/svy/tests/svy/estimation/test_bootstrap.py
@@ -190,9 +190,23 @@ class TestBootstrapTotal:
 
 
 class TestBootstrapMethodResolution:
-    def test_default_is_taylor(self, boot_sample):
-        """With both wgt and rep_wgts, default should be Taylor."""
+    def test_default_autodetects_replication_only_design(self, boot_sample):
+        """boot_sample has weight + replicate weights but no strata/PSU:
+        the documented auto-detection resolves method=None to replication.
+        (Previously None always meant Taylor, silently giving a
+        replication-only design SRS-like variance.)"""
         result = boot_sample.estimation.mean(y="income")
+        assert result.method.name == "BOOTSTRAP"
+
+    def test_default_is_taylor_when_design_has_structure(self, boot_sample):
+        """With strata/PSU present, method=None still defaults to Taylor."""
+        import polars as pl
+
+        df = boot_sample.data.with_columns(
+            (pl.col("id") % 5).alias("_psu_"),
+        )
+        s = Sample(data=df, design=boot_sample.design.update(psu="_psu_"))
+        result = s.estimation.mean(y="income")
         assert result.method.name == "TAYLOR"
 
     def test_explicit_replication(self, boot_sample):


### PR DESCRIPTION
Round 7 of the 2026-07 review — the papercut batch. None of these
corrupt estimates, but several silently misreport or crash.

## Behavior fixes

- **`method=None` auto-detection now matches its docs**: replication
  when the only variance information is replicate weights (no
  strata/PSU); Taylor otherwise. Previously `None` always meant Taylor,
  silently giving a replication-only design SRS-like variance. (One
  test asserted the footgun; updated to the documented contract, with a
  companion test that structured designs still default to Taylor.)
- **Strict replicate-prefix matching** (`^prefix\d+$`) in both
  resolution helpers — a loose `startswith` absorbed stray columns like
  `repwt_flag` into the replicate set; count/n_reps mismatches raise a
  typed `DimensionError`.
- **`set_data`/`update_data`/`set_design`/`update_design` rebuild
  internal state** (concat columns, singleton detection, design
  validation) exactly as `__init__` does, via a shared
  `_refresh_internal_state()`. Previously they skipped all of it.
- **`describe()` honesty**: weighted runs report weighted std/var/
  quantiles (aweight convention) instead of unweighted values labeled
  `weighted=True`; categorical proportions are over all levels, not
  renormalized within the displayed top-k; `n_levels` is the true count
  with an honest `truncated` flag; boolean nulls count as missing, not
  `False`.
- **`singleton.handle(SingletonHandling.POOL)`** (enum form) crashed on
  `.strip()`; both enum and string are accepted now.
- **`PopSize(psu=...)`** with `ssu=None` is accepted for PSU-only FPC,
  as the type signature always promised.
- **`polars_mask()` is explicitly null-safe** (`fill_null(True)`) so
  Kleene null propagation can't flip rows depending on the consumer.
- **Importing svy no longer replaces `sys.excepthook`** of host
  applications: Rich tracebacks install only on explicit `SVY_RICH=1`;
  auto mode keeps pretty-printing (displayhook) only. `SvyError`s
  render their panels via `__str__`/`__rich_console__` regardless.

## Hygiene

- Design-fields cache bounded (cleared beyond 512 entries) — the
  staleness half of the review's id-cache item was already fixed by the
  data-version counter; this closes the unbounded-growth half.
- Deleted the unused content-based `Sample.__hash__` (content hash on a
  mutable object with identity `__eq__`) and the dead, wrong
  `_calculate_fpc` (`int(1 - n/N)` truncates to 0).
- `scale()` docstring now describes the R-validated
  `lonely.psu="average"` behavior per estimator (the 1/(1-f) wording
  only applied to the TOTAL path; confirmed not a math bug in review).

## Testing

svy: 2625 passed, 1 skipped (2 new method-resolution tests; one
footgun-asserting test updated).