### PR TITLE
fix(size): correct power-based sizing formulas and parameter validation

### DIFF
--- a/packages/svy/src/svy/engine/size_and_power/power.py
+++ b/packages/svy/src/svy/engine/size_and_power/power.py
@@ -150,8 +150,12 @@ def calculate_power_number(
     zc = _zcrit(alpha, two_sides)
     if samp_size <= 0 or sigma <= 0:
         return float("nan")
-    lam = float(delta) * math.sqrt(float(samp_size)) / float(sigma)
-    ttype: Literal["two-sided", "less", "greater"] = "two-sided" if two_sides else "greater"
+    d = float(delta)
+    lam = d * math.sqrt(float(samp_size)) / float(sigma)
+    # One-sided direction follows the sign of delta (matches the array flavor)
+    ttype: Literal["two-sided", "less", "greater"] = (
+        "two-sided" if two_sides else ("greater" if d >= 0.0 else "less")
+    )
     return _scalar_power(lam, zc, ttype)
 
 
@@ -172,14 +176,18 @@ def calculate_power_map(
     if not (kd == ks == kn):
         raise KeyError("delta, sigma, and samp_size must have identical keys")
     out: dict[Category, float] = {}
-    ttype: Literal["two-sided", "less", "greater"] = "two-sided" if two_sides else "greater"
     for k in kd:
         n = float(samp_size[k])
         s = float(sigma[k])
         if n <= 0 or s <= 0:
             out[k] = float("nan")
             continue
-        lam = float(delta[k]) * math.sqrt(n) / s
+        d = float(delta[k])
+        lam = d * math.sqrt(n) / s
+        # One-sided direction follows the sign of delta (matches the array flavor)
+        ttype: Literal["two-sided", "less", "greater"] = (
+            "two-sided" if two_sides else ("greater" if d >= 0.0 else "less")
+        )
         out[k] = _scalar_power(lam, zc, ttype)
     return out
 

--- a/packages/svy/src/svy/engine/size_and_power/size.py
+++ b/packages/svy/src/svy/engine/size_and_power/size.py
@@ -8,7 +8,6 @@ from typing import Literal, cast
 
 import numpy as np
 
-from numpy._core.numeric import inf
 from scipy.stats import norm
 
 from svy.core.enumerations import MeanVarMode, PropVarMode
@@ -19,6 +18,7 @@ from svy.core.types import (
     FloatArray,
     Number,
 )
+from svy.errors.method_errors import MethodError
 
 
 # ============================================================
@@ -90,11 +90,22 @@ def _resolve_maps(
 # ============================================================
 
 
+def _resp_rate_error(rv: object) -> MethodError:
+    return MethodError.invalid_range(
+        where=None,
+        param="resp_rate",
+        got=rv,
+        min_=0.0,
+        max_=1.0,
+        hint="resp_rate is a fraction in (0, 1], e.g. 0.85 for 85% response.",
+    )
+
+
 def _apply_nonresponse(
     *,
     n: Number | DomainScalarMap,
     resp_rate: Number | DomainScalarMap,
-    strict: bool = False,
+    strict: bool = True,
 ) -> Number | DomainScalarMap:
     """
     Adjust for nonresponse:
@@ -107,18 +118,18 @@ def _apply_nonresponse(
       * If both mappings, keys must match.
 
     Validation:
-    - resp_rate must be in (0, 1].
-      * strict=False: if invalid (<=0, >1, non-finite) -> leave n unchanged for that key.
-      * strict=True: raise ValueError on invalid entries.
+    - resp_rate must be finite and in (0, 1].
+      * strict=True (default): raise MethodError on invalid entries.
+      * strict=False: leave n unchanged for that key.
     """
 
     def _adj(nv: Number, rv: Number) -> float:
         n_f = float(nv)
         r_f = float(rv)
-        valid = (r_f > 0.0) and (r_f <= 1.0)
-        if not valid or not (r_f == r_f):  # NaN check
+        valid = math.isfinite(r_f) and (r_f > 0.0) and (r_f <= 1.0)
+        if not valid:
             if strict:
-                raise ValueError(f"Invalid response rate: {rv} (must be in (0,1]).")
+                raise _resp_rate_error(rv)
             return float(math.ceil(n_f))
         return float(math.ceil(n_f / r_f))
 
@@ -133,6 +144,15 @@ def _apply_nonresponse(
 # ============================================================
 # Adjsut for the design effect
 # ============================================================
+
+
+def _deff_error(dv: object) -> MethodError:
+    return MethodError.invalid_range(
+        where=None,
+        param="deff",
+        got=dv,
+        hint="deff must be a positive finite number (deff=1 means SRS).",
+    )
 
 
 def _apply_deff(
@@ -150,15 +170,15 @@ def _apply_deff(
         * Scalars are broadcast to the mapping's keys.
         * Mapping keys must match if both are mappings.
 
-    Safeguards:
-      - If deff is non-finite or <= 0 for a key, returns the unadjusted n for that key.
+    Validation:
+      - deff must be finite and > 0; invalid values raise MethodError.
     """
 
     def _adjust(n_val: Number, d_val: Number) -> float:
         n_f = float(n_val)
         d_f = float(d_val)
-        if not (d_f > 0.0):
-            return float(math.ceil(n_f))
+        if not (math.isfinite(d_f) and d_f > 0.0):
+            raise _deff_error(d_val)
         return float(math.ceil(d_f * n_f))
 
     # Scalar-scalar
@@ -214,6 +234,89 @@ def _apply_fpc_srswor(
 # ============================================================
 
 _EPS = 1e-12
+
+
+def _validate_prob(p: Number, *, param: str) -> float:
+    p_f = float(p)
+    if not (math.isfinite(p_f) and 0.0 < p_f < 1.0):
+        raise MethodError.invalid_range(where=None, param=param, got=p, min_=0.0, max_=1.0)
+    return p_f
+
+
+def _validate_power(power: Number) -> float:
+    b = float(power)
+    if not (math.isfinite(b) and 0.0 < b < 1.0):
+        raise MethodError.invalid_range(
+            where=None,
+            param="power",
+            got=power,
+            min_=0.0,
+            max_=1.0,
+            hint="power is a probability, e.g. 0.80 for 80% power.",
+        )
+    return b
+
+
+def _validate_sigma(sigma: Number, *, param: str = "sigma") -> float:
+    s = float(sigma)
+    if not (math.isfinite(s) and s > 0.0):
+        raise MethodError.invalid_range(
+            where=None,
+            param=param,
+            got=sigma,
+            hint=f"{param} must be a positive finite number.",
+        )
+    return s
+
+
+def _validate_moe(moe: Number, *, upper: float | None = None) -> float:
+    d = float(moe)
+    ok = math.isfinite(d) and d > 0.0 and (upper is None or d < upper)
+    if not ok:
+        raise MethodError.invalid_range(
+            where=None,
+            param="moe",
+            got=moe,
+            min_=0.0,
+            max_=upper,
+            hint="moe is the half-width of the confidence interval"
+            + (" on the proportion scale." if upper is not None else "."),
+        )
+    return d
+
+
+def _infeasible(detail: str) -> MethodError:
+    return MethodError(
+        title="Infeasible design",
+        detail=detail,
+        code="INFEASIBLE_DESIGN",
+    )
+
+
+def _test_denominator(*, epsilon: float, delta: float, two_sides: bool) -> float:
+    """
+    Effect denominator for power-based sizing (Chow–Shao–Wang conventions,
+    epsilon signed = true difference under the alternative):
+
+      - standard test (delta == 0):            epsilon
+      - equivalence (two-sided, delta != 0):   delta - |epsilon|  (must be > 0)
+      - non-inferiority / superiority (else):  epsilon - delta    (H0: eps <= delta)
+    """
+    if two_sides and delta != 0.0:
+        denom = delta - abs(epsilon)
+        if denom <= _EPS:
+            raise _infeasible(
+                f"Equivalence requires |epsilon| < delta; got epsilon={epsilon}, "
+                f"delta={delta}."
+            )
+        return denom
+    denom = epsilon - delta
+    if abs(denom) <= _EPS:
+        raise _infeasible(
+            f"epsilon - delta is (near) zero (epsilon={epsilon}, delta={delta}); "
+            "the required sample size is unbounded."
+        )
+    return denom
 
 
 def _as_float(x: Number) -> float:
@@ -308,8 +411,8 @@ def _wald_sample_size_prop_scalar(
     half_ci: Number,
     alpha: Number,
 ) -> float:
-    p = _as_float(target)
-    d = max(_EPS, _as_float(half_ci))
+    p = _validate_prob(target, param="p")
+    d = _validate_moe(half_ci, upper=1.0)
     z = _zcrit(_as_float(alpha), True)
     n = (z * z) * p * (1.0 - p) / (d * d)
     return float(math.ceil(n))
@@ -376,8 +479,8 @@ def _fleiss_sample_size_prop_scalar(
     half_ci: Number,
     alpha: Number,
 ) -> float:
-    p = _as_float(target)
-    d = max(_EPS, _as_float(half_ci))
+    p = _validate_prob(target, param="p")
+    d = _validate_moe(half_ci, upper=1.0)
     z = _zcrit(_as_float(alpha), True)
     f = _fleiss_factor_scalar(p=p, d=d)
     n = (f * (z * z) / (4.0 * d * d)) + (1.0 / d) - (2.0 * z * z) + ((z + 2.0) / f)
@@ -433,8 +536,8 @@ def _wilson_sample_size_prop_scalar(
     half_ci: Number,
     alpha: Number,
 ) -> float:
-    p = _as_float(target)
-    d = max(_EPS, _as_float(half_ci))
+    p = _validate_prob(target, param="p")
+    d = _as_float(half_ci)
     if not (0.0 < d < 0.5):
         raise ValueError("Wilson requires 0 < half_ci < 0.5 for a proportion.")
 
@@ -502,8 +605,8 @@ def _wald_sample_size_mean_scalar(
     sigma: Number,
     alpha: Number,
 ) -> float:
-    d = max(_EPS, _as_float(half_ci))
-    s2 = max(_EPS, _as_float(sigma)) ** 2
+    d = _validate_moe(half_ci)
+    s2 = _validate_sigma(sigma) ** 2
     z2 = _zcrit(_as_float(alpha), True) ** 2
     n = z2 * s2 / (d * d)
     return float(math.ceil(n))
@@ -578,22 +681,13 @@ def _wald_sample_size_one_mean_scalar(
     power: Number,
 ) -> float:
     d0 = _as_float(delta)
-    eps = abs(_as_float(epsilon))
-    s = max(_EPS, _as_float(sigma))
+    eps = _as_float(epsilon)  # signed
+    s = _validate_sigma(sigma)
     a = _as_float(alpha)
-    b = _as_float(power)
+    b = _validate_power(power)
 
-    if two_sides and d0 == 0.0:
-        z_a = _zcrit(a, True)
-        z_b = float(norm.ppf(b))
-    elif two_sides:
-        z_a = _zcrit(a, False)
-        z_b = float(norm.ppf((1.0 + b) / 2.0))
-    else:
-        z_a = _zcrit(a, False)
-        z_b = float(norm.ppf(b))
-
-    denom = max(_EPS, d0 - eps)
+    z_a, z_b = _zcrit_pair(two_sides=two_sides, alpha=a, power=b, delta=d0)
+    denom = _test_denominator(epsilon=eps, delta=d0, two_sides=two_sides)
     n = ((z_a + z_b) * s / denom) ** 2
     return float(math.ceil(n))
 
@@ -646,7 +740,7 @@ def _apply_nonresponse_pair(
     *,
     n: tuple[Number, Number] | Mapping[Category, tuple[Number, Number]],
     resp_rate: Number | tuple[Number, Number] | Mapping[Category, Number | tuple[Number, Number]],
-    strict: bool = False,
+    strict: bool = True,
 ) -> tuple[Number, Number] | dict[Category, tuple[Number, Number]]:
     def _valid_rr(r: float) -> bool:
         return math.isfinite(r) and (r > 0.0) and (r <= 1.0)
@@ -656,7 +750,7 @@ def _apply_nonresponse_pair(
         r_f = float(rv)
         if not _valid_rr(r_f):
             if strict:
-                raise ValueError(f"Invalid response rate: {rv} (must be finite and in (0, 1]).")
+                raise _resp_rate_error(rv)
             return float(math.ceil(n_f))
         return float(math.ceil(n_f / r_f))
 
@@ -726,8 +820,8 @@ def _apply_deff_pair(
     def _adjust_scalar(n_val: Number, d_val: Number) -> float:
         n_f = float(n_val)
         d_f = float(d_val)
-        if not (d_f > 0.0):
-            return float(math.ceil(n_f))
+        if not (math.isfinite(d_f) and d_f > 0.0):
+            raise _deff_error(d_val)
         return float(math.ceil(d_f * n_f))
 
     def _adjust_pair(
@@ -882,12 +976,11 @@ def _zcrit_pair(
 
 
 def _wald_n2_from_varfactor(*, var_factor: float, denom: float, z_a: float, z_b: float) -> int:
-    n2 = var_factor * (((z_a + z_b) / denom) ** 2) if abs(denom) > _EPS else inf
-    return int(math.ceil(n2))
-
-
-def _prob_clip(p: float) -> float:
-    return min(max(p, _EPS), 1.0 - _EPS)
+    if abs(denom) <= _EPS:
+        raise _infeasible(
+            "Effect denominator is (near) zero; the required sample size is unbounded."
+        )
+    return int(math.ceil(var_factor * (((z_a + z_b) / denom) ** 2)))
 
 
 def _choose_kappa(user_kappa: float | None, default_kappa: float) -> float:
@@ -927,10 +1020,10 @@ def _wald_sample_size_two_means(
     delta: Number | DomainScalarMap,
     sigma_1: Number | DomainScalarMap,
     sigma_2: Number | DomainScalarMap | None,
-    equal_var: bool | DomainScalarMap,
     alloc_ratio: Number | DomainScalarMap,
     alpha: Number | DomainScalarMap,
     power: Number | DomainScalarMap,
+    var_mode: MeanVarMode = MeanVarMode.EQUAL_VAR,
 ) -> tuple[Number, Number] | dict[Category, tuple[Number, Number]]:
     if (
         _is_number(epsilon)
@@ -949,6 +1042,7 @@ def _wald_sample_size_two_means(
             kappa=cast(Number, alloc_ratio),
             alpha=cast(Number, alpha),
             power=cast(Number, power),
+            var_mode=var_mode,
         )
     elif _is_map(epsilon) and _is_map(alpha) and _is_map(power):
         return _wald_sample_size_two_means_map(
@@ -960,6 +1054,7 @@ def _wald_sample_size_two_means(
             kappa=cast(DomainScalarMap, alloc_ratio),
             alpha=alpha,
             power=power,
+            var_mode=var_mode,
         )
     else:
         raise ValueError("Invalid input types")
@@ -978,12 +1073,12 @@ def _wald_sample_size_two_means_scalar(
     var_mode: MeanVarMode = MeanVarMode.EQUAL_VAR,
 ) -> tuple[Number, Number]:
     d0 = _as_float(delta)
-    eps = abs(_as_float(epsilon))
-    s1 = max(_EPS, _as_float(sigma_1))
-    s2 = max(_EPS, _as_float(sigma_2) if sigma_2 is not None else s1)
+    eps = _as_float(epsilon)  # signed
+    s1 = _validate_sigma(sigma_1, param="sigma1")
+    s2 = _validate_sigma(sigma_2, param="sigma2") if sigma_2 is not None else s1
     a = _as_float(alpha)
-    b = _as_float(power)
-    denom = d0 - eps
+    b = _validate_power(power)
+    denom = _test_denominator(epsilon=eps, delta=d0, two_sides=two_sides)
 
     match var_mode:
         case MeanVarMode.EQUAL_VAR:
@@ -991,7 +1086,8 @@ def _wald_sample_size_two_means_scalar(
             k = _choose_kappa(float(kappa) if kappa is not None else None, default_kappa=1.0)
         case MeanVarMode.UNEQUAL_VAR:
             v1, v2 = s1 * s1, s2 * s2
-            k_opt = s1 / s2
+            # kappa = n2/n1; total-n-minimizing allocation is sigma2/sigma1
+            k_opt = s2 / s1
             k = _choose_kappa(float(kappa) if kappa is not None else None, default_kappa=k_opt)
 
     return _wald_two_group_sizes(
@@ -1108,23 +1204,25 @@ def _wald_sample_size_two_props_scalar(
     var_mode: PropVarMode = PropVarMode.ALT_PROPS,
 ) -> tuple[Number, Number]:
     d0 = _as_float(delta)
-    eps = abs(_as_float(epsilon))
-    pa = _prob_clip(_as_float(p1))
-    pb = _prob_clip(_as_float(p2))
+    eps = _as_float(epsilon)  # signed
+    pa = _validate_prob(p1, param="p1")
+    pb = _validate_prob(p2, param="p2")
     a = _as_float(alpha)
-    b = _as_float(power)
-    denom = d0 - eps
+    b = _validate_power(power)
+    denom = _test_denominator(epsilon=eps, delta=d0, two_sides=two_sides)
 
     match var_mode:
         case PropVarMode.POOLED_PROP:
             k_tmp = _choose_kappa(float(kappa) if kappa is not None else None, default_kappa=1.0)
-            ppool = (k_tmp * pa + pb) / (k_tmp + 1.0)
+            # kappa = n2/n1: pooled p = (n1*p1 + n2*p2)/(n1+n2)
+            ppool = (pa + k_tmp * pb) / (1.0 + k_tmp)
             v1 = v2 = ppool * (1.0 - ppool)
             k = k_tmp
         case PropVarMode.ALT_PROPS:
             v1 = pa * (1.0 - pa)
             v2 = pb * (1.0 - pb)
-            k_opt = math.sqrt(v1 / v2) if v2 > 0 else 1.0
+            # kappa = n2/n1; total-n-minimizing allocation is sqrt(v2/v1)
+            k_opt = math.sqrt(v2 / v1) if v1 > 0 else 1.0
             k = _choose_kappa(float(kappa) if kappa is not None else None, default_kappa=k_opt)
         case PropVarMode.MAX_VAR:
             v1 = v2 = 0.25

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -125,12 +125,22 @@ class GLM:
 
     PRINT_WIDTH: ClassVar[int | None] = None
 
-    __slots__ = ("_sample", "fitted", "_print_width")
+    __slots__ = (
+        "_sample",
+        "fitted",
+        "_print_width",
+        "_fit_frame",
+        "_fit_weight_col",
+        "_fit_domain_col",
+    )
 
     def __init__(self, sample: Sample) -> None:
         self._sample = sample
         self.fitted: GLMFit | None = None
         self._print_width: int | None = None
+        self._fit_frame: pl.DataFrame | None = None
+        self._fit_weight_col: str | None = None
+        self._fit_domain_col: str | None = None
 
     def _ensure_fitted(self) -> GLMFit:
         if self.fitted is None:
@@ -508,6 +518,13 @@ class GLM:
                 )
             except Exception:
                 pass
+
+        # Persist the exact rows the fit used (post null-drop, post weight
+        # filter, with the domain column) so margins() reproduces the fitted
+        # frame instead of recomputing from the raw sample data.
+        self._fit_frame = df
+        self._fit_weight_col = w_col
+        self._fit_domain_col = by_col_name
 
         self.fitted = fit_obj
         return self

--- a/packages/svy/src/svy/regression/links.py
+++ b/packages/svy/src/svy/regression/links.py
@@ -1,4 +1,4 @@
-# src/svy/regression/base.py
+# src/svy/regression/links.py
 """
 Base definitions for regression module.
 """
@@ -57,6 +57,32 @@ def link_mu_eta(link: str, eta: np.ndarray) -> np.ndarray:
     elif name == "inverse_squared":
         mu = link_inverse(link, eta)
         return -0.5 * (mu**3)
+
+    else:
+        raise ValueError(f"Unknown link: {name}")
+
+
+def link_mu_eta2(link: str, eta: np.ndarray) -> np.ndarray:
+    """Compute d^2(mu)/d(eta)^2 for the AME delta method."""
+    name = link.lower()
+
+    if name == "identity":
+        return np.zeros_like(eta)
+
+    elif name == "logit":
+        mu = link_inverse(link, eta)
+        return mu * (1.0 - mu) * (1.0 - 2.0 * mu)
+
+    elif name == "log":
+        return link_inverse(link, eta)
+
+    elif name == "inverse":
+        mu = link_inverse(link, eta)
+        return 2.0 * (mu**3)
+
+    elif name == "inverse_squared":
+        mu = link_inverse(link, eta)
+        return 0.75 * (mu**5)
 
     else:
         raise ValueError(f"Unknown link: {name}")

--- a/packages/svy/src/svy/regression/margins.py
+++ b/packages/svy/src/svy/regression/margins.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING, ClassVar, cast
+from typing import TYPE_CHECKING, ClassVar
 
 import msgspec
 import numpy as np
@@ -15,12 +15,13 @@ import polars as pl
 
 from scipy import stats
 
-from svy.regression.base import link_inverse, link_mu_eta
+from svy.regression.links import link_inverse, link_mu_eta, link_mu_eta2
 from svy.ui.printing import make_panel, render_plain_table, render_rich_to_str, resolve_width
 
 
 if TYPE_CHECKING:
-    from svy.regression.glm import GLM
+    from svy.regression.base import GLM
+    from svy.regression.glm import GLMFit
 
 log = logging.getLogger(__name__)
 
@@ -317,6 +318,77 @@ def _validate_ame_variables(glm: GLM, variables: list[str]) -> list[str]:
 # =============================================================================
 
 
+def _fitted_frame(glm: GLM, fit: GLMFit) -> tuple[pl.DataFrame, np.ndarray]:
+    """
+    Return the (data, weights) the fit actually used.
+
+    The frame is persisted by ``GLM.fit`` (post null-drop, post weight
+    filter) and restricted here to in-domain rows when the fit had a
+    ``where=`` clause, so margins average over exactly the fitted
+    observations — matching Stata ``margins`` after a domain fit and R
+    ``marginaleffects`` on ``svyglm(design = subset(...))``.
+    """
+    from svy.errors.model_errors import ModelError
+
+    frame = glm._fit_frame
+    w_col = glm._fit_weight_col
+    if frame is None or w_col is None:
+        raise ModelError.not_fitted(where="GLM.margins")
+
+    d_col = glm._fit_domain_col
+    if d_col is not None and d_col in frame.columns:
+        frame = frame.filter(pl.col(d_col).str.to_lowercase() == "true").drop(d_col)
+
+    weights = frame.get_column(w_col).to_numpy().astype(float)
+    return frame, weights
+
+
+def _model_df(fit: GLMFit) -> float:
+    """Design degrees of freedom used for t-based intervals."""
+    return fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
+
+
+def _term_derivative_matrix(
+    glm: GLM,
+    fit: GLMFit,
+    data: pl.DataFrame,
+    var: str,
+) -> np.ndarray:
+    """
+    Build the n x k matrix D with D[:, j] = d X_j / d var.
+
+    Each engineered feature column is a product of factors (split on
+    ':'). The derivative w.r.t. a continuous variable follows the
+    product rule: sum over each occurrence of `var` of the product of
+    the remaining factors (Cat dummies and other covariates evaluated
+    at their observed values). Terms not involving `var` have zero
+    derivative.
+    """
+    term_info = fit.term_info or {}
+    terms = fit.feature_names
+    n = data.height
+    D = np.zeros((n, len(terms)))
+
+    for j, term in enumerate(terms):
+        if term == "_intercept_":
+            continue
+        parts = term.split(":")
+        occurrences = [i for i, p in enumerate(parts) if p == var]
+        if not occurrences:
+            continue
+        dcol = np.zeros(n)
+        for occ in occurrences:
+            prod = np.ones(n)
+            for i, part in enumerate(parts):
+                if i == occ:
+                    continue
+                prod = prod * glm._resolve_pred_term(part, data, term_info)
+            dcol += prod
+        D[:, j] = dcol
+
+    return D
+
+
 def compute_predictive_margins(
     glm: GLM,
     variable: str,
@@ -325,29 +397,23 @@ def compute_predictive_margins(
 ) -> GLMMargins:
     """
     Compute predictive margins at specific values of a variable.
+
+    For each value v, every fitted observation is set counterfactually
+    to ``variable = v``, predictions are averaged with the survey
+    weights, and the SE comes from the delta method over the
+    design-based V(beta): se^2 = g' V g with
+    g = sum_i w_i mu'(eta_i) x_i / sum_i w_i  (Stata ``margins``
+    convention; covariates treated as fixed).
     """
     fit = glm.fitted
-    sample = glm._sample
-
-    # Get original data
-    _raw = sample._data
-    data: pl.DataFrame = (
-        _raw if isinstance(_raw, pl.DataFrame) else cast(pl.DataFrame, _raw.collect())
-    )
-
-    # Get weights
-    design = sample._design
-    w_col = design.wgt or "_svy_ones_"
-    if design.wgt is None:
-        data = data.with_columns(pl.lit(1.0).alias(w_col))
-
-    weights = data.get_column(w_col).to_numpy().astype(float)
-    w_sum = weights.sum()
-
-    # Get df from model
     if fit is None:
         raise ValueError("Model not fitted")
-    df = fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
+    if fit.cov_matrix is None:
+        raise ValueError("Covariance matrix not available")
+
+    data, weights = _fitted_frame(glm, fit)
+    w_sum = weights.sum()
+    df = _model_df(fit)
 
     at_values = np.asarray(at_values)
     n_values = len(at_values)
@@ -355,38 +421,39 @@ def compute_predictive_margins(
     margins = np.zeros(n_values)
     se = np.zeros(n_values)
 
-    # Build design matrix once and extract the column index for `variable`.
-    # Each counterfactual only changes one column — no need to rebuild X or
-    # call predict() (which materialises a full Polars DataFrame) per value.
-    X_base = glm._build_prediction_matrix(data, fit)
     beta_vec = np.array([c.est for c in fit.coefs])
+    cov = fit.cov_matrix
+    terms = fit.feature_names
 
+    # The single-column fast path is only valid when `variable` is a plain
+    # feature column that appears in no interaction term; otherwise the
+    # interaction columns must be rebuilt from the counterfactual data.
+    in_interaction = any(":" in t and variable in t.split(":") for t in terms)
+    col_idx: int | None
     try:
-        col_idx = fit.feature_names.index(variable)
+        col_idx = terms.index(variable)
     except ValueError:
-        # variable is not directly a feature column (e.g. categorical base name);
-        # fall back to the original per-value predict() path
+        # e.g. categorical base name — needs the full rebuild path
         col_idx = None
 
+    X_base = glm._build_prediction_matrix(data, fit) if col_idx is not None else None
+
     for i, val in enumerate(at_values):
-        if col_idx is not None:
+        if col_idx is not None and not in_interaction:
             X_cf = X_base.copy()
             X_cf[:, col_idx] = float(val)
-            eta = X_cf @ beta_vec
-            yhat = link_inverse(fit.link, eta)
         else:
             cf_data = data.with_columns(pl.lit(val).alias(variable))
-            yhat = glm.predict(cf_data).yhat
+            X_cf = glm._build_prediction_matrix(cf_data, fit)
 
-        # Weighted mean
+        eta = X_cf @ beta_vec
+        yhat = link_inverse(fit.link, eta)
         margins[i] = np.sum(weights * yhat) / w_sum
 
-        # Survey variance of mean with finite population correction
-        ybar = margins[i]
-        n_obs = len(weights)
-        var_est = np.sum(weights**2 * (yhat - ybar) ** 2) / (w_sum**2)
-        var_est *= n_obs / (n_obs - 1)
-        se[i] = np.sqrt(var_est)
+        # Delta method: gradient of the weighted mean prediction w.r.t. beta
+        dmu_deta = link_mu_eta(fit.link, eta)
+        grad = (weights * dmu_deta) @ X_cf / w_sum
+        se[i] = np.sqrt(max(float(grad @ cov @ grad), 0.0))
 
     # Confidence intervals
     t_crit = stats.t.ppf(1 - alpha / 2, df)
@@ -413,37 +480,31 @@ def compute_average_marginal_effects(
 ) -> list[GLMMargins]:
     """
     Compute average marginal effects (AME) for continuous variables.
+
+    The marginal effect differentiates the full linear predictor, so a
+    variable appearing in interaction terms contributes
+    beta_x + beta_{x:z} * z (evaluated at observed z). SEs use the full
+    delta method over the design-based V(beta):
+    g_j = mean_w(mu''(eta) X_j deta_dx + mu'(eta) D_j), se^2 = g' V g.
     """
     fit = glm.fitted
-    sample = glm._sample
-
-    # Get original data
-    _raw2 = sample._data
-    data: pl.DataFrame = (
-        _raw2 if isinstance(_raw2, pl.DataFrame) else cast(pl.DataFrame, _raw2.collect())
-    )
-
-    # Get weights
-    design = sample._design
-    w_col = design.wgt or "_svy_ones_"
-    if design.wgt is None:
-        data = data.with_columns(pl.lit(1.0).alias(w_col))
-
-    weights = data.get_column(w_col).to_numpy().astype(float)
-    w_sum = weights.sum()
-
-    # Get df and coefficients
     if fit is None:
         raise ValueError("Model not fitted")
-    df = fit.coefs[0].wald.df if fit.coefs[0].wald else 1e6
-    beta = {c.term: c.est for c in fit.coefs}
-    beta_se = {c.term: c.se for c in fit.coefs}
+    if fit.cov_matrix is None:
+        raise ValueError("Covariance matrix not available")
 
-    # Get predictions on link scale
-    X = glm._build_prediction_matrix(data, fit)
+    data, weights = _fitted_frame(glm, fit)
+    w_sum = weights.sum()
+    df = _model_df(fit)
+
     beta_vec = np.array([c.est for c in fit.coefs])
+    cov = fit.cov_matrix
+
+    # Predictions on the link scale over the fitted rows
+    X = glm._build_prediction_matrix(data, fit)
     eta = X @ beta_vec
     dmu_deta = link_mu_eta(fit.link, eta)
+    d2mu_deta2 = link_mu_eta2(fit.link, eta)
 
     # Determine which variables to compute AME for
     term_info = fit.term_info or {}
@@ -459,16 +520,20 @@ def compute_average_marginal_effects(
     t_crit = stats.t.ppf(1 - alpha / 2, df)
 
     for var in variables:
-        if var not in beta:
+        D = _term_derivative_matrix(glm, fit, data, var)
+        if not D.any():
             log.warning(f"Variable '{var}' not found in model coefficients")
             continue
 
-        # AME = weighted mean of (dmu/deta * beta)
-        ame = np.sum(weights * dmu_deta * beta[var]) / w_sum
+        # d(eta)/d(var) per observation, including interaction terms
+        deta_dx = D @ beta_vec
+        ame = np.sum(weights * dmu_deta * deta_dx) / w_sum
 
-        # SE via delta method (simplified)
-        mean_dmu_deta = np.sum(weights * dmu_deta) / w_sum
-        se_val = abs(mean_dmu_deta) * beta_se[var]
+        # Full delta method: gradient of AME w.r.t. beta
+        grad_rows = (weights * d2mu_deta2 * deta_dx)[:, None] * X
+        grad_rows += (weights * dmu_deta)[:, None] * D
+        grad = grad_rows.sum(axis=0) / w_sum
+        se_val = np.sqrt(max(float(grad @ cov @ grad), 0.0))
 
         lci = ame - t_crit * se_val
         uci = ame + t_crit * se_val

--- a/packages/svy/src/svy/selection/allocation.py
+++ b/packages/svy/src/svy/selection/allocation.py
@@ -27,20 +27,66 @@ import warnings
 # ---------------------------------------------------------------------------
 
 
+def _apply_population_caps(
+    alloc: dict[str, int],
+    group_sizes: dict[str, int],
+    measure: dict[str, float],
+    *,
+    label: str,
+) -> dict[str, int]:
+    """
+    Cap each group's allocation at its frame count, redistributing the
+    surplus to groups with headroom (proportional to `measure`, Hamilton
+    largest-remainder rounding). Warns if the surplus cannot be placed.
+    """
+    import numpy as np
+
+    out = dict(alloc)
+    for _ in range(len(out)):
+        over = {g: out[g] - group_sizes[g] for g in out if out[g] > group_sizes[g]}
+        if not over:
+            return out
+        surplus = sum(over.values())
+        for g in over:
+            out[g] = group_sizes[g]
+        receivers = [g for g in out if out[g] < group_sizes[g]]
+        if not receivers:
+            warnings.warn(
+                f"{label}: total allocation reduced by {surplus} because every "
+                "group is capped at its frame size.",
+                stacklevel=4,
+            )
+            return out
+        m = np.array([max(measure.get(g, 0.0), 0.0) for g in receivers], dtype=np.float64)
+        if m.sum() <= 0:
+            m = np.ones(len(receivers), dtype=np.float64)
+        raw = m / m.sum() * surplus
+        base = np.floor(raw)
+        rem = surplus - int(base.sum())
+        order = np.argsort(-(raw - base))
+        for i in range(max(0, rem)):
+            base[order[i % len(order)]] += 1
+        for i, g in enumerate(receivers):
+            out[g] += int(base[i])
+    return out
+
+
 def _proportional_allocation(
     group_sizes: dict[str, int],
     n_total: int,
     *,
     min_n: int = 1,
+    cap_at_population: bool = True,
 ) -> dict[str, int]:
     """
     Allocate n_total units proportional to group size.
 
     Parameters
     ----------
-    group_sizes : {group_key: frame_count}
-    n_total     : target overall sample size
-    min_n       : floor allocation per non-empty group (default 1)
+    group_sizes       : {group_key: frame_count}
+    n_total           : target overall sample size
+    min_n             : floor allocation per non-empty group (default 1)
+    cap_at_population : cap n_h <= N_h, redistributing surplus (default True)
     """
     import numpy as np
 
@@ -69,6 +115,11 @@ def _proportional_allocation(
     remainder = n_total - int(floored.sum())
     if remainder < 0:
         # min_n forced over-allocation -- scale back
+        warnings.warn(
+            f"proportional_allocation: min_n={min_n} floors exceed n_total="
+            f"{n_total}; min_n is not honored and allocation is rescaled.",
+            stacklevel=3,
+        )
         floored = np.floor(raw * (n_total / raw.sum()))
         remainder = n_total - int(floored.sum())
 
@@ -77,7 +128,15 @@ def _proportional_allocation(
     for i in range(max(0, remainder)):
         floored[order[i % len(order)]] += 1
 
-    return {g: int(floored[i]) for i, g in enumerate(groups)}
+    result = {g: int(floored[i]) for i, g in enumerate(groups)}
+    if cap_at_population:
+        result = _apply_population_caps(
+            result,
+            group_sizes,
+            {g: float(group_sizes[g]) for g in groups},
+            label="proportional_allocation",
+        )
+    return result
 
 
 def _neyman_allocation(
@@ -86,20 +145,41 @@ def _neyman_allocation(
     n_total: int,
     *,
     min_n: int = 1,
+    cap_at_population: bool = True,
 ) -> dict[str, int]:
     """
     Neyman / optimal allocation: n_h proportional to N_h * SD_h.
 
     Parameters
     ----------
-    group_sizes : {group_key: frame_count}
-    group_sds   : {group_key: within-group SD of target variable}
-    n_total     : target overall sample size
-    min_n       : floor per non-empty group
+    group_sizes       : {group_key: frame_count}
+    group_sds         : {group_key: within-group SD of target variable};
+                        must cover every non-empty group
+    n_total           : target overall sample size
+    min_n             : floor per non-empty group
+    cap_at_population : cap n_h <= N_h, redistributing surplus (default True)
     """
     import numpy as np
 
     groups = list(group_sizes.keys())
+    missing = [g for g in groups if group_sizes[g] > 0 and g not in group_sds]
+    if missing:
+        raise ValueError(
+            f"neyman_allocation: group_sds is missing entries for non-empty "
+            f"groups {missing!r}. Provide an SD for every group."
+        )
+
+    if n_total <= 0:
+        raise ValueError(f"neyman_allocation: n_total must be > 0, got {n_total}.")
+    total_pop = sum(group_sizes.values())
+    if cap_at_population and n_total > total_pop:
+        warnings.warn(
+            f"neyman_allocation: n_total={n_total} exceeds the total frame "
+            f"size of {total_pop}. Capping at frame size.",
+            stacklevel=3,
+        )
+        n_total = total_pop
+
     N = np.array([group_sizes[g] for g in groups], dtype=np.float64)
     S = np.array([group_sds.get(g, 0.0) for g in groups], dtype=np.float64)
 
@@ -115,12 +195,30 @@ def _neyman_allocation(
     non_empty = N > 0
     floored = np.where(non_empty, np.maximum(np.floor(raw), min_n), 0.0)
     remainder = n_total - int(floored.sum())
+    if remainder < 0:
+        # min_n forced over-allocation -- scale back (mirror proportional)
+        warnings.warn(
+            f"neyman_allocation: min_n={min_n} floors exceed n_total="
+            f"{n_total}; min_n is not honored and allocation is rescaled.",
+            stacklevel=3,
+        )
+        floored = np.floor(raw * (n_total / raw.sum()))
+        remainder = n_total - int(floored.sum())
+
     fractional = raw - floored
     order = np.argsort(-fractional)
     for i in range(max(0, remainder)):
         floored[order[i % len(order)]] += 1
 
-    return {g: int(floored[i]) for i, g in enumerate(groups)}
+    result = {g: int(floored[i]) for i, g in enumerate(groups)}
+    if cap_at_population:
+        result = _apply_population_caps(
+            result,
+            group_sizes,
+            {g: float(measure[i]) for i, g in enumerate(groups)},
+            label="neyman_allocation",
+        )
+    return result
 
 
 def _equal_allocation(
@@ -230,14 +328,18 @@ def allocate(
     if method == "proportional":
         if n_total is None:
             raise ValueError("allocate(method='proportional') requires n_total=.")
-        return _proportional_allocation(group_sizes, n_total, min_n=min_n)
+        return _proportional_allocation(
+            group_sizes, n_total, min_n=min_n, cap_at_population=cap_at_population
+        )
 
     if method == "neyman":
         if n_total is None:
             raise ValueError("allocate(method='neyman') requires n_total=.")
         if group_sds is None:
             raise ValueError("allocate(method='neyman') requires group_sds=.")
-        return _neyman_allocation(group_sizes, group_sds, n_total, min_n=min_n)
+        return _neyman_allocation(
+            group_sizes, group_sds, n_total, min_n=min_n, cap_at_population=cap_at_population
+        )
 
     if method == "equal":
         if n_per_group is None:

--- a/packages/svy/src/svy/size/base.py
+++ b/packages/svy/src/svy/size/base.py
@@ -83,7 +83,7 @@ class SampleSize:
 
     @staticmethod
     def _is_size_obj(obj) -> bool:
-        return all(hasattr(obj, a) for a in ("n0", "n1_fpc", "n2_deff", "n"))
+        return all(hasattr(obj, a) for a in ("n0", "n1_deff", "n2_fpc", "n"))
 
     def _iter_sizes(self):
         """Return a flat list of Size-like objects from self._size."""
@@ -148,7 +148,7 @@ class SampleSize:
             include_stratum = stratified
 
         if not objs:
-            cols = (["stratum"] if include_stratum else []) + ["n0", "n1_fpc", "n2_deff", "n"]
+            cols = (["stratum"] if include_stratum else []) + ["n0", "n1_deff", "n2_fpc", "n"]
             return pl.DataFrame({c: [] for c in cols})
 
         from collections.abc import Iterable as _Iterable
@@ -156,7 +156,7 @@ class SampleSize:
         def _len_if_iter(x):
             return len(x) if isinstance(x, _Iterable) and not isinstance(x, (str, bytes)) else None
 
-        fields = ("n0", "n1_fpc", "n2_deff", "n")
+        fields = ("n0", "n1_deff", "n2_fpc", "n")
         group_len = None
         for s in objs:
             lens = {f: _len_if_iter(getattr(s, f)) for f in fields}
@@ -178,15 +178,15 @@ class SampleSize:
                 label = getattr(s, "stratum", None) or getattr(s, "domain", None) or "overall"
                 row: dict[str, object] = {
                     "n0": float(s.n0),
-                    "n1_fpc": float(s.n1_fpc),
-                    "n2_deff": float(s.n2_deff),
+                    "n1_deff": float(s.n1_deff),
+                    "n2_fpc": float(s.n2_fpc),
                     "n": float(s.n),
                 }
                 if include_stratum:
                     row["stratum"] = "" if label is None else str(label)
                 rows.append(row)
             df = pl.DataFrame(rows)
-            cols = (["stratum"] if include_stratum else []) + ["n0", "n1_fpc", "n2_deff", "n"]
+            cols = (["stratum"] if include_stratum else []) + ["n0", "n1_deff", "n2_fpc", "n"]
             df = df.select(cols)
         else:
             if not group_labels:
@@ -200,8 +200,8 @@ class SampleSize:
                     row: dict[str, object] = {
                         "group": group_labels[i],
                         "n0": float(n0[i]),
-                        "n1_fpc": float(n1[i]),
-                        "n2_deff": float(n2[i]),
+                        "n1_deff": float(n1[i]),
+                        "n2_fpc": float(n2[i]),
                         "n": float(n[i]),
                     }
                     if include_stratum:
@@ -211,8 +211,8 @@ class SampleSize:
             cols = (["stratum"] if include_stratum else []) + [
                 "group",
                 "n0",
-                "n1_fpc",
-                "n2_deff",
+                "n1_deff",
+                "n2_fpc",
                 "n",
             ]
             df = df.select(cols)
@@ -256,7 +256,7 @@ class SampleSize:
                 )
             else:
                 df = df.sort("group", descending=not ascending)
-        elif order_by in {"n", "n0", "n1_fpc", "n2_deff"}:
+        elif order_by in {"n", "n0", "n2_fpc", "n1_deff"}:
             df = df.sort(order_by, descending=not ascending)
 
         if include_stratum and "group" in df.columns and order_by in {"stratum", "group"}:
@@ -303,14 +303,14 @@ class SampleSize:
 
         if any_tuple:
             headers = (
-                ("group", "n0", "n1_fpc", "n2_deff", "n")
+                ("group", "n0", "n1_deff", "n2_fpc", "n")
                 if not stratified
-                else ("stratum", "group", "n0", "n1_fpc", "n2_deff", "n")
+                else ("stratum", "group", "n0", "n1_deff", "n2_fpc", "n")
             )
             rows = []
             for s in objs:
                 label = getattr(s, "stratum", None) or getattr(s, "domain", None) or "overall"
-                n0, n1, n2, n = s.n0, s.n1_fpc, s.n2_deff, s.n
+                n0, n1, n2, n = s.n0, s.n1_deff, s.n2_fpc, s.n
                 m = len(n)
                 _glabels = self._group_labels or [f"group{j + 1}" for j in range(m)]
                 for i in range(m):
@@ -324,17 +324,17 @@ class SampleSize:
                 rows.sort(key=lambda r: self._nat_key(r[0]))
         else:
             headers = (
-                ("n0", "n1_fpc", "n2_deff", "n")
+                ("n0", "n1_deff", "n2_fpc", "n")
                 if not stratified
-                else ("stratum", "n0", "n1_fpc", "n2_deff", "n")
+                else ("stratum", "n0", "n1_deff", "n2_fpc", "n")
             )
             rows = []
             for s in objs:
                 label = getattr(s, "stratum", None) or getattr(s, "domain", None) or "overall"
                 if stratified:
-                    rows.append((str(label), s.n0, s.n1_fpc, s.n2_deff, s.n))
+                    rows.append((str(label), s.n0, s.n1_deff, s.n2_fpc, s.n))
                 else:
-                    rows.append((s.n0, s.n1_fpc, s.n2_deff, s.n))
+                    rows.append((s.n0, s.n1_deff, s.n2_fpc, s.n))
             if stratified:
                 rows.sort(key=lambda r: self._nat_key(r[0]))
 
@@ -384,14 +384,14 @@ class SampleSize:
 
         if any_tuple:
             h = (
-                ["group", "n0", "n1_fpc", "n2_deff", "n"]
+                ["group", "n0", "n1_deff", "n2_fpc", "n"]
                 if not stratified
-                else ["stratum", "group", "n0", "n1_fpc", "n2_deff", "n"]
+                else ["stratum", "group", "n0", "n1_deff", "n2_fpc", "n"]
             )
             rows = []
             for s in objs:
                 label = getattr(s, "stratum", None) or getattr(s, "domain", None) or "overall"
-                n0, n1, n2, n = s.n0, s.n1_fpc, s.n2_deff, s.n
+                n0, n1, n2, n = s.n0, s.n1_deff, s.n2_fpc, s.n
                 m = len(n)
                 _glabels = self._group_labels or [f"group{j + 1}" for j in range(m)]
                 for i in range(m):
@@ -422,9 +422,9 @@ class SampleSize:
                 rows.sort(key=lambda r: self._nat_key(r[0]))
         else:
             h = (
-                ["n0", "n1_fpc", "n2_deff", "n"]
+                ["n0", "n1_deff", "n2_fpc", "n"]
                 if not stratified
-                else ["stratum", "n0", "n1_fpc", "n2_deff", "n"]
+                else ["stratum", "n0", "n1_deff", "n2_fpc", "n"]
             )
             rows = []
             for s in objs:
@@ -434,8 +434,8 @@ class SampleSize:
                         [
                             str(label),
                             self._fmt_num(s.n0),
-                            self._fmt_num(s.n1_fpc),
-                            self._fmt_num(s.n2_deff),
+                            self._fmt_num(s.n1_deff),
+                            self._fmt_num(s.n2_fpc),
                             self._fmt_num(s.n),
                         ]
                     )
@@ -443,8 +443,8 @@ class SampleSize:
                     rows.append(
                         [
                             self._fmt_num(s.n0),
-                            self._fmt_num(s.n1_fpc),
-                            self._fmt_num(s.n2_deff),
+                            self._fmt_num(s.n1_deff),
+                            self._fmt_num(s.n2_fpc),
                             self._fmt_num(s.n),
                         ]
                     )
@@ -611,14 +611,18 @@ class SampleSize:
 
     def compare_means(
         self,
-        mu1: Number,
-        mu2: Number,
+        mu1: Number | DomainScalarMap,
+        mu2: Number | DomainScalarMap,
+        sigma1: Number | DomainScalarMap,
+        sigma2: Number | DomainScalarMap | None = None,
         *,
         pop_size: Number | DomainScalarMap | None = None,
-        method: Literal["wald", "fleiss"] = "wald",
-        alloc_ratio: Number = 1.0,
-        alpha: Number = 0.05,
-        power: Number = 0.80,
+        two_sides: bool = True,
+        delta: Number | DomainScalarMap = 0.0,
+        alloc_ratio: Number | DomainScalarMap = 1.0,
+        method: Literal["wald"] = "wald",
+        alpha: Number | DomainScalarMap = 0.05,
+        power: Number | DomainScalarMap = 0.80,
         deff: Number | DomainScalarMap = 1.0,
         resp_rate: Number | DomainScalarMap = 1.0,
         group_labels: list[str] | None = None,
@@ -629,9 +633,13 @@ class SampleSize:
             self,
             mu1,
             mu2,
+            sigma1,
+            sigma2,
             pop_size=pop_size,
-            method=method,
+            two_sides=two_sides,
+            delta=delta,
             alloc_ratio=alloc_ratio,
+            method=method,
             alpha=alpha,
             power=power,
             deff=deff,

--- a/packages/svy/src/svy/size/comparison_goals.py
+++ b/packages/svy/src/svy/size/comparison_goals.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Literal, cast
 
+from svy.core.enumerations import MeanVarMode as _MeanVarMode
 from svy.core.enumerations import PopParam
 from svy.core.enumerations import (
     TwoPropsSizeMethod as _TwoPropsSizeMethod,
@@ -25,6 +26,7 @@ from svy.engine.size_and_power.size import (
     _apply_deff_pair,
     _apply_fpc_srswor_pair,
     _apply_nonresponse_pair,
+    _wald_sample_size_two_means,
     _wald_sample_size_two_props,
 )
 from svy.size._normalize import (
@@ -177,16 +179,17 @@ def compare_props(
     else:
         raise NotImplementedError("farrington-manning method is not implemented yet.")
 
-    n1_fpc = _apply_fpc_srswor_pair(n0=n0, pop_size=pop_size) if _has_pop(pop_size) else n0
-    n2_deff = _apply_deff_pair(n=n1_fpc, deff=deff)
-    n_final = _apply_nonresponse_pair(n=n2_deff, resp_rate=resp_rate)
+    # Pipeline: n0 (SRS) -> DEFF -> FPC -> nonresponse (see estimate_prop).
+    n1_deff = _apply_deff_pair(n=n0, deff=deff)
+    n2_fpc = _apply_fpc_srswor_pair(n0=n1_deff, pop_size=pop_size) if _has_pop(pop_size) else n1_deff
+    n_final = _apply_nonresponse_pair(n=n2_fpc, resp_rate=resp_rate)
     _build_sizes(
         ss,
         stratified=stratified,
         strata=strata if stratified else None,
         n0=n0,
-        n1_fpc=n1_fpc,
-        n2_deff=n2_deff,
+        n1_deff=n1_deff,
+        n2_fpc=n2_fpc,
         n_final=n_final,
     )
     return ss
@@ -194,14 +197,18 @@ def compare_props(
 
 def compare_means(
     ss: SampleSize,
-    mu1: Number,
-    mu2: Number,
+    mu1: Number | DomainScalarMap,
+    mu2: Number | DomainScalarMap,
+    sigma1: Number | DomainScalarMap,
+    sigma2: Number | DomainScalarMap | None = None,
     *,
     pop_size: Number | DomainScalarMap | None = None,
-    method: Literal["wald", "fleiss"] = "wald",
-    alloc_ratio: Number = 1.0,
-    alpha: Number = 0.05,
-    power: Number = 0.80,
+    two_sides: bool = True,
+    delta: Number | DomainScalarMap = 0.0,
+    alloc_ratio: Number | DomainScalarMap = 1.0,
+    method: Literal["wald"] = "wald",
+    alpha: Number | DomainScalarMap = 0.05,
+    power: Number | DomainScalarMap = 0.80,
     deff: Number | DomainScalarMap = 1.0,
     resp_rate: Number | DomainScalarMap = 1.0,
 ) -> SampleSize:
@@ -212,19 +219,28 @@ def compare_means(
     ----------
     ss : SampleSize
         The SampleSize instance to update.
-    mu1 : Number
-        Mean in group 1.
-    mu2 : Number
-        Mean in group 2.
+    mu1 : Number | DomainScalarMap
+        Mean in group 1. Scalar or per-stratum mapping.
+    mu2 : Number | DomainScalarMap
+        Mean in group 2. Scalar or per-stratum mapping.
+    sigma1 : Number | DomainScalarMap
+        Standard deviation in group 1. Scalar or per-stratum mapping.
+    sigma2 : Number | DomainScalarMap | None, default None
+        Standard deviation in group 2. If None, assumes equal variances
+        (sigma2 = sigma1).
     pop_size : Number | DomainScalarMap | None, default None
         Target population size. If None, no finite population correction is applied.
-    method : str, default 'wald'
-        Calculation method: ``'wald'`` or ``'fleiss'``.
-    alloc_ratio : Number, default 1.0
+    two_sides : bool, default True
+        Whether to use a two-sided test.
+    delta : Number | DomainScalarMap, default 0.0
+        Non-inferiority / equivalence margin.
+    alloc_ratio : Number | DomainScalarMap, default 1.0
         Allocation ratio n2/n1.
-    alpha : Number, default 0.05
+    method : str, default 'wald'
+        Calculation method. Only ``'wald'`` is currently implemented.
+    alpha : Number | DomainScalarMap, default 0.05
         Significance level.
-    power : Number, default 0.80
+    power : Number | DomainScalarMap, default 0.80
         Desired statistical power.
     deff : Number | DomainScalarMap, default 1.0
         Design effect. Scalar or per-stratum mapping.
@@ -235,10 +251,122 @@ def compare_means(
     -------
     SampleSize
         The updated SampleSize instance (chainable).
-
-    Notes
-    -----
-    Placeholder for future implementation; kept for API symmetry.
     """
+    from svy.errors.method_errors import MethodError
+
     ss._param = PopParam.MEAN
+
+    if method != "wald":
+        raise MethodError.invalid_choice(
+            where="SampleSize.compare_means",
+            param="method",
+            got=method,
+            allowed=["wald"],
+        )
+
+    stratified = any(
+        isinstance(v, Mapping)
+        for v in [
+            mu1,
+            mu2,
+            sigma1,
+            sigma2,
+            pop_size,
+            delta,
+            alloc_ratio,
+            alpha,
+            power,
+            deff,
+            resp_rate,
+        ]
+    )
+
+    if stratified:
+        strata = _get_keys_from_maps(
+            **{
+                k: v
+                for k, v in dict(
+                    mu1=mu1,
+                    mu2=mu2,
+                    sigma1=sigma1,
+                    sigma2=sigma2,
+                    pop_size=pop_size,
+                    delta=delta,
+                    alloc_ratio=alloc_ratio,
+                    alpha=alpha,
+                    power=power,
+                    deff=deff,
+                    resp_rate=resp_rate,
+                ).items()
+                if isinstance(v, Mapping)
+            }
+        )
+        params = {
+            "mu1": mu1,
+            "mu2": mu2,
+            "sigma1": sigma1,
+            "pop_size": pop_size,
+            "delta": delta,
+            "alloc_ratio": alloc_ratio,
+            "alpha": alpha,
+            "power": power,
+            "deff": deff,
+            "resp_rate": resp_rate,
+        }
+        if sigma2 is not None:
+            params["sigma2"] = sigma2
+        _broadcast_scalars(strata, params)
+        mu1, mu2, sigma1, pop_size, delta, alloc_ratio, alpha, power, deff, resp_rate = (
+            params["mu1"],
+            params["mu2"],
+            params["sigma1"],
+            params["pop_size"],
+            params["delta"],
+            params["alloc_ratio"],
+            params["alpha"],
+            params["power"],
+            params["deff"],
+            params["resp_rate"],
+        )
+        sigma2 = params.get("sigma2")
+    else:
+        all_scalars = all(
+            isinstance(x, (int, float))
+            for x in [mu1, mu2, sigma1, delta, alloc_ratio, alpha, power]
+        ) and (sigma2 is None or isinstance(sigma2, (int, float)))
+        assert all_scalars, "All inputs must be scalars when not stratified."
+
+    if stratified:
+        _mu1_map = cast(DomainScalarMap, mu1)
+        _mu2_map = cast(DomainScalarMap, mu2)
+        epsilon: Number | DomainScalarMap = {s: _mu2_map[s] - _mu1_map[s] for s in _mu1_map}
+    else:
+        epsilon = cast(Number, mu2) - cast(Number, mu1)
+
+    var_mode = _MeanVarMode.EQUAL_VAR if sigma2 is None else _MeanVarMode.UNEQUAL_VAR
+    n0 = _wald_sample_size_two_means(
+        two_sides=two_sides,
+        epsilon=epsilon,
+        delta=delta,
+        sigma_1=sigma1,
+        sigma_2=sigma2,
+        alloc_ratio=alloc_ratio,
+        alpha=alpha,
+        power=power,
+        var_mode=var_mode,
+    )
+
+    # Pipeline: n0 (SRS) -> DEFF -> FPC -> nonresponse (see estimate_prop).
+    n1_deff = _apply_deff_pair(n=n0, deff=deff)
+    n2_fpc = _apply_fpc_srswor_pair(n0=n1_deff, pop_size=pop_size) if _has_pop(pop_size) else n1_deff
+    n_final = _apply_nonresponse_pair(n=n2_fpc, resp_rate=resp_rate)
+    _build_sizes(
+        ss,
+        stratified=stratified,
+        strata=strata if stratified else None,
+        n0=n0,
+        n1_deff=n1_deff,
+        n2_fpc=n2_fpc,
+        n_final=n_final,
+    )
     return ss

--- a/packages/svy/src/svy/size/estimation_goals.py
+++ b/packages/svy/src/svy/size/estimation_goals.py
@@ -56,23 +56,23 @@ def _has_pop(pop_size) -> bool:
     return pop_size is not None
 
 
-def _build_sizes(ss, *, stratified: bool, strata, n0, n1_fpc, n2_deff, n_final) -> None:
+def _build_sizes(ss, *, stratified: bool, strata, n0, n1_deff, n2_fpc, n_final) -> None:
     """Assign Size object(s) to ss._size."""
     if not stratified:
         ss._size = Size(
             stratum=None,
             n0=cast(Number, n0),
-            n1_fpc=cast(Number, n1_fpc),
-            n2_deff=cast(Number, n2_deff),
+            n1_deff=cast(Number, n1_deff),
+            n2_fpc=cast(Number, n2_fpc),
             n=cast(Number, n_final),
         )
     else:
         _n0 = cast(DomainScalarMap, n0)
-        _n1 = cast(DomainScalarMap, n1_fpc)
-        _n2 = cast(DomainScalarMap, n2_deff)
+        _n1 = cast(DomainScalarMap, n1_deff)
+        _n2 = cast(DomainScalarMap, n2_fpc)
         _nf = cast(DomainScalarMap, n_final)
         ss._size = [
-            Size(stratum=str(s), n0=_n0[s], n1_fpc=_n1[s], n2_deff=_n2[s], n=_nf[s]) for s in _n0
+            Size(stratum=str(s), n0=_n0[s], n1_deff=_n1[s], n2_fpc=_n2[s], n=_nf[s]) for s in _n0
         ]
 
 
@@ -162,16 +162,19 @@ def estimate_prop(
     else:
         n0 = _fleiss_sample_size_prop(target=p, half_ci=moe, alpha=alpha)
 
-    n1_fpc = _apply_fpc_srswor(n0=n0, pop_size=pop_size) if _has_pop(pop_size) else n0
-    n2_deff = _apply_deff(n=n1_fpc, deff=deff)
-    n_final = _apply_nonresponse(n=n2_deff, resp_rate=resp_rate)
+    # Pipeline: n0 (SRS) -> DEFF -> FPC -> nonresponse. The design effect
+    # inflates the SRS size first; the FPC then shrinks toward pop_size, so
+    # the final n can never exceed the population.
+    n1_deff = _apply_deff(n=n0, deff=deff)
+    n2_fpc = _apply_fpc_srswor(n0=n1_deff, pop_size=pop_size) if _has_pop(pop_size) else n1_deff
+    n_final = _apply_nonresponse(n=n2_fpc, resp_rate=resp_rate)
     _build_sizes(
         ss,
         stratified=stratified,
         strata=strata if stratified else None,
         n0=n0,
-        n1_fpc=n1_fpc,
-        n2_deff=n2_deff,
+        n1_deff=n1_deff,
+        n2_fpc=n2_fpc,
         n_final=n_final,
     )
     return ss
@@ -265,16 +268,17 @@ def estimate_mean(
     else:
         raise NotImplementedError("Fleiss method is not implemented for the mean.")
 
-    n1_fpc = _apply_fpc_srswor(n0=n0, pop_size=pop_size) if _has_pop(pop_size) else n0
-    n2_deff = _apply_deff(n=n1_fpc, deff=deff)
-    n_final = _apply_nonresponse(n=n2_deff, resp_rate=resp_rate)
+    # Pipeline: n0 (SRS) -> DEFF -> FPC -> nonresponse (see estimate_prop).
+    n1_deff = _apply_deff(n=n0, deff=deff)
+    n2_fpc = _apply_fpc_srswor(n0=n1_deff, pop_size=pop_size) if _has_pop(pop_size) else n1_deff
+    n_final = _apply_nonresponse(n=n2_fpc, resp_rate=resp_rate)
     _build_sizes(
         ss,
         stratified=stratified,
         strata=strata if stratified else None,
         n0=n0,
-        n1_fpc=n1_fpc,
-        n2_deff=n2_deff,
+        n1_deff=n1_deff,
+        n2_fpc=n2_fpc,
         n_final=n_final,
     )
     return ss

--- a/packages/svy/src/svy/size/types.py
+++ b/packages/svy/src/svy/size/types.py
@@ -63,7 +63,7 @@ Target = TargetProp | TargetMean | TargetTwoProps | TargetTwoMeans
 
 class Size(msgspec.Struct, frozen=True, tag="size"):
     stratum: str | None = None
-    n0: Number | tuple[Number, Number] = 0  # base (no FPC/DEFF/nonresponse)
-    n1_fpc: Number | tuple[Number, Number] | None = None  # after FPC (if pop_size provided)
-    n2_deff: Number | tuple[Number, Number] | None = None  # after DEFF
+    n0: Number | tuple[Number, Number] = 0  # base (no DEFF/FPC/nonresponse)
+    n1_deff: Number | tuple[Number, Number] | None = None  # after DEFF
+    n2_fpc: Number | tuple[Number, Number] | None = None  # after FPC (if pop_size provided)
     n: Number | tuple[Number, Number] = 0  # final after nonresponse adjustment

--- a/packages/svy/tests/svy/regression/test_glm_margins.py
+++ b/packages/svy/tests/svy/regression/test_glm_margins.py
@@ -19,11 +19,17 @@ DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
 # =============================================================================
 # R Reference Values
 # =============================================================================
-
-# R: Logistic AME (manual calculation)
-# ame_ell = -0.0009982936
-# ame_meals = -0.0080360454
-# ame_mobility = 0.0007552178
+# Generated with R survey 4.5 + marginaleffects 0.32.0 (2026-07-23):
+#
+#   api <- read.csv("apistrat.csv"); api$y_bin <- as.integer(api$api00 > 600)
+#   d1 <- svydesign(ids=~1, weights=~pw, data=api)
+#   m1 <- svyglm(y_bin ~ ell + meals + mobility, design=d1, family=quasibinomial())
+#   avg_slopes(m1, wts=weights(m1))
+#   avg_predictions(m1, variables=list(meals=c(20,50,80)), by="meals", wts=weights(m1))
+#
+# `wts=weights(fit)` makes marginaleffects average with the design weights
+# (Stata `margins` convention). SEs are delta-method over vcov(svyglm),
+# i.e. g'V(beta)g with covariates fixed — the convention svy implements.
 
 R_LOGISTIC_AME = {
     "ell": -0.0009982936,
@@ -31,16 +37,46 @@ R_LOGISTIC_AME = {
     "mobility": 0.0007552178,
 }
 
-# R: Predictive margins at meals = 20, 50, 80
-# mean SE
-# pred_20 0.96989 0.0005
-# pred_50 0.77227 0.0031
-# pred_80 0.26554 0.0032
+R_LOGISTIC_AME_SE = {
+    "ell": 0.0016047333,
+    "meals": 0.0010179779,
+    "mobility": 0.0019007082,
+}
 
 R_PREDICTIVE_MARGINS = {
     "values": np.array([20, 50, 80]),
-    "margin": np.array([0.96989, 0.77227, 0.26554]),
-    "se": np.array([0.0005, 0.0031, 0.0032]),
+    "margin": np.array([0.9698889120, 0.7722732242, 0.2655410705]),
+    "se": np.array([0.0158168043, 0.0400183429, 0.0813343039]),
+}
+
+# R: interaction model m2 <- svyglm(y_bin ~ ell * meals, design=d1, ...)
+R_INTERACTION_AME = {
+    "ell": (-0.0014277197, 0.0017420001),
+    "meals": (-0.0077599270, 0.0011161544),
+}
+
+R_INTERACTION_PREDICTIVE = {
+    "values": np.array([20, 50, 80]),
+    "margin": np.array([0.9621412052, 0.7593207994, 0.2591576034]),
+    "se": np.array([0.0305195844, 0.0513012146, 0.0813251070]),
+}
+
+# R: Cat x continuous m3 <- svyglm(y_bin ~ awards * ell, design=d1, ...)
+R_CAT_INTERACTION_AME_ELL = (-0.0101530922, 0.0010906246)
+
+# R: stratified design + domain fit
+#   d4 <- svydesign(ids=~1, strata=~stype, weights=~pw, data=api)
+#   m4 <- svyglm(y_bin ~ ell + meals, design=subset(d4, awards=="Yes"),
+#                family=quasibinomial())
+R_DOMAIN_AME = {
+    "ell": (-0.0002686150, 0.0016696858),
+    "meals": (-0.0085233748, 0.0014792988),
+}
+
+R_DOMAIN_PREDICTIVE = {
+    "values": np.array([20, 50, 80]),
+    "margin": np.array([0.9935953493, 0.8893161765, 0.2943536384]),
+    "se": np.array([0.0067214884, 0.0402467347, 0.1307085096]),
 }
 
 # R: Linear AME (just coefficients)
@@ -52,6 +88,12 @@ R_LINEAR_AME = {
 
 RTOL = 1e-2  # 1% tolerance for margins
 ATOL = 1e-4
+
+# Margin point estimates should agree with R to numerical precision; SEs to
+# ~1e-4 relative (marginaleffects uses a numerical Jacobian, svy an
+# analytic gradient).
+RTOL_EST = 1e-6
+RTOL_SE = 5e-4
 
 
 # =============================================================================
@@ -116,6 +158,21 @@ class TestGLMMarginAME:
             ame_dict["mobility"], R_LOGISTIC_AME["mobility"], rtol=RTOL, atol=ATOL
         )
 
+    def test_logistic_ame_se_vs_r(self, api_binary):
+        """Logistic AME delta-method SEs match R marginaleffects."""
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", "mobility"],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins()
+        se_dict = {m.term: m.se[0] for m in margins}
+
+        for var, se in R_LOGISTIC_AME_SE.items():
+            np.testing.assert_allclose(se_dict[var], se, rtol=RTOL_SE)
+
     def test_ame_returns_list(self, api_strat):
         """AME returns list of GLMMargins."""
         sample = Sample(api_strat, Design(wgt="pw"))
@@ -162,9 +219,7 @@ class TestGLMMarginPredictive:
 
         margins = model.margins(at={"meals": [20, 50, 80]})
 
-        np.testing.assert_allclose(
-            margins.margin, R_PREDICTIVE_MARGINS["margin"], rtol=RTOL, atol=ATOL
-        )
+        np.testing.assert_allclose(margins.margin, R_PREDICTIVE_MARGINS["margin"], rtol=RTOL_EST)
 
     def test_predictive_margins_se_vs_r(self, api_binary):
         """Predictive margins SE matches R."""
@@ -177,13 +232,7 @@ class TestGLMMarginPredictive:
 
         margins = model.margins(at={"meals": [20, 50, 80]})
 
-        # SE tolerance is looser due to simplified variance estimation
-        np.testing.assert_allclose(
-            margins.se,
-            R_PREDICTIVE_MARGINS["se"],
-            rtol=0.5,
-            atol=0.01,  # Allow 50% relative difference for SE
-        )
+        np.testing.assert_allclose(margins.se, R_PREDICTIVE_MARGINS["se"], rtol=RTOL_SE)
 
     def test_predictive_margins_returns_single(self, api_binary):
         """Single at variable returns single GLMMargins."""
@@ -216,6 +265,130 @@ class TestGLMMarginPredictive:
         margins = model.margins(at={"meals": [20, 50, 80]})
 
         np.testing.assert_array_equal(margins.values, np.array([20, 50, 80]))
+
+
+# =============================================================================
+# Interaction, Domain, and Missing-Data Tests
+# =============================================================================
+
+
+class TestGLMMarginInteractions:
+    """Margins for models with interaction terms (Round 8: R2/R3)."""
+
+    def test_interaction_ame_vs_r(self, api_binary):
+        """AME differentiates the full linear predictor incl. ell:meals."""
+        from svy.core.terms import Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", Cross("ell", "meals")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = {m.term: m for m in model.margins()}
+        for var, (est, se) in R_INTERACTION_AME.items():
+            np.testing.assert_allclose(margins[var].margin[0], est, rtol=RTOL_EST)
+            np.testing.assert_allclose(margins[var].se[0], se, rtol=RTOL_SE)
+
+    def test_interaction_predictive_margins_vs_r(self, api_binary):
+        """Counterfactuals rebuild interaction columns (no stale ell:meals)."""
+        from svy.core.terms import Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals", Cross("ell", "meals")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins(at={"meals": [20, 50, 80]})
+        np.testing.assert_allclose(
+            margins.margin, R_INTERACTION_PREDICTIVE["margin"], rtol=RTOL_EST
+        )
+        np.testing.assert_allclose(margins.se, R_INTERACTION_PREDICTIVE["se"], rtol=RTOL_SE)
+
+    def test_cat_interaction_ame_vs_r(self, api_binary):
+        """AME for a continuous variable interacted with a Cat term."""
+        from svy.core.terms import Cat, Cross
+
+        sample = Sample(api_binary, Design(wgt="pw"))
+        model = sample.glm.fit(
+            y="y_bin",
+            x=[Cat("awards"), "ell", Cross(Cat("awards"), "ell")],
+            family=DistFamily.BINOMIAL,
+        )
+
+        margins = model.margins(variables=["ell"])
+        est, se = R_CAT_INTERACTION_AME_ELL
+        np.testing.assert_allclose(margins[0].margin[0], est, rtol=RTOL_EST)
+        np.testing.assert_allclose(margins[0].se[0], se, rtol=RTOL_SE)
+
+
+class TestGLMMarginDomain:
+    """Margins after a domain (where=) fit use the fitted rows (Round 8: R1)."""
+
+    def _domain_model(self, api_binary):
+        import svy
+
+        sample = Sample(api_binary, Design(stratum="stype", wgt="pw"))
+        return sample.glm.fit(
+            y="y_bin",
+            x=["ell", "meals"],
+            family=DistFamily.BINOMIAL,
+            where=svy.col("awards") == "Yes",
+        )
+
+    def test_domain_ame_vs_r(self, api_binary):
+        """AME after where= matches R svyglm on subset(design, ...)."""
+        model = self._domain_model(api_binary)
+
+        margins = {m.term: m for m in model.margins()}
+        for var, (est, se) in R_DOMAIN_AME.items():
+            np.testing.assert_allclose(margins[var].margin[0], est, rtol=RTOL_EST)
+            np.testing.assert_allclose(margins[var].se[0], se, rtol=RTOL_SE)
+
+    def test_domain_predictive_margins_vs_r(self, api_binary):
+        """Predictive margins after where= average over in-domain rows only."""
+        model = self._domain_model(api_binary)
+
+        margins = model.margins(at={"meals": [20, 50, 80]})
+        np.testing.assert_allclose(margins.margin, R_DOMAIN_PREDICTIVE["margin"], rtol=RTOL_EST)
+        np.testing.assert_allclose(margins.se, R_DOMAIN_PREDICTIVE["se"], rtol=RTOL_SE)
+
+
+class TestGLMMarginInvariants:
+    """Structural invariants of the delta-method margins."""
+
+    def test_identity_link_ame_se_equals_coef_se(self, api_strat):
+        """For the identity link, AME == coef and se(AME) == se(coef)."""
+        sample = Sample(api_strat, Design(wgt="pw"))
+        model = sample.glm.fit(y="api00", x=["ell", "meals", "mobility"])
+
+        coef = {c.term: c for c in model.fitted.coefs}
+        for m in model.margins():
+            np.testing.assert_allclose(m.margin[0], coef[m.term].est, rtol=1e-12)
+            np.testing.assert_allclose(m.se[0], coef[m.term].se, rtol=1e-12)
+
+    def test_null_covariates_do_not_propagate_nan(self, api_binary):
+        """Margins average over the fitted rows, so covariate nulls
+        (dropped at fit time) cannot produce NaN margins."""
+        data = api_binary.with_columns(
+            pl.when(pl.int_range(pl.len()) < 5)
+            .then(None)
+            .otherwise(pl.col("ell"))
+            .alias("ell")
+        )
+        sample = Sample(data, Design(wgt="pw"))
+        model = sample.glm.fit(y="y_bin", x=["ell", "meals"], family=DistFamily.BINOMIAL)
+
+        ame = model.margins(variables=["ell"])[0]
+        assert np.isfinite(ame.margin[0])
+        assert np.isfinite(ame.se[0])
+
+        pred = model.margins(at={"meals": [20, 50]})
+        assert np.all(np.isfinite(pred.margin))
+        assert np.all(np.isfinite(pred.se))
 
 
 # =============================================================================

--- a/packages/svy/tests/svy/selection/test_allocation.py
+++ b/packages/svy/tests/svy/selection/test_allocation.py
@@ -1,0 +1,136 @@
+"""
+Allocation helper tests (round 8, SZ11).
+
+Covers population capping with redistribution, missing-SD validation,
+and min_n over-allocation handling for proportional / neyman.
+"""
+
+import pytest
+
+from svy.selection.allocation import allocate
+
+
+# =============================================================================
+# Neyman — group_sds validation
+# =============================================================================
+
+
+def test_neyman_missing_sds_raises():
+    """Missing SD keys silently defaulted to 0.0 (min_n allocation) before."""
+    with pytest.raises(ValueError, match="missing entries"):
+        allocate(
+            {"a": 100, "b": 100},
+            method="neyman",
+            n_total=50,
+            group_sds={"a": 10.0},
+        )
+
+
+def test_neyman_missing_sds_for_empty_group_ok():
+    """Empty groups need no SD entry."""
+    out = allocate(
+        {"a": 100, "b": 0},
+        method="neyman",
+        n_total=50,
+        group_sds={"a": 10.0},
+    )
+    assert out == {"a": 50, "b": 0}
+
+
+# =============================================================================
+# Population caps (cap_at_population=True is the default)
+# =============================================================================
+
+
+def test_neyman_caps_at_frame_size_and_redistributes():
+    """a: N*SD = 10*100 = 1000, b: 1000*1 = 1000 -> raw 50/50, but a has
+    only 10 units; surplus flows to b."""
+    out = allocate(
+        {"a": 10, "b": 1000},
+        method="neyman",
+        n_total=100,
+        group_sds={"a": 100.0, "b": 1.0},
+    )
+    assert out == {"a": 10, "b": 90}
+    assert sum(out.values()) == 100
+
+
+def test_neyman_uncapped_when_disabled():
+    out = allocate(
+        {"a": 10, "b": 1000},
+        method="neyman",
+        n_total=100,
+        group_sds={"a": 100.0, "b": 1.0},
+        cap_at_population=False,
+    )
+    assert out["a"] == 50
+    assert out["b"] == 50
+
+
+def test_proportional_min_n_over_allocation_rescales_and_respects_caps():
+    """min_n=5 floors (a:5, b:49) exceed n_total=50 -> warn, drop min_n,
+    rescale; nothing exceeds its frame count."""
+    with pytest.warns(UserWarning, match="min_n"):
+        out = allocate(
+            {"a": 2, "b": 100},
+            method="proportional",
+            n_total=50,
+            min_n=5,
+        )
+    assert sum(out.values()) == 50
+    assert out["a"] <= 2
+    assert out["b"] <= 100
+
+
+def test_neyman_n_total_exceeding_frame_warns_and_caps():
+    with pytest.warns(UserWarning, match="exceeds the total frame"):
+        out = allocate(
+            {"a": 10, "b": 20},
+            method="neyman",
+            n_total=100,
+            group_sds={"a": 1.0, "b": 1.0},
+        )
+    assert out == {"a": 10, "b": 20}
+
+
+# =============================================================================
+# min_n over-allocation
+# =============================================================================
+
+
+def test_proportional_min_n_overallocation_warns():
+    """Floors (5 groups x min_n=1) exceed n_total=3 -> warn + rescale."""
+    sizes = {g: 100 for g in "abcde"}
+    with pytest.warns(UserWarning, match="min_n"):
+        out = allocate(sizes, method="proportional", n_total=3)
+    assert sum(out.values()) == 3
+
+
+def test_neyman_min_n_overallocation_warns():
+    sizes = {g: 100 for g in "abcde"}
+    sds = {g: 1.0 for g in "abcde"}
+    with pytest.warns(UserWarning, match="min_n"):
+        out = allocate(sizes, method="neyman", n_total=3, group_sds=sds)
+    assert sum(out.values()) == 3
+
+
+# =============================================================================
+# Exact-sum property preserved
+# =============================================================================
+
+
+@pytest.mark.parametrize("n_total", [7, 50, 111])
+def test_proportional_exact_sum(n_total):
+    out = allocate({"a": 300, "b": 500, "c": 200}, method="proportional", n_total=n_total)
+    assert sum(out.values()) == n_total
+
+
+@pytest.mark.parametrize("n_total", [7, 50, 111])
+def test_neyman_exact_sum(n_total):
+    out = allocate(
+        {"a": 300, "b": 500, "c": 200},
+        method="neyman",
+        n_total=n_total,
+        group_sds={"a": 5.0, "b": 2.0, "c": 8.0},
+    )
+    assert sum(out.values()) == n_total

--- a/packages/svy/tests/svy/size/test_correctness.py
+++ b/packages/svy/tests/svy/size/test_correctness.py
@@ -17,10 +17,15 @@ def test_samp_size_dict_wald():
 # ============================================================
 # Sample size to estimate proportion
 # ============================================================
+# Pipeline (round 8, SZ6): n0 (SRS) -> DEFF -> FPC -> nonresponse.
+# Expected chains recomputed by hand from the pinned n0 values:
+#   n1_deff = ceil(deff * n0)
+#   n2_fpc  = ceil(N * n1_deff / (N + n1_deff - 1))   (when pop_size given)
+#   n       = ceil(n2_fpc / resp_rate)
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(p=0.8, moe=0.10, pop_size=None, deff=1.0, resp_rate=1.0),
@@ -32,23 +37,23 @@ def test_samp_size_dict_wald():
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.0, resp_rate=1.0),
             62,
-            59,
+            62,
             59,
             59,
         ),
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.5, resp_rate=1.0),
             62,
-            59,
-            89,
-            89,
+            93,
+            86,
+            86,
         ),
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.5, resp_rate=0.85),
             62,
-            59,
-            89,
-            105,
+            93,
+            86,
+            102,
         ),
     ],
     ids=[
@@ -58,17 +63,17 @@ def test_samp_size_dict_wald():
         "finite_pop_deff_nr_85",
     ],
 )
-def test_samp_size_prop_wald(args, n0, n_fpc, n_deff, n):
+def test_samp_size_prop_wald(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_prop(**args)
 
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(
@@ -94,7 +99,7 @@ def test_samp_size_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=1.0,
             ),
             88,
-            81,
+            88,
             81,
             81,
         ),
@@ -108,9 +113,9 @@ def test_samp_size_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=1.0,
             ),
             88,
-            81,
-            122,
-            122,
+            132,
+            117,
+            117,
         ),
         (
             dict(
@@ -122,9 +127,9 @@ def test_samp_size_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=0.85,
             ),
             88,
-            81,
-            122,
-            144,
+            132,
+            117,
+            138,
         ),
     ],
     ids=[
@@ -134,12 +139,12 @@ def test_samp_size_prop_wald(args, n0, n_fpc, n_deff, n):
         "finite_pop_deff_nr_85",
     ],
 )
-def test_samp_size_prop_fleiss(args, n0, n_fpc, n_deff, n):
+def test_samp_size_prop_fleiss(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_prop(**args)
 
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -149,7 +154,7 @@ def test_samp_size_prop_fleiss(args, n0, n_fpc, n_deff, n):
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(sigma=30, moe=5, pop_size=None, deff=1.0, resp_rate=1.0),
@@ -161,23 +166,23 @@ def test_samp_size_prop_fleiss(args, n0, n_fpc, n_deff, n):
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.0, resp_rate=1.0),
             139,
-            123,
+            139,
             123,
             123,
         ),
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.5, resp_rate=1.0),
             139,
-            123,
-            185,
-            185,
+            209,
+            174,
+            174,
         ),
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.5, resp_rate=0.85),
             139,
-            123,
-            185,
-            218,
+            209,
+            174,
+            205,
         ),
     ],
     ids=[
@@ -187,12 +192,12 @@ def test_samp_size_prop_fleiss(args, n0, n_fpc, n_deff, n):
         "finite_pop_deff_nr_85",
     ],
 )
-def test_samp_size_mean_wald(args, n0, n_fpc, n_deff, n):
+def test_samp_size_mean_wald(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_mean(**args)
 
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -202,7 +207,7 @@ def test_samp_size_mean_wald(args, n0, n_fpc, n_deff, n):
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(
@@ -251,9 +256,9 @@ def test_samp_size_mean_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=1.0,
             ),
             (25, 25),
-            (25, 25),
             (38, 38),
-            (38, 38),
+            (37, 37),
+            (37, 37),
         ),
         (
             dict(
@@ -268,9 +273,9 @@ def test_samp_size_mean_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=0.85,
             ),
             (25, 25),
-            (25, 25),
             (38, 38),
-            (45, 45),
+            (37, 37),
+            (44, 44),
         ),
     ],
     ids=[
@@ -280,10 +285,10 @@ def test_samp_size_mean_wald(args, n0, n_fpc, n_deff, n):
         "finite_pop_deff_nr_85",
     ],
 )
-def test_samp_size_compare_props(args, n0, n_fpc, n_deff, n):
+def test_samp_size_compare_props(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().compare_props(**args)
 
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n

--- a/packages/svy/tests/svy/size/test_extra.py
+++ b/packages/svy/tests/svy/size/test_extra.py
@@ -54,10 +54,18 @@ def test_chaining_returns_same_instance():
     assert result is ss
 
 
-def test_compare_means_placeholder():
-    """compare_means is a placeholder — should return without error."""
-    ss = SampleSize().compare_means(mu1=10.0, mu2=12.0)
+def test_compare_means_basic():
+    """compare_means computes group sizes (round 8, SZ1).
+
+    Hand-computed Wald/CSW reference: n/group =
+    (z_{a/2}+z_b)^2 (s1^2 + s2^2/kappa) / (mu2-mu1)^2
+    = (1.959964+0.841621)^2 * 50 / 4 = 98.11 -> 99.
+    (statsmodels zt_ind_solve_power(effect_size=0.4, alpha=0.05,
+    power=0.8) = 98.1 confirms.)
+    """
+    ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=5.0)
     assert isinstance(ss, SampleSize)
+    assert ss.size.n0 == (99, 99)
 
 
 # =============================================================================
@@ -66,7 +74,7 @@ def test_compare_means_placeholder():
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(p=0.8, moe=0.10, pop_size=None, deff=1.0, resp_rate=1.0),
@@ -78,23 +86,23 @@ def test_compare_means_placeholder():
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.0, resp_rate=1.0),
             62,
-            59,
+            62,
             59,
             59,
         ),
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.5, resp_rate=1.0),
             62,
-            59,
-            89,
-            89,
+            93,
+            86,
+            86,
         ),
         (
             dict(p=0.8, moe=0.10, pop_size=1000, deff=1.5, resp_rate=0.85),
             62,
-            59,
-            89,
-            105,
+            93,
+            86,
+            102,
         ),
     ],
     ids=[
@@ -104,11 +112,11 @@ def test_compare_means_placeholder():
         "finite_pop_deff_nr_85",
     ],
 )
-def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
+def test_estimate_prop_wald(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_prop(**args)
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -118,7 +126,7 @@ def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(
@@ -144,7 +152,7 @@ def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=1.0,
             ),
             88,
-            81,
+            88,
             81,
             81,
         ),
@@ -158,9 +166,9 @@ def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=1.0,
             ),
             88,
-            81,
-            122,
-            122,
+            132,
+            117,
+            117,
         ),
         (
             dict(
@@ -172,9 +180,9 @@ def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
                 resp_rate=0.85,
             ),
             88,
-            81,
-            122,
-            144,
+            132,
+            117,
+            138,
         ),
     ],
     ids=[
@@ -184,11 +192,11 @@ def test_estimate_prop_wald(args, n0, n_fpc, n_deff, n):
         "finite_pop_deff_nr_85",
     ],
 )
-def test_estimate_prop_fleiss(args, n0, n_fpc, n_deff, n):
+def test_estimate_prop_fleiss(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_prop(**args)
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -207,19 +215,19 @@ def test_estimate_prop_stratified_all_dicts():
     )
     sizes = {s.stratum: s for s in ss.size}
     assert sizes["r1"].n0 == 323
-    assert sizes["r1"].n1_fpc == 304
-    assert sizes["r1"].n2_deff == 456
-    assert sizes["r1"].n == 537
+    assert sizes["r1"].n1_deff == 485
+    assert sizes["r1"].n2_fpc == 443
+    assert sizes["r1"].n == 522
 
     assert sizes["r2"].n0 == 151
-    assert sizes["r2"].n1_fpc == 149
-    assert sizes["r2"].n2_deff == 224
-    assert sizes["r2"].n == 264
+    assert sizes["r2"].n1_deff == 227
+    assert sizes["r2"].n2_fpc == 221
+    assert sizes["r2"].n == 260
 
     assert sizes["r3"].n0 == 225
-    assert sizes["r3"].n1_fpc == 210
-    assert sizes["r3"].n2_deff == 315
-    assert sizes["r3"].n == 371
+    assert sizes["r3"].n1_deff == 338
+    assert sizes["r3"].n2_fpc == 304
+    assert sizes["r3"].n == 358
 
 
 def test_estimate_prop_stratified_strata_count():
@@ -246,19 +254,19 @@ def test_estimate_prop_mixed_pop_size_dict_others_scalar():
     )
     sizes = {s.stratum: s for s in ss.size}
     assert sizes["r1"].n0 == 385
-    assert sizes["r1"].n1_fpc == 218
-    assert sizes["r1"].n2_deff == 262
-    assert sizes["r1"].n == 292
+    assert sizes["r1"].n1_deff == 462
+    assert sizes["r1"].n2_fpc == 241
+    assert sizes["r1"].n == 268
 
     assert sizes["r2"].n0 == 385
-    assert sizes["r2"].n1_fpc == 323
-    assert sizes["r2"].n2_deff == 388
-    assert sizes["r2"].n == 432
+    assert sizes["r2"].n1_deff == 462
+    assert sizes["r2"].n2_fpc == 376
+    assert sizes["r2"].n == 418
 
     assert sizes["r3"].n0 == 385
-    assert sizes["r3"].n1_fpc == 371
-    assert sizes["r3"].n2_deff == 446
-    assert sizes["r3"].n == 496
+    assert sizes["r3"].n1_deff == 462
+    assert sizes["r3"].n2_fpc == 442
+    assert sizes["r3"].n == 492
 
 
 def test_estimate_prop_mixed_resp_rate_dict_others_scalar():
@@ -270,8 +278,8 @@ def test_estimate_prop_mixed_resp_rate_dict_others_scalar():
         resp_rate={"r1": 1.0, "r2": 0.90},
     )
     sizes = {s.stratum: s for s in ss.size}
-    assert sizes["r1"].n == sizes["r1"].n2_deff  # resp_rate=1 -> n == n2_deff
-    assert sizes["r2"].n > sizes["r2"].n2_deff  # resp_rate<1 -> n > n2_deff
+    assert sizes["r1"].n == sizes["r1"].n2_fpc  # resp_rate=1 -> n == n2_fpc
+    assert sizes["r2"].n > sizes["r2"].n2_fpc  # resp_rate<1 -> n > n2_fpc
 
 
 # =============================================================================
@@ -280,27 +288,27 @@ def test_estimate_prop_mixed_resp_rate_dict_others_scalar():
 
 
 def test_estimate_prop_deff_one_identity():
-    """deff=1.0 -> n2_deff == n1_fpc."""
+    """deff=1.0 -> n1_deff == n0."""
     ss = SampleSize().estimate_prop(p=0.5, moe=0.05, pop_size=1000, deff=1.0, resp_rate=1.0)
-    assert ss.size.n2_deff == ss.size.n1_fpc
+    assert ss.size.n1_deff == ss.size.n0
 
 
 def test_estimate_prop_resp_rate_one_identity():
-    """resp_rate=1.0 -> n == n2_deff."""
+    """resp_rate=1.0 -> n == n2_fpc."""
     ss = SampleSize().estimate_prop(p=0.5, moe=0.05, pop_size=1000, deff=1.5, resp_rate=1.0)
-    assert ss.size.n == ss.size.n2_deff
+    assert ss.size.n == ss.size.n2_fpc
 
 
 def test_estimate_prop_large_pop_no_fpc():
-    """Very large pop_size -> n1_fpc ~= n0."""
+    """Very large pop_size -> n2_fpc ~= n1_deff."""
     ss = SampleSize().estimate_prop(p=0.5, moe=0.05, pop_size=10_000_000)
-    assert ss.size.n1_fpc == ss.size.n0
+    assert ss.size.n2_fpc == ss.size.n1_deff
 
 
 def test_estimate_prop_no_pop_size_no_fpc():
-    """pop_size=None -> n1_fpc == n0."""
+    """pop_size=None -> n2_fpc == n1_deff."""
     ss = SampleSize().estimate_prop(p=0.5, moe=0.05)
-    assert ss.size.n1_fpc == ss.size.n0
+    assert ss.size.n2_fpc == ss.size.n1_deff
 
 
 # =============================================================================
@@ -373,7 +381,7 @@ def test_estimate_prop_lower_resp_rate_larger_n():
 def test_estimate_prop_finite_pop_smaller_n():
     ss_inf = SampleSize().estimate_prop(p=0.5, moe=0.05)
     ss_fin = SampleSize().estimate_prop(p=0.5, moe=0.05, pop_size=500)
-    assert ss_fin.size.n1_fpc <= ss_inf.size.n0
+    assert ss_fin.size.n2_fpc <= ss_inf.size.n0
 
 
 # =============================================================================
@@ -382,7 +390,7 @@ def test_estimate_prop_finite_pop_smaller_n():
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(sigma=30, moe=5, pop_size=None, deff=1.0, resp_rate=1.0),
@@ -394,23 +402,23 @@ def test_estimate_prop_finite_pop_smaller_n():
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.0, resp_rate=1.0),
             139,
-            123,
+            139,
             123,
             123,
         ),
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.5, resp_rate=1.0),
             139,
-            123,
-            185,
-            185,
+            209,
+            174,
+            174,
         ),
         (
             dict(sigma=30, moe=5, pop_size=1000, deff=1.5, resp_rate=0.85),
             139,
-            123,
-            185,
-            218,
+            209,
+            174,
+            205,
         ),
     ],
     ids=[
@@ -420,11 +428,11 @@ def test_estimate_prop_finite_pop_smaller_n():
         "finite_pop_deff_nr_85",
     ],
 )
-def test_estimate_mean_wald(args, n0, n_fpc, n_deff, n):
+def test_estimate_mean_wald(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().estimate_mean(**args)
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -443,18 +451,18 @@ def test_estimate_mean_stratified_all_dicts():
     sizes = {s.stratum: s for s in ss.size}
 
     assert sizes["r1"].n0 == 189
-    assert sizes["r1"].n1_fpc == 189
-    assert sizes["r1"].n2_deff == 227
+    assert sizes["r1"].n1_deff == 227
+    assert sizes["r1"].n2_fpc == 227
     assert sizes["r1"].n == 239
 
     assert sizes["r2"].n0 == 276
-    assert sizes["r2"].n1_fpc == 276
-    assert sizes["r2"].n2_deff == 332
+    assert sizes["r2"].n1_deff == 332
+    assert sizes["r2"].n2_fpc == 332
     assert sizes["r2"].n == 369
 
     assert sizes["r3"].n0 == 196
-    assert sizes["r3"].n1_fpc == 196
-    assert sizes["r3"].n2_deff == 236
+    assert sizes["r3"].n1_deff == 236
+    assert sizes["r3"].n2_fpc == 236
     assert sizes["r3"].n == 278
 
 
@@ -473,12 +481,12 @@ def test_estimate_mean_stratified_strata_count():
 
 def test_estimate_mean_deff_one_identity():
     ss = SampleSize().estimate_mean(sigma=30, moe=5, pop_size=1000, deff=1.0, resp_rate=1.0)
-    assert ss.size.n2_deff == ss.size.n1_fpc
+    assert ss.size.n1_deff == ss.size.n0
 
 
 def test_estimate_mean_resp_rate_one_identity():
     ss = SampleSize().estimate_mean(sigma=30, moe=5, deff=1.5, resp_rate=1.0)
-    assert ss.size.n == ss.size.n2_deff
+    assert ss.size.n == ss.size.n2_fpc
 
 
 def test_estimate_mean_larger_sigma_larger_n():
@@ -499,7 +507,7 @@ def test_estimate_mean_smaller_moe_larger_n():
 
 
 @pytest.mark.parametrize(
-    "args,n0,n_fpc,n_deff,n",
+    "args,n0,n_deff,n_fpc,n",
     [
         (
             dict(
@@ -548,9 +556,9 @@ def test_estimate_mean_smaller_moe_larger_n():
                 resp_rate=1.0,
             ),
             (25, 25),
-            (25, 25),
             (38, 38),
-            (38, 38),
+            (37, 37),
+            (37, 37),
         ),
         (
             dict(
@@ -565,9 +573,9 @@ def test_estimate_mean_smaller_moe_larger_n():
                 resp_rate=0.85,
             ),
             (25, 25),
-            (25, 25),
             (38, 38),
-            (45, 45),
+            (37, 37),
+            (44, 44),
         ),
     ],
     ids=[
@@ -577,11 +585,11 @@ def test_estimate_mean_smaller_moe_larger_n():
         "finite_pop_deff_nr_85",
     ],
 )
-def test_compare_props_wald(args, n0, n_fpc, n_deff, n):
+def test_compare_props_wald(args, n0, n_deff, n_fpc, n):
     ss = SampleSize().compare_props(**args)
     assert ss.size.n0 == n0
-    assert ss.size.n1_fpc == n_fpc
-    assert ss.size.n2_deff == n_deff
+    assert ss.size.n1_deff == n_deff
+    assert ss.size.n2_fpc == n_fpc
     assert ss.size.n == n
 
 
@@ -654,12 +662,12 @@ def test_compare_props_alloc_ratio_one_equal_groups():
 
 def test_compare_props_deff_one_identity():
     ss = SampleSize().compare_props(p1=0.3, p2=0.5, pop_size=1000, deff=1.0, resp_rate=1.0)
-    assert ss.size.n2_deff == ss.size.n1_fpc
+    assert ss.size.n1_deff == ss.size.n0
 
 
 def test_compare_props_resp_rate_one_identity():
     ss = SampleSize().compare_props(p1=0.3, p2=0.5, deff=1.5, resp_rate=1.0)
-    assert ss.size.n == ss.size.n2_deff
+    assert ss.size.n == ss.size.n2_fpc
 
 
 # =============================================================================
@@ -742,7 +750,7 @@ def test_param_none_before_any_call():
 def test_to_polars_unstratified_columns():
     ss = SampleSize().estimate_prop(p=0.5, moe=0.05)
     df = ss.to_polars()
-    assert set(df.columns) == {"n0", "n1_fpc", "n2_deff", "n"}
+    assert set(df.columns) == {"n0", "n1_deff", "n2_fpc", "n"}
 
 
 def test_to_polars_stratified_has_stratum_column():
@@ -788,13 +796,16 @@ def test_compare_props_custom_labels_in_ascii():
 
 
 def test_compare_means_default_group_labels():
-    ss = SampleSize().compare_means(mu1=10.0, mu2=12.0)
-    # compare_means is a placeholder so _size is None — just check no error
+    ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=5.0)
     assert ss._group_labels is None
+    df = ss.to_polars()
+    assert list(df["group"]) == ["group1", "group2"]
 
 
 def test_compare_means_custom_group_labels_stored():
-    ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, group_labels=["control", "treatment"])
+    ss = SampleSize().compare_means(
+        mu1=10.0, mu2=12.0, sigma1=5.0, group_labels=["control", "treatment"]
+    )
     assert ss._group_labels == ["control", "treatment"]
 
 

--- a/packages/svy/tests/svy/size/test_round8_formulas.py
+++ b/packages/svy/tests/svy/size/test_round8_formulas.py
@@ -1,0 +1,282 @@
+"""
+Round 8 size & power formula fixes (findings SZ1-SZ10).
+
+Reference values are hand-computed from the Chow-Shao-Wang / Cochran
+formulas with z-quantiles from scipy (za2 = 1.959964, za1 = 1.644854,
+zb80 = 0.841621); each test states its derivation.
+"""
+
+import numpy as np
+import pytest
+
+from svy import SampleSize
+from svy.core.enumerations import MeanVarMode
+from svy.engine.size_and_power.power import calculate_power
+from svy.engine.size_and_power.size import (
+    _wald_sample_size_one_mean_scalar,
+    _wald_sample_size_two_means_scalar,
+)
+from svy.errors import MethodError
+
+
+# =============================================================================
+# SZ1 — compare_means is implemented
+# =============================================================================
+
+
+class TestCompareMeans:
+    def test_equal_var(self):
+        """n/group = (za2+zb)^2 * 2*sigma^2 / eps^2 = 7.848886*50/4 -> 99."""
+        ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=5.0)
+        assert ss.size.n0 == (99, 99)
+
+    def test_unequal_var(self):
+        """n1 = (za2+zb)^2 (s1^2 + s2^2/k) / eps^2 = 7.848886*(16+36)/4 -> 103."""
+        ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=4.0, sigma2=6.0)
+        assert ss.size.n0 == (103, 103)
+
+    def test_non_inferiority(self):
+        """CSW NI: eps=-0.2, delta=-0.5 -> denom=0.3.
+        n1 = (1.959964+0.841621)^2 * 8 / 0.09 -> 698."""
+        ss = SampleSize().compare_means(
+            mu1=10.0,
+            mu2=9.8,
+            sigma1=2.0,
+            delta=-0.5,
+            two_sides=False,
+            alpha=0.025,
+            power=0.80,
+        )
+        assert ss.size.n0 == (698, 698)
+
+    def test_alloc_ratio(self):
+        ss = SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=5.0, alloc_ratio=2.0)
+        n1, n2 = ss.size.n0
+        assert n2 == 2 * n1
+
+    def test_stratified(self):
+        ss = SampleSize().compare_means(
+            mu1={"r1": 10.0, "r2": 20.0},
+            mu2={"r1": 12.0, "r2": 24.0},
+            sigma1={"r1": 5.0, "r2": 10.0},
+        )
+        sizes = {s.stratum: s for s in ss.size}
+        assert sizes["r1"].n0 == (99, 99)
+        # r2 has doubled eps and sigma -> identical n
+        assert sizes["r2"].n0 == (99, 99)
+
+    def test_requires_sigma(self):
+        with pytest.raises(TypeError):
+            SampleSize().compare_means(mu1=10.0, mu2=12.0)
+
+    def test_invalid_method_raises(self):
+        with pytest.raises(MethodError):
+            SampleSize().compare_means(mu1=10.0, mu2=12.0, sigma1=5.0, method="fleiss")
+
+
+# =============================================================================
+# SZ2 — one-mean power-size denominator
+# =============================================================================
+
+
+def test_one_mean_power_size_two_sided():
+    """Two-sided delta=0 superiority: n = (za2+zb)^2 sigma^2 / eps^2 = 32
+    (the old clamp gave ~7.85e24)."""
+    n = _wald_sample_size_one_mean_scalar(
+        two_sides=True, epsilon=0.5, delta=0.0, sigma=1.0, alpha=0.05, power=0.80
+    )
+    assert n == 32
+
+
+def test_one_mean_power_size_negative_epsilon():
+    """Signed epsilon: same magnitude -> same n."""
+    n = _wald_sample_size_one_mean_scalar(
+        two_sides=True, epsilon=-0.5, delta=0.0, sigma=1.0, alpha=0.05, power=0.80
+    )
+    assert n == 32
+
+
+# =============================================================================
+# SZ3 — one-sided power direction follows sign(delta)
+# =============================================================================
+
+
+class TestOneSidedPowerDirection:
+    def test_scalar_matches_array(self):
+        scalar = calculate_power(False, -1.0, 1.0, 25, 0.05)
+        arr = calculate_power(
+            False, np.array([-1.0]), np.array([1.0]), np.array([25.0]), 0.05
+        )
+        assert scalar == pytest.approx(float(arr[0]), rel=1e-12)
+        # Phi(-zc + 5) = 0.99960 (the old hardcoded "greater" gave ~1.5e-11)
+        assert scalar == pytest.approx(0.9996034, abs=1e-6)
+
+    def test_scalar_sign_symmetry(self):
+        up = calculate_power(False, 1.0, 1.0, 25, 0.05)
+        down = calculate_power(False, -1.0, 1.0, 25, 0.05)
+        assert up == pytest.approx(down, rel=1e-12)
+
+    def test_map_matches_scalar(self):
+        out = calculate_power(
+            False, {"a": -1.0, "b": 1.0}, {"a": 1.0, "b": 1.0}, {"a": 25, "b": 25}, 0.05
+        )
+        assert out["a"] == pytest.approx(out["b"], rel=1e-12)
+        assert out["a"] == pytest.approx(0.9996034, abs=1e-6)
+
+
+# =============================================================================
+# SZ4 — non-inferiority uses signed epsilon (denominator eps - delta)
+# =============================================================================
+
+
+class TestNonInferioritySigned:
+    def test_two_props_ni(self):
+        """CSW: p1=.60, p2=.58 (eps=-.02), delta=-.05 -> denom=.03.
+        var = .6*.4 + .58*.42 = .4836; n1 = .4836*((za2+zb)/.03)^2 -> 4218
+        (the old |eps| denominator gave 775/group: ~22% achieved power)."""
+        ss = SampleSize().compare_props(
+            p1=0.60,
+            p2=0.58,
+            delta=-0.05,
+            two_sides=False,
+            alpha=0.025,
+            power=0.80,
+        )
+        assert ss.size.n0 == (4218, 4218)
+
+    def test_superiority_unchanged(self):
+        """delta=0: signed eps changes nothing (denominator squared)."""
+        ss = SampleSize().compare_props(p1=0.3, p2=0.5, two_sides=False)
+        assert ss.size.n0 == (72, 72)
+
+    def test_equivalence_branch_keeps_delta_minus_abs_eps(self):
+        """Two-sided delta!=0 equivalence: denom = delta - |eps| = 0.4.
+        n1 = (za1 + z_{(1+b)/2})^2 * 2 / 0.16 -> 108."""
+        n1, n2 = _wald_sample_size_two_means_scalar(
+            two_sides=True,
+            epsilon=0.1,
+            delta=0.5,
+            sigma_1=1.0,
+            kappa=1.0,
+            alpha=0.05,
+            power=0.80,
+        )
+        assert (n1, n2) == (108, 108)
+
+    def test_equivalence_infeasible_raises(self):
+        """|eps| >= delta cannot reach equivalence power."""
+        with pytest.raises(MethodError):
+            _wald_sample_size_two_means_scalar(
+                two_sides=True,
+                epsilon=0.6,
+                delta=0.5,
+                sigma_1=1.0,
+                kappa=1.0,
+                alpha=0.05,
+                power=0.80,
+            )
+
+
+# =============================================================================
+# SZ5 — p/moe validation
+# =============================================================================
+
+
+class TestParamValidation:
+    @pytest.mark.parametrize("p", [-0.2, 0.0, 1.0, 1.5])
+    def test_estimate_prop_invalid_p_raises(self, p):
+        with pytest.raises(MethodError):
+            SampleSize().estimate_prop(p=p, moe=0.05)
+
+    @pytest.mark.parametrize("moe", [-0.1, 0.0, 5.0])
+    def test_estimate_prop_invalid_moe_raises(self, moe):
+        with pytest.raises(MethodError):
+            SampleSize().estimate_prop(p=0.5, moe=moe)
+
+    def test_compare_props_invalid_p_raises(self):
+        """The old code silently clipped p1=1.5 to ~1."""
+        with pytest.raises(MethodError):
+            SampleSize().compare_props(p1=1.5, p2=0.5)
+
+
+# =============================================================================
+# SZ7 — pooled-proportion weights under unequal allocation
+# =============================================================================
+
+
+def test_pooled_prop_unequal_allocation():
+    """kappa = n2/n1 = 3: pooled p = (p1 + 3*p2)/4 = 0.525.
+    var_factor = v + v/3 = 0.3325; n1 = 0.3325*((za2+zb)/0.1)^2 -> 261
+    (the swapped weights gave 256)."""
+    ss = SampleSize().compare_props(
+        p1=0.6, p2=0.5, alloc_ratio=3.0, var_mode="pooled-prop"
+    )
+    assert ss.size.n0 == (261, 783)
+
+
+# =============================================================================
+# SZ8 — clear errors instead of cryptic crashes
+# =============================================================================
+
+
+class TestCrashGuards:
+    def test_power_out_of_range_raises(self):
+        """power=80 used to crash with 'cannot convert float NaN to integer'."""
+        with pytest.raises(MethodError):
+            SampleSize().compare_props(p1=0.3, p2=0.5, power=80)
+
+    def test_delta_equals_epsilon_raises(self):
+        """delta == eps used to crash with OverflowError."""
+        with pytest.raises(MethodError):
+            SampleSize().compare_props(
+                p1=0.6, p2=0.5, delta=-0.10, two_sides=False
+            )
+
+
+# =============================================================================
+# SZ9 — no silent parameter sanitization
+# =============================================================================
+
+
+class TestNoSilentSanitization:
+    def test_resp_rate_percent_raises(self):
+        """resp_rate=90 (percent instead of fraction) used to be ignored."""
+        with pytest.raises(MethodError):
+            SampleSize().estimate_prop(p=0.5, moe=0.05, resp_rate=90)
+
+    def test_negative_deff_raises(self):
+        with pytest.raises(MethodError):
+            SampleSize().estimate_prop(p=0.5, moe=0.05, deff=-2.0)
+
+    def test_negative_sigma_raises(self):
+        """sigma=-5 used to be clamped to ~0, giving n0=1."""
+        with pytest.raises(MethodError):
+            SampleSize().estimate_mean(sigma=-5, moe=1)
+
+    def test_comparison_resp_rate_raises(self):
+        with pytest.raises(MethodError):
+            SampleSize().compare_props(p1=0.3, p2=0.5, resp_rate=85)
+
+
+# =============================================================================
+# SZ10 — optimal allocation ratio orientation (kappa = n2/n1)
+# =============================================================================
+
+
+def test_optimal_kappa_two_means_unequal_var():
+    """With kappa unset, the total-n-minimizing ratio is sigma2/sigma1:
+    sigma1=2, sigma2=6 -> kappa=3, so n2 = 3*n1."""
+    n1, n2 = _wald_sample_size_two_means_scalar(
+        two_sides=True,
+        epsilon=1.0,
+        delta=0.0,
+        sigma_1=2.0,
+        sigma_2=6.0,
+        kappa=None,
+        alpha=0.05,
+        power=0.80,
+        var_mode=MeanVarMode.UNEQUAL_VAR,
+    )
+    assert n2 == 3 * n1
+    # n1 = (za2+zb)^2 (4 + 36/3) / 1 = 7.848886*16 -> 126
+    assert n1 == 126


### PR DESCRIPTION
## Summary

Round 8 review findings SZ1–SZ11: the size & power stack had one silent no-op API, several wrong formulas (worst: ~5x under-sizing of non-inferiority designs), and pervasive silent parameter sanitization.

### Wrong results fixed
- **SZ4 (severe)** — non-inferiority sizing collapsed ε to |ε|; the denominator is now the signed **ε − δ** (Chow–Shao–Wang, H0: ε ≤ δ), with **δ − |ε|** reserved for the two-sided equivalence branch. At the CSW reference case (p1=0.60, p2=0.58, δ=−0.05, one-sided α=0.025, power 0.8) the old code returned n=775/group (achieved power ≈ 0.22); correct is 4218.
- **SZ2** — the one-mean power-size primitive clamped a legitimately negative denominator to 1e-12 before squaring (n ≈ 7.85e24 for the standard two-sided case; correct: 32).
- **SZ3** — scalar/map `calculate_power` hardcoded the "greater" direction; now follows sign(delta) like the array flavor.
- **SZ7** — pooled two-prop variance used swapped weights; now `(p1 + κ·p2)/(1+κ)` for κ=n2/n1.
- **SZ10** — optimal allocation ratios were inverted; now σ2/σ1 and √(v2/v1).
- **SZ6** — adjustment pipeline reordered to **n0 → DEFF → FPC → nonresponse** so the FPC caps the deff-inflated size toward the population (deff-after-FPC previously produced n=591 for a population of 400). **Breaking:** `Size` result fields renamed `n1_fpc`/`n2_deff` → `n1_deff`/`n2_fpc` to match the new order (maintainer-approved).

### API / robustness
- **SZ1** — `compare_means()` was a silent no-op stub (no sigma parameter existed; `.size` stayed None). Now implemented with `sigma1`/`sigma2`, `delta`, `two_sides`, `alloc_ratio`, and stratified support (maintainer chose implement over block).
- **SZ5/SZ8/SZ9** — typed `MethodError` validation for p/moe ∈ (0,1), σ > 0, 0 < power < 1, deff > 0, resp_rate ∈ (0,1]; infeasible designs (ε == δ) raise a clear error instead of NaN-cast/OverflowError crashes; `resp_rate=90`, `deff=-2`, `sigma=-5` no longer sanitized silently (maintainer chose errors over warnings).
- **SZ11** — allocation: neyman raises on missing `group_sds` entries, proportional/neyman honor `cap_at_population` with surplus redistribution, min_n over-allocation warns before rescaling.

## Validation

- New formula tests carry hand-computed CSW/Cochran derivations in their docstrings (references match the round-8 review evidence: 4218, 32, 261, 0.9996, etc.); `compare_means` cross-checked against statsmodels `zt_ind_solve_power`.
- Pipeline test expectations regenerated arithmetically from the unchanged pinned n0 values: `n1_deff = ceil(deff·n0)`, `n2_fpc = ceil(N·n1_deff/(N+n1_deff−1))`, `n = ceil(n2_fpc/rr)`.
- The existing NI test cases (ε=+0.20, δ=−0.10) pin denominators whose magnitude is unchanged by the sign fix — their n values were already correct and did not shift.

## Tests

`uv run pytest tests --ignore=tests/benchmark_test.py` → 2681 passed, 1 skipped (46 new/updated tests over the PR #83 baseline).