### PR TITLE
fix(weighting): adjustment/calibration/trimming marshalling batch

### DIFF
--- a/packages/svy/src/svy/weighting/_calibration_utils.py
+++ b/packages/svy/src/svy/weighting/_calibration_utils.py
@@ -9,13 +9,14 @@ construction — they are not general-purpose weighting utilities.
 
 from __future__ import annotations
 
-from typing import Sequence
+from typing import Any, Sequence
 
 import numpy as np
 import polars as pl
 
 from svy.core.terms import Cat, Cross, Feature
 from svy.core.types import Category, Number
+from svy.errors import DimensionError
 
 
 def _expand_term(
@@ -24,7 +25,21 @@ def _expand_term(
     if isinstance(term, str):
         if term not in df.columns:
             raise KeyError(f"{where}: Continuous term '{term}' not found in data.")
-        return [pl.col(term).cast(pl.Float64).fill_null(0.0)], [term]
+        n_null = int(df.get_column(term).is_null().sum())
+        if n_null > 0:
+            # Silently filling with 0 would bias the calibration totals; the
+            # Cat branch treats null as an explicit level needing a target,
+            # so a continuous auxiliary must be complete.
+            raise DimensionError(
+                title="Missing values in continuous auxiliary",
+                detail=f"Column '{term}' has {n_null} null value(s).",
+                code="AUX_NA",
+                where=where,
+                param=str(term),
+                hint="Impute or drop missing values (e.g. wrangling.fill_null) "
+                "before calibrating on this auxiliary.",
+            )
+        return [pl.col(term).cast(pl.Float64)], [term]
 
     if isinstance(term, Cat):
         col_name = term.name

--- a/packages/svy/src/svy/weighting/adjustment.py
+++ b/packages/svy/src/svy/weighting/adjustment.py
@@ -35,10 +35,21 @@ def _encode_resp_status(
     resp_status_arr: np.ndarray,
     resp_mapping: DomainScalarMap | None,
 ) -> np.ndarray:
-    codes = np.zeros(len(resp_status_arr), dtype=np.int64)
+    """
+    Encode response statuses to the Rust integer codes (0=rr, 1=nr, 2=in, 3=uk).
+
+    Every row must match a mapping entry (or a canonical label when no mapping
+    is given) — code 0 means "respondent", so letting unmatched rows fall
+    through would silently inflate their weights. Mapping values may be
+    scalars or collections (e.g. {"nr": ["refusal", "noncontact"]}).
+    """
+    n = len(resp_status_arr)
+    codes = np.zeros(n, dtype=np.int64)
+    matched = np.zeros(n, dtype=bool)
     lower = np.char.lower(resp_status_arr.astype(str))
 
     if resp_mapping is not None:
+        allowed_labels: list[str] = []
         for canonical_key, data_label in resp_mapping.items():
             key_lower = str(canonical_key).lower()
             if key_lower not in _CANONICAL_TO_INT:
@@ -49,10 +60,34 @@ def _encode_resp_status(
                     allowed=list(_CANONICAL_TO_INT.keys()),
                     hint="Use canonical response status codes: rr, nr, in, uk.",
                 )
-            codes[lower == str(data_label).lower()] = _CANONICAL_TO_INT[key_lower]
+            labels = (
+                list(data_label)
+                if isinstance(data_label, (list, tuple, set, frozenset, np.ndarray))
+                else [data_label]
+            )
+            for lab in labels:
+                mask = lower == str(lab).lower()
+                codes[mask] = _CANONICAL_TO_INT[key_lower]
+                matched |= mask
+                allowed_labels.append(str(lab))
     else:
+        allowed_labels = list(_CANONICAL_TO_INT.keys())
         for label, code in _CANONICAL_TO_INT.items():
-            codes[lower == label] = code
+            mask = lower == label
+            codes[mask] = code
+            matched |= mask
+
+    if not matched.all():
+        unmatched = sorted(set(resp_status_arr[~matched].astype(str)))
+        raise MethodError.invalid_choice(
+            where="Sample.weighting.adjust",
+            param="resp_status",
+            got=unmatched[:10],
+            allowed=allowed_labels,
+            hint="Every response status value (including nulls) must match a "
+            "resp_mapping entry, or a canonical code (rr/nr/in/uk) when "
+            "resp_mapping is None.",
+        )
 
     return codes
 
@@ -166,24 +201,43 @@ def adjust(
     sample._data = df
 
     if respondents_only:
-
-        def _resp_mask_expr(col: str, mapping: dict | None) -> pl.Expr:
-            if mapping is None:
-                return pl.col(col) == "rr"
-            rr_codes = mapping.get("rr", "rr")
-            if isinstance(rr_codes, (list, tuple, set, np.ndarray)):
-                return pl.col(col).is_in(list(rr_codes))
-            return pl.col(col) == rr_codes
-
-        sample._data = sample._data.filter(_resp_mask_expr(resp_status, resp_mapping))
+        # Filter from the encoded codes (0 == respondent) — the single source
+        # of truth already used for the adjustment itself. Re-deriving the
+        # mask from raw strings was case-sensitive while the encoder is not,
+        # which could silently empty the sample.
+        sample._data = sample._data.filter(pl.Series("__resp_mask__", resp_codes == 0))
 
     if trimming is not None:
-        sample = _apply_trim(
-            sample,
-            trimming,
-            replace=True,
-            update_design_wgts=update_design_wgts,
-            where="Sample.weighting.adjust",
-        )
+        if update_design_wgts:
+            sample = _apply_trim(
+                sample,
+                trimming,
+                replace=True,
+                update_design_wgts=True,
+                where="Sample.weighting.adjust",
+            )
+        else:
+            # The trim must target the freshly created adjusted weight (and
+            # its replicate columns), not the caller's original design weight:
+            # point the design at the new columns for the trim, then restore.
+            original_design = sample._design
+            tmp_design = original_design.update(wgt=wgt_name)
+            if not ignore_reps and design.rep_wgts is not None:
+                tmp_design = tmp_design.update_rep_weights(
+                    method=design.rep_wgts.method,
+                    prefix=wgt_name,
+                    n_reps=len(design.rep_wgts.columns),
+                    fay_coef=design.rep_wgts.fay_coef,
+                    df=design.rep_wgts.df,
+                )
+            sample._design = tmp_design
+            sample = _apply_trim(
+                sample,
+                trimming,
+                replace=True,
+                update_design_wgts=False,
+                where="Sample.weighting.adjust",
+            )
+            sample._design = original_design
 
     return sample

--- a/packages/svy/src/svy/weighting/calibration.py
+++ b/packages/svy/src/svy/weighting/calibration.py
@@ -48,10 +48,12 @@ except ImportError:  # pragma: no cover
 
 from svy.core.terms import Feature
 from svy.core.types import Category, Number
+from svy.core.warnings import Severity, WarnCode
 from svy.errors import DimensionError, MethodError
 from svy.weighting._calibration_utils import _expand_term, _match_term_targets
 from svy.weighting._helpers import _build_by_array, _by_to_cols, _normalize_dict_keys
 from svy.weighting.raking import _trim_constraints_satisfied
+from svy.weighting.trimming import _build_domain_array
 from svy.weighting.types import TrimConfig, resolve_threshold
 
 
@@ -214,26 +216,27 @@ def calibrate(
 
     X, shape_template = build_aux_matrix(sample, x=terms, by=by)
 
-    if is_global:
-        x_labels = list(shape_template.keys())
-    else:
-        x_labels = list(next(iter(shape_template.values())).keys())
+    # Ordered per-term label lists. Targets are matched per term and kept as
+    # ordered flat lists end-to-end — routing them through label-keyed dicts
+    # collapsed duplicate level labels across terms (e.g. two Cats sharing
+    # numeric codes), breaking the column alignment.
+    term_label_lists: list[tuple[Feature, list[Category]]] = []
+    x_labels: list[Category] = []
+    for term in terms:
+        _, term_labs = _expand_term(term, sample.data, where)
+        term_label_lists.append((term, term_labs))
+        x_labels.extend(term_labs)
+
+    if X.shape[1] != len(x_labels):
+        raise RuntimeError("Internal error: Design matrix label alignment mismatch.")
 
     final_control_arg: Any
 
     if is_global:
         flat_targets = []
-        cursor = 0
-        for term in terms:
-            _, term_labs = _expand_term(term, sample.data, where)
-            k = len(term_labs)
-            segment_labels = x_labels[cursor : cursor + k]
-            if segment_labels != term_labs:
-                raise RuntimeError("Internal error: Design matrix label alignment mismatch.")
-            spec = controls[term]
-            vals = _match_term_targets(segment_labels, spec, str(term))
+        for term, term_labs in term_label_lists:
+            vals = _match_term_targets(term_labs, controls[term], str(term))
             flat_targets.extend(vals)
-            cursor += k
         final_control_arg = np.array(flat_targets, dtype=float)
     else:
         final_control_arg = {}
@@ -251,22 +254,17 @@ def calibrate(
 
         for domain, domain_specs in controls.items():
             flat_targets = []
-            cursor = 0
-            for term in terms:
+            for term, term_labs in term_label_lists:
                 if term not in domain_specs:
                     raise MethodError.invalid_mapping_keys(
                         where=where,
                         param=f"controls[{domain!r}]",
                         missing=[str(term)],
                     )
-                _, term_labs = _expand_term(term, sample.data, where)
-                k = len(term_labs)
-                segment_labels = x_labels[cursor : cursor + k]
-                spec = domain_specs[term]
-                vals = _match_term_targets(segment_labels, spec, str(term))
+                vals = _match_term_targets(term_labs, domain_specs[term], str(term))
                 flat_targets.extend(vals)
-                cursor += k
-            final_control_arg[domain] = dict(zip(x_labels, flat_targets))
+            # Ordered list (not a label-keyed dict): aligned with X columns
+            final_control_arg[domain] = flat_targets
 
     return calibrate_matrix(
         sample,
@@ -277,7 +275,7 @@ def calibrate(
         bounded=bounded,
         wgt_name=wgt_name,
         update_design_wgts=update_design_wgts,
-        labels=x_labels,
+        labels=None,
         weights_only=False,
         ignore_reps=ignore_reps,
         strict=strict,
@@ -316,6 +314,16 @@ def calibrate_matrix(
     trimming: TrimConfig | None = None,
 ) -> Any:
     where = "Sample.weighting.calibrate_matrix"
+
+    if bounded:
+        # Accepting-and-ignoring this flag previously produced bit-identical
+        # results to bounded=False.
+        raise NotImplementedError(
+            "bounded calibration (distance-bounded g-weights, as in R survey's "
+            "calibrate(bounds=)) is not implemented yet. Use trimming= to "
+            "constrain calibrated weights, or leave bounded=False."
+        )
+
     df: pl.DataFrame = sample.data
     design = sample._design
 
@@ -467,6 +475,150 @@ def calibrate_matrix(
             reason=f"Column '{wgt_name}' already exists. Choose a different wgt_name.",
         )
 
+    # ── Trim-calibrate cycle ──────────────────────────────────────────────
+    # Runs on arrays BEFORE anything is written to the sample, so a strict
+    # failure genuinely leaves the data and design untouched.
+    if trimming is not None:
+        # Resolve trim domains (honor TrimConfig.by / min_cell_size, matching
+        # the contract adjust()/trim() already implement)
+        if trimming.by is not None:
+            t_by_cols = (
+                [trimming.by] if isinstance(trimming.by, str) else list(trimming.by)
+            )
+            missing_by = [c for c in t_by_cols if c not in df.columns]
+            if missing_by:
+                raise MethodError.invalid_choice(
+                    where=where,
+                    param="trimming.by",
+                    got=missing_by,
+                    allowed=list(df.columns),
+                    hint="All trimming by= columns must exist in the data.",
+                )
+            _trim_dom_arr = _build_domain_array(df, t_by_cols)
+            _group_masks = [(str(d), _trim_dom_arr == d) for d in np.unique(_trim_dom_arr)]
+        else:
+            _group_masks = [("(global)", np.ones(len(new_w), dtype=bool))]
+
+        # Thresholds resolved once per domain from the initial calibrated
+        # weights; domains below min_cell_size are skipped with a warning.
+        trim_groups: list[tuple[np.ndarray, float | None, float | None]] = []
+        for _label, _mask in _group_masks:
+            _w_pos = new_w[_mask]
+            _w_pos = _w_pos[_w_pos > 0].astype(np.float64)
+            if len(_w_pos) < trimming.min_cell_size:
+                sample.warn(
+                    code=WarnCode.DOMAIN_SKIPPED,
+                    title="Domain skipped — cell too small",
+                    detail=(
+                        f"Trim domain {_label!r} has {len(_w_pos)} positive-weight "
+                        f"unit(s), below min_cell_size={trimming.min_cell_size}. "
+                        "Trimming skipped."
+                    ),
+                    where=where,
+                    level=Severity.WARNING,
+                )
+                continue
+            _up = (
+                resolve_threshold(trimming.upper, _w_pos)
+                if trimming.upper is not None
+                else None
+            )
+            _lo = (
+                resolve_threshold(trimming.lower, _w_pos)
+                if trimming.lower is not None
+                else None
+            )
+            trim_groups.append((_mask, _up, _lo))
+
+        assert rust_trim_weights is not None  # noqa: S101
+
+        _current_w = new_w.copy()
+        _calib_converged = True  # already checked above if strict
+        _trim_ok = True  # nothing to trim when every domain was skipped
+        _scale_arr_cycle = (
+            np.full(len(w), float(scale), dtype=np.float64)
+            if isinstance(scale, (int, float))
+            else np.asarray(scale, dtype=np.float64)
+        )
+
+        def _cycle_calibrate(w_in: np.ndarray) -> np.ndarray:
+            if domain_vec is None:
+                return rust_calibrate(
+                    w_in.reshape(-1, 1),
+                    X,
+                    totals_arr,
+                    _scale_arr_cycle,
+                    False,  # additive=False always — see module docstring
+                )[:, 0]
+            return rust_calibrate_by_domain(
+                w_in.reshape(-1, 1),
+                X,
+                domain_indices,
+                controls_dict_main,
+                _scale_arr_cycle,
+                False,  # additive=False always — see module docstring
+            )[:, 0]
+
+        def _cycle_fit_ok(w_in: np.ndarray) -> bool:
+            if domain_vec is None:
+                return _check_calibration_fit(w_in, X, totals_arr)
+            return all(
+                _check_calibration_fit(
+                    w_in[domain_vec == d],
+                    X[domain_vec == d],
+                    np.array(controls_dict_main[domain_to_idx[d]], dtype=np.float64),
+                )
+                for d in unique_domains
+            )
+
+        def _cycle_trim_ok(w_in: np.ndarray) -> bool:
+            return all(
+                _trim_constraints_satisfied(w_in[m], u, lo, 1e-4) for m, u, lo in trim_groups
+            )
+
+        if trim_groups:
+            _trim_ok = False
+            for _cycle in range(trimming.max_iter):
+                # Calibrate step — restore control totals
+                _current_w = _cycle_calibrate(_current_w)
+                _calib_converged = _cycle_fit_ok(_current_w)
+
+                # Trim step — per domain with its own thresholds
+                for _mask, _up, _lo in trim_groups:
+                    (_trimmed_w, *_) = rust_trim_weights(
+                        _current_w[_mask],
+                        _up,
+                        _lo,
+                        trimming.redistribute,
+                        trimming.max_iter,
+                        trimming.tol,
+                    )
+                    _current_w[_mask] = _trimmed_w
+                _trim_ok = _cycle_trim_ok(_current_w)
+
+                if _trim_ok:
+                    # Final calibrate to restore totals after last trim
+                    _current_w = _cycle_calibrate(_current_w)
+                    # Re-check trim and fit after final calibrate
+                    _trim_ok = _cycle_trim_ok(_current_w)
+                    _calib_converged = _cycle_fit_ok(_current_w)
+                    break
+
+        if strict and not (_calib_converged and _trim_ok):
+            raise MethodError.not_applicable(
+                where=where,
+                method="calibrate",
+                reason=(
+                    f"Trim-calibrate cycle did not converge after {trimming.max_iter} cycles. "
+                    "The design has NOT been modified. "
+                    "Pass strict=False to store partial results."
+                ),
+                hint="Increase max_iter, relax tol, or use a less restrictive TrimConfig.",
+            )
+
+        new_w = _current_w
+
+    # ── Write results (only after the strict guard above) ────────────────
     df = df.with_columns(pl.Series(name=wgt_name, values=new_w))
 
     if update_design_wgts:
@@ -525,130 +677,6 @@ def calibrate_matrix(
                     fay_coef=design.rep_wgts.fay_coef,
                     df=design.rep_wgts.df,
                 )
-
-    sample._data = df
-
-    # ── Trim-calibrate cycle ──────────────────────────────────────────────
-    if trimming is not None:
-        # Resolve thresholds once from the initial calibrated weights
-        _w_pos = new_w[new_w > 0].astype(np.float64)
-        _upper_val = (
-            resolve_threshold(trimming.upper, _w_pos) if trimming.upper is not None else None
-        )
-        _lower_val = (
-            resolve_threshold(trimming.lower, _w_pos) if trimming.lower is not None else None
-        )
-
-        assert rust_trim_weights is not None  # noqa: S101
-
-        _current_w = new_w.copy()
-        _calib_converged = True  # already checked above if strict
-        _trim_ok = False
-        _scale_arr_cycle = (
-            np.full(len(w), float(scale), dtype=np.float64)
-            if isinstance(scale, (int, float))
-            else np.asarray(scale, dtype=np.float64)
-        )
-        _n_cycles = trimming.max_iter
-
-        for _cycle in range(_n_cycles):
-            # Calibrate step — restore control totals
-            if domain_vec is None:
-                _cal_result = rust_calibrate(
-                    _current_w.reshape(-1, 1),
-                    X,
-                    totals_arr,
-                    _scale_arr_cycle,
-                    False,  # additive=False always — see module docstring
-                )
-            else:
-                # domain_indices and controls_dict_main are populated above
-                _cal_result = rust_calibrate_by_domain(
-                    _current_w.reshape(-1, 1),
-                    X,
-                    domain_indices,
-                    controls_dict_main,
-                    _scale_arr_cycle,
-                    False,  # additive=False always — see module docstring
-                )
-            _current_w = _cal_result[:, 0]
-
-            # FIX: check calibration fit for domain case too
-            if domain_vec is None:
-                _calib_converged = _check_calibration_fit(_current_w, X, totals_arr)
-            else:
-                _calib_converged = all(
-                    _check_calibration_fit(
-                        _current_w[domain_vec == d],
-                        X[domain_vec == d],
-                        np.array(controls_dict_main[domain_to_idx[d]], dtype=np.float64),
-                    )
-                    for d in unique_domains
-                )
-
-            # Trim step
-            (_trimmed_w, *_) = rust_trim_weights(
-                _current_w,
-                _upper_val,
-                _lower_val,
-                trimming.redistribute,
-                trimming.max_iter,
-                trimming.tol,
-            )
-            _current_w = _trimmed_w
-            _trim_ok = _trim_constraints_satisfied(_current_w, _upper_val, _lower_val, 1e-4)
-
-            if _trim_ok:
-                # Final calibrate to restore totals after last trim
-                if domain_vec is None:
-                    _final = rust_calibrate(
-                        _current_w.reshape(-1, 1),
-                        X,
-                        totals_arr,
-                        _scale_arr_cycle,
-                        False,  # additive=False always — see module docstring
-                    )
-                else:
-                    _final = rust_calibrate_by_domain(
-                        _current_w.reshape(-1, 1),
-                        X,
-                        domain_indices,
-                        controls_dict_main,
-                        _scale_arr_cycle,
-                        False,  # additive=False always — see module docstring
-                    )
-                _current_w = _final[:, 0]
-                # Re-check trim and fit after final calibrate
-                _trim_ok = _trim_constraints_satisfied(_current_w, _upper_val, _lower_val, 1e-4)
-                if domain_vec is None:
-                    _calib_converged = _check_calibration_fit(_current_w, X, totals_arr)
-                else:
-                    _calib_converged = all(
-                        _check_calibration_fit(
-                            _current_w[domain_vec == d],
-                            X[domain_vec == d],
-                            np.array(controls_dict_main[domain_to_idx[d]], dtype=np.float64),
-                        )
-                        for d in unique_domains
-                    )
-                break
-
-        if strict and not (_calib_converged and _trim_ok):
-            raise MethodError.not_applicable(
-                where=where,
-                method="calibrate",
-                reason=(
-                    f"Trim-calibrate cycle did not converge after {trimming.max_iter} cycles. "
-                    "The design has NOT been modified. "
-                    "Pass strict=False to store partial results."
-                ),
-                hint="Increase max_iter, relax tol, or use a less restrictive TrimConfig.",
-            )
-
-        # Update the stored weight with the final cycled result
-        new_w = _current_w
-        # FIX: was wgt_col_name (NameError) — correct variable is wgt_name
-        df = df.with_columns(pl.Series(name=wgt_name, values=new_w))
 
     sample._data = df
     return sample

--- a/packages/svy/tests/svy/weighting/test_wgt_aux_build.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_aux_build.py
@@ -129,20 +129,26 @@ def test_build_aux_matrix_with_by_single_and_multi_keys():
     assert X1.shape[0] == n and X2.shape[0] == n
 
 
-def test_build_aux_matrix_continuous_na_handling():
+def test_build_aux_matrix_continuous_na_raises():
+    """Nulls in a continuous auxiliary raise (round 8, W8) — silently
+    filling 0.0 biased the calibration totals."""
+    from svy.errors import DimensionError
+
     s = _make_sample()
-    # 'x' has a None. Default behavior for continuous terms is fill_null(0.0).
-    X, shape = s.weighting.build_aux_matrix(x=["x"])
+    with pytest.raises(DimensionError, match="null value"):
+        s.weighting.build_aux_matrix(x=["x"])
+
+
+def test_build_aux_matrix_continuous_complete_ok():
+    s = _make_sample()
+    df = s.data.with_columns(pl.col("x").fill_null(0.0))
+    s2 = Sample(df)
+    X, shape = s2.weighting.build_aux_matrix(x=["x"])
 
     # one continuous column -> 1 feature
     assert X.shape[1] == 1
     # shape contains one label (the column name)
     assert list(shape.keys()) == ["x"]
-
-    # Verify fillna behavior: last row is None, should be 0.0
-    import numpy as np
-
-    assert np.isclose(X[-1, 0], 0.0)
 
 
 def test_build_aux_matrix_requires_some_output_columns():

--- a/packages/svy/tests/svy/weighting/test_wgt_round8_fixes.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_round8_fixes.py
@@ -1,0 +1,279 @@
+# tests/svy/weighting/test_wgt_round8_fixes.py
+"""
+Round 8 weighting marshalling fixes (findings W1-W8).
+
+W1  bounded= calibration raises instead of being silently ignored
+W2  unmatched response statuses raise instead of encoding as respondents
+W3  respondents_only filters from the encoded codes (case-insensitive)
+W4  adjust(trimming=..., update_design_wgts=False) trims the new weight
+W5  calibrate handles overlapping level labels across terms
+W6  strict trim-calibrate failure leaves the sample untouched
+W7  calibrate's trim cycle honors TrimConfig.by / min_cell_size
+"""
+
+import numpy as np
+import polars as pl
+import pytest
+
+from svy.core.sample import Design, Sample
+from svy.core.terms import Cat
+from svy.errors import MethodError
+from svy.weighting.types import TrimConfig
+
+
+# ---------------------------------------------------------------------------
+# W1 — bounded calibration blocked
+# ---------------------------------------------------------------------------
+
+
+def _calib_sample(n=40, seed=7):
+    rng = np.random.default_rng(seed)
+    return Sample(
+        pl.DataFrame(
+            {
+                "wgt": rng.uniform(1.0, 3.0, n),
+                "grp": ["a", "b"] * (n // 2),
+                "z": rng.normal(10.0, 2.0, n),
+            }
+        ),
+        Design(wgt="wgt"),
+    )
+
+
+def test_bounded_calibration_raises():
+    s = _calib_sample()
+    with pytest.raises(NotImplementedError, match="bounded"):
+        s.weighting.calibrate(
+            controls={Cat("grp"): {"a": 40.0, "b": 40.0}},
+            bounded=True,
+        )
+
+
+# ---------------------------------------------------------------------------
+# W2 — unmatched response statuses raise
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_unmatched_status_raises():
+    """'noncontact' outside the mapping used to be encoded as a respondent
+    and receive an INFLATED weight."""
+    s = Sample(
+        pl.DataFrame(
+            {
+                "wgt": [1.0] * 4,
+                "status": ["resp", "resp", "refusal", "noncontact"],
+            }
+        ),
+        Design(wgt="wgt"),
+    )
+    with pytest.raises(MethodError, match="noncontact"):
+        s.weighting.adjust(
+            resp_status="status",
+            by=None,
+            resp_mapping={"rr": "resp", "nr": "refusal"},
+        )
+
+
+def test_adjust_null_status_raises():
+    s = Sample(
+        pl.DataFrame({"wgt": [1.0] * 3, "status": ["rr", None, "nr"]}),
+        Design(wgt="wgt"),
+    )
+    with pytest.raises(MethodError):
+        s.weighting.adjust(resp_status="status", by=None)
+
+
+def test_adjust_collection_valued_mapping():
+    """{"nr": ["refusal", "noncontact"]} matches both labels."""
+    s = Sample(
+        pl.DataFrame(
+            {
+                "wgt": [1.0] * 4,
+                "status": ["resp", "resp", "refusal", "noncontact"],
+            }
+        ),
+        Design(wgt="wgt"),
+    )
+    out = s.weighting.adjust(
+        resp_status="status",
+        by=None,
+        resp_mapping={"rr": "resp", "nr": ["refusal", "noncontact"]},
+    )
+    # Both nonrespondents' weight moved to the two respondents: 4/2 = 2.0
+    w = out.data.get_column("nr_wgt").to_numpy()
+    np.testing.assert_allclose(w, [2.0, 2.0])
+
+
+# ---------------------------------------------------------------------------
+# W3 — respondents_only uses the encoded codes
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_case_insensitive_statuses_keep_respondents():
+    """Upper-case statuses used to encode fine but filter to a 0-row Sample."""
+    s = Sample(
+        pl.DataFrame({"wgt": [1.0] * 4, "status": ["RR", "RR", "NR", "IN"]}),
+        Design(wgt="wgt"),
+    )
+    out = s.weighting.adjust(resp_status="status", by=None)
+    assert out.data.height == 2
+    w = out.data.get_column("nr_wgt").to_numpy()
+    # One NR's weight redistributed over two RRs (IN weight is not): 1.5 each
+    np.testing.assert_allclose(w, [1.5, 1.5])
+
+
+# ---------------------------------------------------------------------------
+# W4 — adjust(trimming=..., update_design_wgts=False)
+# ---------------------------------------------------------------------------
+
+
+def test_adjust_trim_without_design_update_preserves_original_weights():
+    """The trim used to overwrite the ORIGINAL design weight column in place
+    (leaving the new nr_wgt untrimmed)."""
+    wgts = [1.0] * 11 + [100.0]
+    statuses = ["rr"] * 11 + ["rr"]
+    s = Sample(
+        pl.DataFrame({"wgt": wgts, "status": statuses}),
+        Design(wgt="wgt"),
+    )
+    out = s.weighting.adjust(
+        resp_status="status",
+        by=None,
+        update_design_wgts=False,
+        trimming=TrimConfig(upper=5.0, redistribute=False),
+    )
+    # Original design weight column untouched
+    np.testing.assert_allclose(out.data.get_column("wgt").to_numpy(), wgts)
+    # The new adjusted weight is the trimmed one
+    nr = out.data.get_column("nr_wgt").to_numpy()
+    assert nr.max() <= 5.0 + 1e-9
+    # Design still points at the original weight
+    assert out._design.wgt == "wgt"
+
+
+# ---------------------------------------------------------------------------
+# W5 — overlapping level labels across terms
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_overlapping_level_labels():
+    """Two Cats sharing numeric-style codes used to crash with
+    'Internal error: Design matrix label alignment mismatch'."""
+    rng = np.random.default_rng(11)
+    n = 40
+    s = Sample(
+        pl.DataFrame(
+            {
+                "wgt": rng.uniform(1.0, 2.0, n),
+                "A": ([1, 2] * (n // 2)),
+                "B": ([1] * (n // 2) + [2] * (n // 2)),
+            }
+        ),
+        Design(wgt="wgt"),
+    )
+    out = s.weighting.calibrate(
+        controls={
+            Cat("A", ref=1): {2: 30.0},
+            Cat("B", ref=1): {2: 25.0},
+        },
+        wgt_name="cw",
+    )
+    w = out.data.get_column("cw").to_numpy()
+    a = (out.data.get_column("A") == 2).cast(pl.Float64).to_numpy()
+    b = (out.data.get_column("B") == 2).cast(pl.Float64).to_numpy()
+    np.testing.assert_allclose(float(a @ w), 30.0, rtol=1e-6)
+    np.testing.assert_allclose(float(b @ w), 25.0, rtol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# W6 — strict trim-calibrate failure leaves the sample untouched
+# ---------------------------------------------------------------------------
+
+
+def test_strict_trim_calibrate_failure_mutates_nothing():
+    s = _calib_sample()
+    cols_before = list(s.data.columns)
+    wgt_before = s.data.get_column("wgt").to_numpy().copy()
+    design_wgt_before = s._design.wgt
+
+    # Absolute cap (floats > 1) far below what the totals require: the final
+    # calibrate always pushes weights back above the cap -> cannot converge
+    with pytest.raises(MethodError, match="did not converge"):
+        s.weighting.calibrate(
+            controls={Cat("grp"): {"a": 500.0, "b": 500.0}},
+            wgt_name="cw",
+            strict=True,
+            trimming=TrimConfig(upper=1.5, min_cell_size=1, max_iter=2),
+        )
+
+    assert list(s.data.columns) == cols_before  # no cw column
+    assert s._design.wgt == design_wgt_before
+    np.testing.assert_allclose(s.data.get_column("wgt").to_numpy(), wgt_before)
+
+
+# ---------------------------------------------------------------------------
+# W7 — trim cycle honors TrimConfig.by and min_cell_size
+# ---------------------------------------------------------------------------
+
+
+def test_calibrate_trim_cycle_unknown_by_column_raises():
+    s = _calib_sample()
+    with pytest.raises(MethodError, match="trimming.by|by"):
+        s.weighting.calibrate(
+            controls={Cat("grp"): {"a": 40.0, "b": 40.0}},
+            wgt_name="cw",
+            trimming=TrimConfig(upper=10.0, by="no_such_col"),
+        )
+
+
+def test_calibrate_trim_cycle_min_cell_size_skips_with_warning():
+    """min_cell_size larger than the sample -> trim skipped, warning stored,
+    plain calibration result kept."""
+    s = _calib_sample()
+    plain = s.weighting.calibrate(
+        controls={Cat("grp"): {"a": 40.0, "b": 40.0}},
+        wgt_name="cw_plain",
+        update_design_wgts=False,
+    )
+    plain_w = plain.data.get_column("cw_plain").to_numpy()
+
+    s2 = _calib_sample()
+    out = s2.weighting.calibrate(
+        controls={Cat("grp"): {"a": 40.0, "b": 40.0}},
+        wgt_name="cw",
+        update_design_wgts=False,
+        trimming=TrimConfig(upper=1.01, min_cell_size=999),
+    )
+    from svy.core.warnings import WarnCode
+
+    w = out.data.get_column("cw").to_numpy()
+    np.testing.assert_allclose(w, plain_w)
+    assert out._warnings.list(code=WarnCode.DOMAIN_SKIPPED)
+
+
+def test_calibrate_trim_cycle_by_domain_thresholds():
+    """Per-domain trim: each group's weights end at or below its own cap."""
+    rng = np.random.default_rng(3)
+    n = 40
+    df = pl.DataFrame(
+        {
+            "wgt": np.concatenate(
+                [rng.uniform(1.0, 2.0, n // 2), rng.uniform(5.0, 10.0, n // 2)]
+            ),
+            "grp": ["a"] * (n // 2) + ["b"] * (n // 2),
+        }
+    )
+    s = Sample(df, Design(wgt="wgt"))
+    total_a = float(df.filter(pl.col("grp") == "a")["wgt"].sum())
+    total_b = float(df.filter(pl.col("grp") == "b")["wgt"].sum())
+    out = s.weighting.calibrate(
+        controls={Cat("grp"): {"a": total_a, "b": total_b}},
+        wgt_name="cw",
+        strict=False,
+        trimming=TrimConfig(upper=3.0, by="grp", min_cell_size=1, max_iter=5),
+    )
+    w = out.data.get_column("cw").to_numpy()
+    grp = out.data.get_column("grp").to_numpy()
+    # Group a was never above the cap; group b must have been trimmed toward it
+    assert w[grp == "a"].max() <= 3.0 + 1e-6
+    assert w[grp == "b"].max() < 10.0


### PR DESCRIPTION
## Summary

Round 8 review findings W1–W8: the weight-adjustment/calibration marshalling layer had several silent-wrong-results paths, one data-destruction path, and one error path that mutated first and denied it.

### adjust()
- **W2 (wrong results)** — the status encoder started from `codes = zeros` where 0 = respondent, so unmatched labels, nulls, and list-valued mapping entries (which stringified and matched nothing) silently became respondents with *inflated* weights. Now every row must match, unmatched values raise a typed error listing them, and collection-valued mappings (`{"nr": ["refusal", "noncontact"]}`) are supported consistently with the filter.
- **W3 (wrong results)** — encoding was case-insensitive but the `respondents_only` filter was case-sensitive: `["RR", "RR", "NR", "IN"]` adjusted fine then returned a 0-row Sample. The filter now derives from the encoded codes (`resp_codes == 0`).
- **W4 (data destruction)** — `adjust(trimming=..., update_design_wgts=False)` trimmed and overwrote the **original** design-weight column (and old replicates) in place, leaving the new `nr_wgt` untrimmed. The trim now targets the new weight and its replicates via a temporary design, restored afterward.

### calibrate()
- **W1 (silent ignore)** — `bounded=` was accepted and ignored (bit-identical results). It now raises `NotImplementedError`; real bounded calibration (R `calibrate(bounds=)` style) is deferred to its own PR (maintainer choice).
- **W5 (crash)** — overlapping level labels across terms (very common with numeric codes: `Cat("A", ref=1)` + `Cat("B", ref=1)`) crashed with "Internal error: Design matrix label alignment mismatch" because targets flowed through label-keyed dicts that collapse duplicates. Targets are now ordered per-term lists end-to-end; no public API change.
- **W6 (error-path mutation)** — the strict trim-calibrate failure wrote the new column, design.wgt, replicate columns, and `sample._data` *before* cycling, then raised "The design has NOT been modified". The cycle now runs on arrays before any write; the message is finally true. (Replicates aren't re-trimmed by documented policy, so moving their write after the cycle changes no values.)
- **W7 (silent ignore)** — the trim cycle ignored `TrimConfig.by` and `min_cell_size`. It now trims per domain with per-domain thresholds, skips small cells with a stored `DOMAIN_SKIPPED` warning, and raises on unknown `by=` columns (maintainer chose implement over block).
- **W8 (silent bias)** — nulls in continuous auxiliaries were filled with 0.0, biasing calibration totals (inconsistent with the Cat branch, where null is an explicit level needing a target). They now raise a typed error with an impute/drop hint, matching the `by_na="error"` philosophy and R survey behavior (maintainer approved; the test pinning fill-0 was updated accordingly).

## Tests

13 new regression tests in `test_wgt_round8_fixes.py` covering every finding (weight-conservation checks for the W2/W3 redistribution arithmetic, no-mutation assertions for W6, per-domain cap checks for W7). `uv run pytest tests --ignore=tests/benchmark_test.py` → 2639 passed, 1 skipped.