### PR TITLE
fix(regression): rewrite GLM margins on the fitted frame with delta-method SEs

### DIFF
--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -125,12 +125,22 @@ class GLM:
 
     PRINT_WIDTH: ClassVar[int | None] = None
 
-    __slots__ = ("_sample", "fitted", "_print_width")
+    __slots__ = (
+        "_sample",
+        "fitted",
+        "_print_width",
+        "_fit_frame",
+        "_fit_weight_col",
+        "_fit_domain_col",
+    )
 
     def __init__(self, sample: Sample) -> None:
         self._sample = sample
         self.fitted: GLMFit | None = None
         self._print_width: int | None = None
+        self._fit_frame: pl.DataFrame | None = None
+        self._fit_weight_col: str | None = None
+        self._fit_domain_col: str | None = None
 
     def _ensure_fitted(self) -> GLMFit:
         if self.fitted is None:
@@ -508,6 +518,13 @@ class GLM:
                 )
             except Exception:
                 pass
+
+        # Persist the exact rows the fit used (post null-drop, post weight
+        # filter, with the domain column) so margins() reproduces the fitted
+        # frame instead of recomputing from the raw sample data.
+        self._fit_frame = df
+        self._fit_weight_col = w_col
+        self._fit_domain_col = by_col_name
 
         self.fitted = fit_obj
         return self

--- a/packages/svy/src/svy/regression/links.py
+++ b/packages/svy/src/svy/regression/links.py
@@ -1,4 +1,4 @@
-# src/svy/regression/base.py
+# src/svy/regression/links.py
 """
 Base definitions for regression module.
 """
@@ -57,6 +57,32 @@ def link_mu_eta(link: str, eta: np.ndarray) -> np.ndarray:
     elif name == "inverse_squared":
         mu = link_inverse(link, eta)
         return -0.5 * (mu**3)
+
+    else:
+        raise ValueError(f"Unknown link: {name}")
+
+
+def link_mu_eta2(link: str, eta: np.ndarray) -> np.ndarray:
+    """Compute d^2(mu)/d(eta)^2 for the AME delta method."""
+    name = link.lower()
+
+    if name == "identity":
+        return np.zeros_like(eta)
+
+    elif name == "logit":
+        mu = link_inverse(link, eta)
+        return mu * (1.0 - mu) * (1.0 - 2.0 * mu)
+
+    elif name == "log":
+        return link_inverse(link, eta)
+
+    elif name == "inverse":
+        mu = link_inverse(link, eta)
+        return 2.0 * (mu**3)
+
+    elif name == "inverse_squared":
+        mu = link_inverse(link, eta)
+        return 0.75 * (mu**5)
 
     else:
         raise ValueError(f"Unknown link: {name}")

--- a/packages/svy/src/svy/regression/margins.py
+++ b/packages/svy/src/svy/regression/margins.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar
 
 import msgspec
 import numpy as np
@@ -15,12 +15,13 @@ import polars as pl
 
 from scipy import stats
 
-from svy.regression.base import link_inverse, link_mu_eta
+from svy.regression.links import link_inverse, link_mu_eta, link_mu_eta2
 from svy.ui.printing import make_panel, render_plain_table, render_rich_to_str, resolve_width
 
 
 if TYPE_CHECKING:
-    from svy.regression.glm import GLM
+    from svy.regression.base import GLM
+    from svy.regression.glm import GLMFit
 
 log = logging.getLogger(__name__)
 
@@ -317,6 +318,77 @@ def _validate_ame_variables(glm: GLM, variables: list[str]) -> list[str]:
 # =============================================================================
 
 
+def _fitted_frame(glm: GLM, fit: GLMFit) -> tuple[pl.DataFrame, np.ndarray]:
+    """
+    Return the (data, weights) the fit actually used.
+
+    The frame is persisted by ``GLM.fit`` (post null-drop, post weight
+    filter) and restricted here to in-domain rows when the fit had a
+    ``where=`` clause, so margins average over exactly the fitted
+    observations — matching Stata ``margins`` after a domain fit and R
+    ``marginaleffects`` on ``svyglm(design = subset(...))``.
+    """
+    from svy.errors.model_errors import ModelError
+
+    frame = glm._fit_frame
+    w_col = glm._fit_weight_col
+    if frame is None or w_col is None:
+        raise ModelError.not_fitted(where="GLM.margins")
+
+    d_col = glm._fit_domain_col
+    if d_col is not None and d_col in frame.columns:
+        frame = frame.filter(pl.col(d_col).str.to_lowercase() == "true").drop(d_col)
+
+    weights = frame.get_column(w_col).to_numpy().astype(float)
+    return frame, weights
+
+
+def _model_df(fit: GLMFit) -> float:
+    """Design degrees of freedom used for t-based intervals."""
+    return fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
+
+
+def _term_derivative_matrix(
+    glm: GLM,
+    fit: GLMFit,
+    data: pl.DataFrame,
+    var: str,
+) -> np.ndarray:
+    """
+    Build the n x k matrix D with D[:, j] = d X_j / d var.
+
+    Each engineered feature column is a product of factors (split on
+    ':'). The derivative w.r.t. a continuous variable follows the
+    product rule: sum over each occurrence of `var` of the product of
+    the remaining factors (Cat dummies and other covariates evaluated
+    at their observed values). Terms not involving `var` have zero
+    derivative.
+    """
+    term_info = fit.term_info or {}
+    terms = fit.feature_names
+    n = data.height
+    D = np.zeros((n, len(terms)))
+
+    for j, term in enumerate(terms):
+        if term == "_intercept_":
+            continue
+        parts = term.split(":")
+        occurrences = [i for i, p in enumerate(parts) if p == var]
+        if not occurrences:
+            continue
+        dcol = np.zeros(n)
+        for occ in occurrences:
+            prod = np.ones(n)
+            for i, part in enumerate(parts):
+                if i == occ:
+                    continue
+                prod = prod * glm._resolve_pred_term(part, data, term_info)
+            dcol += prod
+        D[:, j] = dcol
+
+    return D
+
+
 def compute_predictive_margins(
     glm: GLM,
     variable: str,
@@ -325,29 +397,23 @@ def compute_predictive_margins(
 ) -> GLMMargins:
     """
     Compute predictive margins at specific values of a variable.
+
+    For each value v, every fitted observation is set counterfactually
+    to ``variable = v``, predictions are averaged with the survey
+    weights, and the SE comes from the delta method over the
+    design-based V(beta): se^2 = g' V g with
+    g = sum_i w_i mu'(eta_i) x_i / sum_i w_i  (Stata ``margins``
+    convention; covariates treated as fixed).
     """
     fit = glm.fitted
-    sample = glm._sample
-
-    # Get original data
-    _raw = sample._data
-    data: pl.DataFrame = (
-        _raw if isinstance(_raw, pl.DataFrame) else cast(pl.DataFrame, _raw.collect())
-    )
-
-    # Get weights
-    design = sample._design
-    w_col = design.wgt or "_svy_ones_"
-    if design.wgt is None:
-        data = data.with_columns(pl.lit(1.0).alias(w_col))
-
-    weights = data.get_column(w_col).to_numpy().astype(float)
-    w_sum = weights.sum()
-
-    # Get df from model
     if fit is None:
         raise ValueError("Model not fitted")
-    df = fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
+    if fit.cov_matrix is None:
+        raise ValueError("Covariance matrix not available")
+
+    data, weights = _fitted_frame(glm, fit)
+    w_sum = weights.sum()
+    df = _model_df(fit)
 
     at_values = np.asarray(at_values)
     n_values = len(at_values)
@@ -355,38 +421,39 @@ def compute_predictive_margins(
     margins = np.zeros(n_values)
     se = np.zeros(n_values)
 
-    # Build design matrix once and extract the column index for `variable`.
-    # Each counterfactual only changes one column — no need to rebuild X or
-    # call predict() (which materialises a full Polars DataFrame) per value.
-    X_base = glm._build_prediction_matrix(data, fit)
     beta_vec = np.array([c.est for c in fit.coefs])
+    cov = fit.cov_matrix
+    terms = fit.feature_names
 
+    # The single-column fast path is only valid when `variable` is a plain
+    # feature column that appears in no interaction term; otherwise the
+    # interaction columns must be rebuilt from the counterfactual data.
+    in_interaction = any(":" in t and variable in t.split(":") for t in terms)
+    col_idx: int | None
     try:
-        col_idx = fit.feature_names.index(variable)
+        col_idx = terms.index(variable)
     except ValueError:
-        # variable is not directly a feature column (e.g. categorical base name);
-        # fall back to the original per-value predict() path
+        # e.g. categorical base name — needs the full rebuild path
         col_idx = None
 
+    X_base = glm._build_prediction_matrix(data, fit) if col_idx is not None else None
+
     for i, val in enumerate(at_values):
-        if col_idx is not None:
+        if col_idx is not None and not in_interaction:
             X_cf = X_base.copy()
             X_cf[:, col_idx] = float(val)
-            eta = X_cf @ beta_vec
-            yhat = link_inverse(fit.link, eta)
         else:
             cf_data = data.with_columns(pl.lit(val).alias(variable))
-            yhat = glm.predict(cf_data).yhat
+            X_cf = glm._build_prediction_matrix(cf_data, fit)
 
-        # Weighted mean
+        eta = X_cf @ beta_vec
+        yhat = link_inverse(fit.link, eta)
         margins[i] = np.sum(weights * yhat) / w_sum
 
-        # Survey variance of mean with finite population correction
-        ybar = margins[i]
-        n_obs = len(weights)
-        var_est = np.sum(weights**2 * (yhat - ybar) ** 2) / (w_sum**2)
-        var_est *= n_obs / (n_obs - 1)
-        se[i] = np.sqrt(var_est)
+        # Delta method: gradient of the weighted mean prediction w.r.t. beta
+        dmu_deta = link_mu_eta(fit.link, eta)
+        grad = (weights * dmu_deta) @ X_cf / w_sum
+        se[i] = np.sqrt(max(float(grad @ cov @ grad), 0.0))
 
     # Confidence intervals
     t_crit = stats.t.ppf(1 - alpha / 2, df)
@@ -413,37 +480,31 @@ def compute_average_marginal_effects(
 ) -> list[GLMMargins]:
     """
     Compute average marginal effects (AME) for continuous variables.
+
+    The marginal effect differentiates the full linear predictor, so a
+    variable appearing in interaction terms contributes
+    beta_x + beta_{x:z} * z (evaluated at observed z). SEs use the full
+    delta method over the design-based V(beta):
+    g_j = mean_w(mu''(eta) X_j deta_dx + mu'(eta) D_j), se^2 = g' V g.
     """
     fit = glm.fitted
-    sample = glm._sample
-
-    # Get original data
-    _raw2 = sample._data
-    data: pl.DataFrame = (
-        _raw2 if isinstance(_raw2, pl.DataFrame) else cast(pl.DataFrame, _raw2.collect())
-    )
-
-    # Get weights
-    design = sample._design
-    w_col = design.wgt or "_svy_ones_"
-    if design.wgt is None:
-        data = data.with_columns(pl.lit(1.0).alias(w_col))
-
-    weights = data.get_column(w_col).to_numpy().astype(float)
-    w_sum = weights.sum()
-
-    # Get df and coefficients
     if fit is None:
         raise ValueError("Model not fitted")
-    df = fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
-    beta = {c.term: c.est for c in fit.coefs}
-    beta_se = {c.term: c.se for c in fit.coefs}
+    if fit.cov_matrix is None:
+        raise ValueError("Covariance matrix not available")
 
-    # Get predictions on link scale
-    X = glm._build_prediction_matrix(data, fit)
+    data, weights = _fitted_frame(glm, fit)
+    w_sum = weights.sum()
+    df = _model_df(fit)
+
     beta_vec = np.array([c.est for c in fit.coefs])
+    cov = fit.cov_matrix
+
+    # Predictions on the link scale over the fitted rows
+    X = glm._build_prediction_matrix(data, fit)
     eta = X @ beta_vec
     dmu_deta = link_mu_eta(fit.link, eta)
+    d2mu_deta2 = link_mu_eta2(fit.link, eta)
 
     # Determine which variables to compute AME for
     term_info = fit.term_info or {}
@@ -459,16 +520,20 @@ def compute_average_marginal_effects(
     t_crit = stats.t.ppf(1 - alpha / 2, df)
 
     for var in variables:
-        if var not in beta:
+        D = _term_derivative_matrix(glm, fit, data, var)
+        if not D.any():
             log.warning(f"Variable '{var}' not found in model coefficients")
             continue
 
-        # AME = weighted mean of (dmu/deta * beta)
-        ame = np.sum(weights * dmu_deta * beta[var]) / w_sum
+        # d(eta)/d(var) per observation, including interaction terms
+        deta_dx = D @ beta_vec
+        ame = np.sum(weights * dmu_deta * deta_dx) / w_sum
 
-        # SE via delta method (simplified)
-        mean_dmu_deta = np.sum(weights * dmu_deta) / w_sum
-        se_val = abs(mean_dmu_deta) * beta_se[var]
+        # Full delta method: gradient of AME w.r.t. beta
+        grad_rows = (weights * d2mu_deta2 * deta_dx)[:, None] * X
+        grad_rows += (weights * dmu_deta)[:, None] * D
+        grad = grad_rows.sum(axis=0) / w_sum
+        se_val = np.sqrt(max(float(grad @ cov @ grad), 0.0))
 
         lci = ame - t_crit * se_val
         uci = ame + t_crit * se_val

--- a/packages/svy/tests/svy/regression/test_glm_margins.py
+++ b/packages/svy/tests/svy/regression/test_glm_margins.py
@@ -19,11 +19,17 @@ DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
 # =============================================================================
 # R Reference Values
 # =============================================================================
-
-# R: Logistic AME (manual calculation)
-# ame_ell = -0.0009982936
-# ame_meals = -0.0080360454
-# ame_mobility = 0.0007552178
+# Generated with R survey 4.5 + marginaleffects 0.32.0 (2026-07-23):
+#
+#   api <- read.csv("apistrat.csv"); api$y_bin <- as.integer(api$api00 > 600)
+#   d1 <- svydesign(ids=~1, weights=~pw, data=api)
+#   m1 <- svyglm(y_bin ~ ell + meals + mobility, design=d1, family=quasibinomial())
+#   avg_slopes(m1, wts=weights(m1))
+#   avg_predictions(m1, variables=list(meals=c(20,50,80)), by="meals", wts=weights(m1))
+#
+# `wts=weights(fit)` makes marginaleffects average with the design weights
+# (Stata `margins` convention). SEs are delta-method over vcov(svyglm),
+# i.e. g'V(beta)g with covariates fixed — the convention svy implements.
 
 R_LOGISTIC_AME = {
     "ell": -0.0009982936,
@@ -31,16 +37,46 @@ R_LOGISTIC_AME = {
     "mobility": 0.0007552178,
 }
 
-# R: Predictive margins at meals = 20, 50, 80
-# mean SE
-# pred_20 0.96989 0.0005
-# pred_50 0.77227 0.0031
-# pred_80 0.26554 0.0032
+R_LOGISTIC_AME_SE = {
+    "ell": 0.0016047333,
+    "meals": 0.0010179779,
+    "mobility": 0.0019007082,
+}
 
 R_PREDICTIVE_MARGINS = {
     "values": np.array([20, 50, 80]),
-    "margin": np.array([0.96989, 0.77227, 0.26554]),
-    "se": np.array([0.0005, 0.0031, 0.0032]),
+    "margin": np.array([0.9698889120, 0.7722732242, 0.2655410705]),
+    "se": np.array([0.0158168043, 0.0400183429, 0.0813343039]),
+}
+
+# R: interaction model m2 <- svyglm(y_bin ~ ell * meals, design=d1, ...)
+R_INTERACTION_AME = {
+    "ell": (-0.0014277197, 0.0017420001),
+    "meals": (-0.0077599270, 0.0011161544),
+}
+
+R_INTERACTION_PREDICTIVE = {
+    "values": np.array([20, 50, 80]),
+    "margin": np.array([0.9621412052, 0.7593207994, 0.2591576034]),
+    "se": np.array([0.0305195844, 0.0513012146, 0.0813251070]),
+}
+
+# R: Cat x continuous m3 <- svyglm(y_bin ~ awards * ell, design=d1, ...)
+R_CAT_INTERACTION_AME_ELL = (-0.0101530922, 0.0010906246)
+
+# R: stratified design + domain fit
+#   d4 <- svydesign(ids=~1, strata=~stype, weights=~pw, data=api)
+#   m4 <- svyglm(y_bin ~ ell + meals, design=subset(d4, awards=="Yes"),
+#                family=quasibinomial())
+R_DOMAIN_AME = {
+    "ell": (-0.0002686150, 0.0016696858),
+    "meals": (-0.0085233748, 0.0014792988),
+}
+
+R_DOMAIN_PREDICTIVE = {
+    "values": np.array([20, 50, 80]),
+    "margin": np.array([0.9935953493, 0.8893161765, 0.2943536384]),
+    "se": np.array([0.0067214884, 0.0402467347, 0.1307085096]),
 }
 
 # R: Linear AME (just coefficients)
@@ -52,6 +88,12 @@ R_LINEAR_AME = {
 
 RTOL = 1e-2  # 1% tolerance for margins
 ATOL = 1e-4
+
+# Margin point estimates should agree with R to numerical precision; SEs to
+# ~1e-4 relative (marginaleffects uses a numerical Jacobian, svy an
+# analytic gradient).
+RTOL_EST = 1e-6
+RTOL_SE = 5e-4
 
 
 # =============================================================================
@@ -116,6 +158,21 @@ class TestGLMMarginAME:
             ame_dict["mobility"], R_LOGISTIC_AME["mobility"], rtol=RTOL, atol=ATOL
         )
 
+    def test_logistic_ame_se_vs_r(self, api_binary):
+        """Logistic AME delta-method SEs match R marginaleffects."""
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", "mobility"],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins()
+        se_dict = {m.term: m.se[0] for m in margins}
+
+        for var, se in R_LOGISTIC_AME_SE.items():
+            np.testing.assert_allclose(se_dict[var], se, rtol=RTOL_SE)
+
     def test_ame_returns_list(self, api_strat):
         """AME returns list of GLMMargins."""
         sample = Sample(api_strat, Design(wgt="pw"))
@@ -162,9 +219,7 @@ class TestGLMMarginPredictive:
 
         margins = model.margins(at={"meals": [20, 50, 80]})
 
-        np.testing.assert_allclose(
-            margins.margin, R_PREDICTIVE_MARGINS["margin"], rtol=RTOL, atol=ATOL
-        )
+        np.testing.assert_allclose(margins.margin, R_PREDICTIVE_MARGINS["margin"], rtol=RTOL_EST)
 
     def test_predictive_margins_se_vs_r(self, api_binary):
         """Predictive margins SE matches R."""
@@ -177,13 +232,7 @@ class TestGLMMarginPredictive:
 
         margins = model.margins(at={"meals": [20, 50, 80]})
 
-        # SE tolerance is looser due to simplified variance estimation
-        np.testing.assert_allclose(
-            margins.se,
-            R_PREDICTIVE_MARGINS["se"],
-            rtol=0.5,
-            atol=0.01,  # Allow 50% relative difference for SE
-        )
+        np.testing.assert_allclose(margins.se, R_PREDICTIVE_MARGINS["se"], rtol=RTOL_SE)
 
     def test_predictive_margins_returns_single(self, api_binary):
         """Single at variable returns single GLMMargins."""
@@ -216,6 +265,130 @@ class TestGLMMarginPredictive:
         margins = model.margins(at={"meals": [20, 50, 80]})
 
         np.testing.assert_array_equal(margins.values, np.array([20, 50, 80]))
+
+
+# =============================================================================
+# Interaction, Domain, and Missing-Data Tests
+# =============================================================================
+
+
+class TestGLMMarginInteractions:
+    """Margins for models with interaction terms (Round 8: R2/R3)."""
+
+    def test_interaction_ame_vs_r(self, api_binary):
+        """AME differentiates the full linear predictor incl. ell:meals."""
+        from svy.core.terms import Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", Cross("ell", "meals")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = {m.term: m for m in model.margins()}
+        for var, (est, se) in R_INTERACTION_AME.items():
+            np.testing.assert_allclose(margins[var].margin[0], est, rtol=RTOL_EST)
+            np.testing.assert_allclose(margins[var].se[0], se, rtol=RTOL_SE)
+
+    def test_interaction_predictive_margins_vs_r(self, api_binary):
+        """Counterfactuals rebuild interaction columns (no stale ell:meals)."""
+        from svy.core.terms import Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", Cross("ell", "meals")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins(at={"meals": [20, 50, 80]})
+        np.testing.assert_allclose(
+            margins.margin, R_INTERACTION_PREDICTIVE["margin"], rtol=RTOL_EST
+        )
+        np.testing.assert_allclose(margins.se, R_INTERACTION_PREDICTIVE["se"], rtol=RTOL_SE)
+
+    def test_cat_interaction_ame_vs_r(self, api_binary):
+        """AME for a continuous variable interacted with a Cat term."""
+        from svy.core.terms import Cat, Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=[Cat("awards"), "ell", Cross(Cat("awards"), "ell")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins(variables=["ell"])
+        est, se = R_CAT_INTERACTION_AME_ELL
+        np.testing.assert_allclose(margins[0].margin[0], est, rtol=RTOL_EST)
+        np.testing.assert_allclose(margins[0].se[0], se, rtol=RTOL_SE)
+
+
+class TestGLMMarginDomain:
+    """Margins after a domain (where=) fit use the fitted rows (Round 8: R1)."""
+
+    def _domain_model(self, api_binary):
+        import svy
+
+        sample = Sample(api_binary, Design(stratum="stype", wgt="pw"))
+        return sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals"],
+            family=DistFamily.BINOMIAL,
+            where=svy.col("awards") == "Yes",
+        )
+
+    def test_domain_ame_vs_r(self, api_binary):
+        """AME after where= matches R svyglm on subset(design, ...)."""
+        model = self._domain_model(api_binary)
+
+        margins = {m.term: m for m in model.margins()}
+        for var, (est, se) in R_DOMAIN_AME.items():
+            np.testing.assert_allclose(margins[var].margin[0], est, rtol=RTOL_EST)
+            np.testing.assert_allclose(margins[var].se[0], se, rtol=RTOL_SE)
+
+    def test_domain_predictive_margins_vs_r(self, api_binary):
+        """Predictive margins after where= average over in-domain rows only."""
+        model = self._domain_model(api_binary)
+
+        margins = model.margins(at={"meals": [20, 50, 80]})
+        np.testing.assert_allclose(margins.margin, R_DOMAIN_PREDICTIVE["margin"], rtol=RTOL_EST)
+        np.testing.assert_allclose(margins.se, R_DOMAIN_PREDICTIVE["se"], rtol=RTOL_SE)
+
+
+class TestGLMMarginInvariants:
+    """Structural invariants of the delta-method margins."""
+
+    def test_identity_link_ame_se_equals_coef_se(self, api_strat):
+        """For the identity link, AME == coef and se(AME) == se(coef)."""
+        sample = Sample(api_strat, Design(wgt="pw"))
+        model = sample.glm.fit(y="api00", x=["ell", "meals", "mobility"])
+
+        coef = {c.term: c for c in model.fitted.coefs}
+        for m in model.margins():
+            np.testing.assert_allclose(m.margin[0], coef[m.term].est, rtol=1e-12)
+            np.testing.assert_allclose(m.se[0], coef[m.term].se, rtol=1e-12)
+
+    def test_null_covariates_do_not_propagate_nan(self, api_binary):
+        """Margins average over the fitted rows, so covariate nulls
+        (dropped at fit time) cannot produce NaN margins."""
+        data = api_binary.with_columns(
+            pl.when(pl.int_range(pl.len()) < 5)
+            .then(None)
+            .otherwise(pl.col("ell"))
+            .alias("ell")
+        )
+        sample = Sample(data, Design(wgt="pw"))
+        model = sample.glm.fit(y="y_bin", x=["ell", "meals"], family=DistFamily.BINOMIAL)
+
+        ame = model.margins(variables=["ell"])[0]
+        assert np.isfinite(ame.margin[0])
+        assert np.isfinite(ame.se[0])
+
+        pred = model.margins(at={"meals": [20, 50]})
+        assert np.all(np.isfinite(pred.margin))
+        assert np.all(np.isfinite(pred.se))
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Round 8 review findings R1–R5: `margins.py` was wrong end-to-end — it recomputed everything from the raw sample data (ignoring `where=` domains and null handling) and used ad-hoc SE formulas that omitted V(β̂), the dominant variance component.

- **R1** — `GLM.fit` now persists the prepared frame (post null-drop, post weight filter, with the domain column); margins average over exactly the fitted rows. Domain fits no longer include out-of-domain rows, and covariate nulls no longer propagate NaN.
- **R2** — AME differentiates the full linear predictor: a variable in interaction terms contributes β_x + β_{x:z}·z, via the product rule over every term containing it (Cat partners included).
- **R3** — predictive-margin counterfactuals rebuild interaction columns through `_build_prediction_matrix`; the single-column fast path applies only when the variable appears in no interaction.
- **R4/R5** — both margin types now use the full delta method, se² = g′V(β̂)g over the design-based covariance (Stata `margins` `vce(delta)` convention). New `link_mu_eta2` provides the second derivatives the AME gradient needs.

## Validation

References generated with R survey 4.5 + marginaleffects 0.32.0 (`wts=weights(fit)` for the Stata-style weighted averaging); the generating R code is in the test-file header. Agreement:

- point estimates ~1e-8 relative;
- SEs ~1e-4 relative (marginaleffects numerical Jacobian vs analytic gradient),

across: plain weighted logit, `ell*meals` interaction, `awards*ell` Cat×continuous interaction, and a stratified `where=` domain fit (matching `svyglm(design=subset(...))`). The AME point references already pinned in the tests were reproduced exactly, confirming their provenance. Identity-link invariant (AME ≡ coef, SE ≡ coef SE) holds to machine precision.

The predictive-margin SE tolerance tightens from 50% to 0.05%; the old pinned SE values (1–2 significant figures, consistent with the removed SRS-of-fixed-ŷ formula) are replaced by full-precision delta-method values.

## Tests

`uv run pytest tests --ignore=tests/benchmark_test.py` → 2635 passed, 1 skipped (baseline 2625 + 9 new margins tests + `test_murphy_rejects_n_not_2`, which needed a stale native `svy_rs` rebuild locally, unrelated to this change).