### PR TITLE
fix(wrangling): edge-case batch (round 8 WR1-WR8)

### DIFF
--- a/packages/svy/src/svy/engine/wrangling/cleaning.py
+++ b/packages/svy/src/svy/engine/wrangling/cleaning.py
@@ -362,28 +362,26 @@ def _categorize(
 
     col_expr = pl.col(varname)
 
-    # First bin
-    lower, upper = bins[0], bins[1]
-    first_label = (
-        labels[0] if labels else (f"({lower}, {upper}]" if right else f"[{lower}, {upper})")
-    )
-    if right:
-        builder = pl.when((col_expr > lower) & (col_expr <= upper)).then(pl.lit(first_label))
-    else:
-        builder = pl.when((col_expr >= lower) & (col_expr < upper)).then(pl.lit(first_label))
-
-    # Remaining bins
-    for i in range(2, len(bins)):
+    # The outermost edge is closed (like R cut(include.lowest=TRUE)): with
+    # right=True, x == bins[0] falls in the first bin; with right=False,
+    # x == bins[-1] falls in the last bin. Otherwise those boundary values
+    # would silently become null and vanish from tabulations.
+    builder = None
+    for i in range(1, len(bins)):
         lower, upper = bins[i - 1], bins[i]
-        lab = (
-            labels[i - 1]
-            if labels
-            else (f"({lower}, {upper}]" if right else f"[{lower}, {upper})")
-        )
+        is_first = i == 1
+        is_last = i == len(bins) - 1
         if right:
-            builder = builder.when((col_expr > lower) & (col_expr <= upper)).then(pl.lit(lab))
+            cond = (col_expr >= lower if is_first else col_expr > lower) & (col_expr <= upper)
+            auto_lab = f"{'[' if is_first else '('}{lower}, {upper}]"
         else:
-            builder = builder.when((col_expr >= lower) & (col_expr < upper)).then(pl.lit(lab))
+            cond = (col_expr >= lower) & (col_expr <= upper if is_last else col_expr < upper)
+            auto_lab = f"[{lower}, {upper}{']' if is_last else ')'}"
+        lab = labels[i - 1] if labels else auto_lab
+        if builder is None:
+            builder = pl.when(cond).then(pl.lit(lab))
+        else:
+            builder = builder.when(cond).then(pl.lit(lab))
 
     # Everything else -> None
     return data.with_columns(builder.otherwise(pl.lit(None)).alias(target))
@@ -550,6 +548,8 @@ def _clean_names(
     old_cols = list(data.columns)
     RESERVED = {"svy_row_index", "svy_weight", "svy_prob", "svy_hit"}
 
+    from svy.core.constants import _INTERNAL_CONCAT_SUFFIX
+
     def _remove_non_alnum(name: str, pat: str) -> str:
         # remove per-character only if it matches `pat` AND is not alphanumeric/underscore
         return "".join(
@@ -557,8 +557,10 @@ def _clean_names(
         )
 
     def normalize(name: str) -> tuple[str, bool]:
-        # preserve reserved/internal columns exactly
-        if name in RESERVED:
+        # preserve reserved/internal columns exactly — renaming the internal
+        # concat columns would orphan them (a fresh lowercase copy gets
+        # rebuilt, leaving the renamed one behind as junk)
+        if name in RESERVED or _INTERNAL_CONCAT_SUFFIX in name:
             return name, False
 
         orig = name

--- a/packages/svy/src/svy/wrangling/_helpers.py
+++ b/packages/svy/src/svy/wrangling/_helpers.py
@@ -296,6 +296,13 @@ def _auto_clean_design(target: "Sample") -> None:
         prob=keep_name(current_design.prob),
         hit=keep_name(current_design.hit),
         mos=keep_name(current_design.mos),
+        # pop_size may be a column name (clean like the others) or a
+        # PopSize object (no column reference — keep as is)
+        pop_size=(
+            keep_name(current_design.pop_size)
+            if isinstance(current_design.pop_size, str)
+            else current_design.pop_size
+        ),
     )
 
     if current_design.rep_wgts is not None:

--- a/packages/svy/src/svy/wrangling/_naming.py
+++ b/packages/svy/src/svy/wrangling/_naming.py
@@ -75,6 +75,7 @@ def _rep_wgts_with_renames(rep_wgts: RepWeights, renames: dict[str, str]) -> Rep
     """
     pattern = re.compile(rf"^{re.escape(rep_wgts.prefix)}(\d+)$", re.IGNORECASE)
     new_prefixes: set[str] = set()
+    matched_olds: set[str] = set()
     for old, new in renames.items():
         m = pattern.match(old)
         if m is None:
@@ -86,12 +87,24 @@ def _rep_wgts_with_renames(rep_wgts: RepWeights, renames: dict[str, str]) -> Rep
                 f"the replicate number suffix {digits!r} must be preserved."
             )
         new_prefixes.add(new[: len(new) - len(digits)])
+        matched_olds.add(old)
     if not new_prefixes:
         return rep_wgts
     if len(new_prefixes) > 1:
         raise ValueError(
             "Replicate weight columns must all be renamed with the same prefix; "
             f"got prefixes {sorted(new_prefixes)}."
+        )
+    # Replicate columns are identified as prefix + number, so a partial
+    # rename cannot be represented: the new prefix would claim columns that
+    # were never renamed, corrupting the replicate metadata.
+    not_renamed = [c for c in rep_wgts.columns if c not in matched_olds]
+    if not_renamed:
+        raise ValueError(
+            f"Partial replicate-weight rename: {len(not_renamed)} of "
+            f"{len(rep_wgts.columns)} replicate columns were not renamed "
+            f"(e.g. {not_renamed[:3]}). Rename all replicate columns together "
+            "with a common new prefix, keeping the numeric suffixes."
         )
     return _struct_replace(rep_wgts, prefix=new_prefixes.pop())
 

--- a/packages/svy/src/svy/wrangling/mutate.py
+++ b/packages/svy/src/svy/wrangling/mutate.py
@@ -145,13 +145,24 @@ def mutate(
         deps: set[str] = _root_names_safe(out_obj) if isinstance(out_obj, pl.Expr) else set()
         compiled[out_name] = (out_obj, deps)
 
-    # Batch by readiness (topological sort)
+    # Batch by readiness (topological sort). A spec that depends on a column
+    # another spec in this call (re)defines waits for that spec, so
+    # dependents always see the updated value — whether the dependency is a
+    # brand-new column or a redefinition of an existing one. (Previously
+    # redefinitions were "ready" immediately and same-call dependents
+    # silently saw the OLD values.) Self-references (x = f(old x)) are fine;
+    # mutual redefinitions raise the dependency error below.
     current_cols = set(local_data.columns)
     pending = set(compiled.keys())
     max_iters = len(pending) + 8
 
     for _ in range(max_iters):
-        ready = [name for name in pending if compiled[name][1] <= current_cols]
+        ready = [
+            name
+            for name in pending
+            if compiled[name][1] <= current_cols
+            and not (compiled[name][1] & (pending - {name}))
+        ]
         if not ready:
             break
 

--- a/packages/svy/src/svy/wrangling/rows.py
+++ b/packages/svy/src/svy/wrangling/rows.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Sequence
 
+import polars as pl
+
 from svy.core.types import WhereArg
 from svy.errors import MethodError, SvyError
 from svy.utils.where import _compile_where as _compile_where_to_pl_expr
@@ -42,8 +44,30 @@ def filter_records(
         if negate:
             pred = ~pred
 
+        # Kleene logic: a null predicate is not true, so those rows are
+        # dropped by BOTH the filter and its negation. Count them so the
+        # user is told instead of rows silently vanishing from either side.
+        _null_df = sample._data.select(pred.is_null().sum().alias("__n_null__"))
+        if isinstance(_null_df, pl.LazyFrame):
+            _null_df = _null_df.collect()
+        n_null_pred = int(_null_df.item())
+
         filtered_data = sample._data.filter(pred)
         target = _resolve_target(sample, filtered_data, inplace=inplace)
+
+        if n_null_pred > 0:
+            target.warn(
+                code="NULL_PREDICATE_ROWS_DROPPED",
+                title="Rows with null filter predicate dropped",
+                detail=(
+                    f"{n_null_pred} row(s) evaluated to null under the filter "
+                    "predicate and were dropped (Kleene logic: null is not "
+                    "true). Such rows are excluded by both the filter and "
+                    "its negation."
+                ),
+                where="wrangling.filter_records",
+                hint="fill_null the referenced columns first to keep these rows.",
+            )
 
         if check_singletons:
             target._check_for_singletons()

--- a/packages/svy/src/svy/wrangling/values.py
+++ b/packages/svy/src/svy/wrangling/values.py
@@ -206,7 +206,13 @@ def cast_columns(
     strict: bool = True,
     inplace: bool = False,
 ) -> "Sample":
-    """Cast columns to specified data type(s)."""
+    """Cast columns to specified data type(s).
+
+    With ``strict=True`` (the default), a float-to-integer cast that would
+    lose fractional parts raises — Polars' own strict cast only guards
+    overflow, so 1.7 -> 1 would otherwise truncate silently (risky on
+    weight columns). Pass ``strict=False`` to allow truncation.
+    """
 
     def _cast_expr(col_name: str, target_dt: pl.DataType, strict: bool) -> pl.Expr:
         base = pl.col(col_name)
@@ -216,8 +222,15 @@ def cast_columns(
             return base.cast(pl.Utf8).cast(target_dt, strict=strict).alias(col_name)
         return base.cast(target_dt, strict=strict).alias(col_name)
 
+    def _is_integer_dtype(dt: object) -> bool:
+        try:
+            return bool(dt.is_integer())  # type: ignore[attr-defined]
+        except Exception:
+            return False
+
     if isinstance(cols, Mapping):
         col_names = set(cols.keys())
+        pairs = list(cols.items())
         exprs = [_cast_expr(c, dt, strict) for c, dt in cols.items()]  # type: ignore[arg-type]
     else:
         if dtype is None:
@@ -229,7 +242,45 @@ def cast_columns(
             )
         col_list = [cols] if isinstance(cols, str) else list(cols)
         col_names = set(col_list)
+        pairs = [(c, dtype) for c in col_list]
         exprs = [_cast_expr(c, dtype, strict) for c in col_list]
+
+    if strict:
+        data = sample._data
+        schema = data.collect_schema() if isinstance(data, pl.LazyFrame) else data.schema
+        to_check = [
+            c
+            for c, dt in pairs
+            if _is_integer_dtype(dt) and c in schema and schema[c].is_float()
+        ]
+        if to_check:
+            check_df = data.select(
+                [
+                    (
+                        pl.col(c).is_not_null()
+                        & (pl.col(c) != pl.col(c).cast(pl.Int64, strict=False))
+                    )
+                    .sum()
+                    .alias(c)
+                    for c in to_check
+                ]
+            )
+            if isinstance(check_df, pl.LazyFrame):
+                check_df = check_df.collect()
+            offenders = {c: int(check_df[c][0]) for c in to_check if int(check_df[c][0]) > 0}
+            if offenders:
+                raise MethodError(
+                    title="Lossy float-to-integer cast",
+                    detail=(
+                        f"Value(s) with fractional parts per column: {offenders}. "
+                        "Casting would silently truncate them (Polars strict "
+                        "casting only guards overflow)."
+                    ),
+                    code="CAST_TRUNCATION",
+                    where="wrangling.cast",
+                    hint="Round explicitly first (e.g. .round(0)) or pass strict=False "
+                    "to allow truncation.",
+                )
 
     new_data = sample._data.with_columns(exprs)
     target = _resolve_target(sample, new_data, inplace=inplace)
@@ -245,11 +296,39 @@ def fill_null(
     strategy: Literal["forward", "backward", "mean", "min", "max", "zero", "one"] | None = None,
     inplace: bool = False,
 ) -> "Sample":
-    """Fill null values in specified columns."""
+    """Fill null values in specified columns.
+
+    With ``strategy="mean"``, integer columns are cast to Float64 so the
+    fill value is the exact mean rather than a truncated integer; a
+    warning records the dtype change.
+    """
     col_list = [cols] if isinstance(cols, str) else list(cols)
 
     if strategy is not None:
-        exprs = [pl.col(c).fill_null(strategy=strategy).alias(c) for c in col_list]
+        int_cols: set[str] = set()
+        if strategy == "mean":
+            data = sample._data
+            schema = (
+                data.collect_schema() if isinstance(data, pl.LazyFrame) else data.schema
+            )
+            int_cols = {c for c in col_list if c in schema and schema[c].is_integer()}
+            if int_cols:
+                sample.warn(
+                    code="MEAN_FILL_INT_CAST",
+                    title="Integer column(s) cast to Float64 for mean fill",
+                    detail=(
+                        f"Column(s) {sorted(int_cols)} are integer-typed; the "
+                        "mean is generally fractional, so they were cast to "
+                        "Float64 instead of truncating the fill value."
+                    ),
+                    where="wrangling.fill_null",
+                )
+        exprs = [
+            (pl.col(c).cast(pl.Float64) if c in int_cols else pl.col(c))
+            .fill_null(strategy=strategy)
+            .alias(c)
+            for c in col_list
+        ]
     else:
         exprs = [pl.col(c).fill_null(value).alias(c) for c in col_list]
 

--- a/packages/svy/tests/svy/wrangling/test_wrangling_integration.py
+++ b/packages/svy/tests/svy/wrangling/test_wrangling_integration.py
@@ -106,8 +106,10 @@ def test_chain_categorize_then_recode():
     df = pl.DataFrame({"value": [5, 15, 25, 35, 45]})
     s = Sample(df)
 
+    # First-bin auto-label is "[0, 20]" — the outermost edge is closed
+    # (round 8, WR1) so x == bins[0] no longer vanishes to null.
     out = s.wrangling.categorize("value", bins=[0, 20, 40, 60]).wrangling.recode(
-        "svy_value_categorized", {"Low": ["(0, 20]"], "Mid": ["(20, 40]"], "High": ["(40, 60]"]}
+        "svy_value_categorized", {"Low": ["[0, 20]"], "Mid": ["(20, 40]"], "High": ["(40, 60]"]}
     )
 
     recoded = out._data["svy_svy_value_categorized_recoded"].to_list()

--- a/packages/svy/tests/svy/wrangling/test_wrangling_round8_fixes.py
+++ b/packages/svy/tests/svy/wrangling/test_wrangling_round8_fixes.py
@@ -1,0 +1,262 @@
+# tests/svy/wrangling/test_wrangling_round8_fixes.py
+"""
+Round 8 wrangling edge-case fixes (findings WR1-WR8).
+
+WR1  categorize() includes values equal to the outermost bin edge
+WR2  remove_columns(force=True) cleans design.pop_size
+WR3  partial replicate rename raises instead of corrupting the prefix
+WR4  mutate() dependents always see same-call (re)defined values
+WR5  clean_names(upper) leaves internal concat columns alone
+WR6  filter_records warns about rows dropped via null predicates
+WR7  fill_null(strategy="mean") casts integer columns to Float64
+WR8  cast(strict=True) raises on lossy float->int truncation
+"""
+
+import polars as pl
+import pytest
+
+import svy
+
+from svy.core.design import make_rep_weights
+from svy.core.sample import Design, Sample
+from svy.errors import MethodError
+
+
+# ---------------------------------------------------------------------------
+# WR1 — categorize outer edge
+# ---------------------------------------------------------------------------
+
+
+class TestCategorizeOuterEdge:
+    def test_right_true_includes_lowest_edge(self):
+        s = Sample(pl.DataFrame({"x": [0, 5, 10, 15, 20]}))
+        out = s.wrangling.categorize("x", bins=[0, 10, 20])
+        cats = out._data["svy_x_categorized"].to_list()
+        assert cats == ["[0, 10]", "[0, 10]", "[0, 10]", "(10, 20]", "(10, 20]"]
+        assert None not in cats
+
+    def test_right_false_includes_highest_edge(self):
+        s = Sample(pl.DataFrame({"x": [0, 5, 10, 15, 20]}))
+        out = s.wrangling.categorize("x", bins=[0, 10, 20], right=False)
+        cats = out._data["svy_x_categorized"].to_list()
+        assert cats == ["[0, 10)", "[0, 10)", "[10, 20]", "[10, 20]", "[10, 20]"]
+        assert None not in cats
+
+    def test_out_of_range_still_null(self):
+        s = Sample(pl.DataFrame({"x": [-1, 5, 21]}))
+        out = s.wrangling.categorize("x", bins=[0, 10, 20])
+        cats = out._data["svy_x_categorized"].to_list()
+        assert cats[0] is None and cats[2] is None
+
+    def test_custom_labels_cover_edge(self):
+        s = Sample(pl.DataFrame({"x": [0, 10, 20]}))
+        out = s.wrangling.categorize("x", bins=[0, 10, 20], labels=["lo", "hi"])
+        assert out._data["svy_x_categorized"].to_list() == ["lo", "lo", "hi"]
+
+
+# ---------------------------------------------------------------------------
+# WR2 — pop_size cleaned on column removal
+# ---------------------------------------------------------------------------
+
+
+def test_remove_columns_cleans_pop_size():
+    s = Sample(
+        pl.DataFrame({"y": [1.0, 2.0], "w": [1.0, 1.0], "N": [100.0, 100.0]}),
+        Design(wgt="w", pop_size="N"),
+    )
+    out = s.wrangling.remove_columns("N", force=True)
+    assert "N" not in out._data.columns
+    # Previously stayed "N", crashing later estimation with a bare KeyError
+    assert out.design.pop_size is None
+
+
+# ---------------------------------------------------------------------------
+# WR3 — partial replicate rename raises
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rep_sample():
+    df = pl.DataFrame(
+        {
+            "strat": ["A", "A", "B", "B"],
+            "psu": ["1", "2", "3", "4"],
+            "w": [1.0, 2.0, 3.0, 4.0],
+            "rw1": [1.0] * 4,
+            "rw2": [1.0] * 4,
+            "rw3": [1.0] * 4,
+        }
+    )
+    rw = make_rep_weights("jackknife", prefix="rw", n_reps=3)
+    return Sample(df, Design(stratum="strat", psu="psu", wgt="w", rep_wgts=rw))
+
+
+def test_partial_replicate_rename_raises(rep_sample):
+    """rw1 -> boot1 with rw2/rw3 left behind used to rewrite the prefix for
+    ALL replicates, surfacing later as REP_WEIGHT_COUNT_MISMATCH."""
+    with pytest.raises(Exception, match="[Pp]artial"):
+        rep_sample.wrangling.rename_columns({"rw1": "boot1"})
+
+
+def test_full_replicate_rename_still_works(rep_sample):
+    out = rep_sample.wrangling.rename_columns(
+        {"rw1": "boot1", "rw2": "boot2", "rw3": "boot3"}
+    )
+    assert out.design.rep_wgts.prefix == "boot"
+    assert set(out.design.rep_wgts.columns) <= set(out._data.columns)
+
+
+# ---------------------------------------------------------------------------
+# WR4 — mutate ordering consistency
+# ---------------------------------------------------------------------------
+
+
+class TestMutateOrdering:
+    def test_dependent_sees_redefined_value(self):
+        """{"x": x+100, "y": x*1000}: y must use the NEW x (it previously
+        used the old value, unlike the new-column path)."""
+        s = Sample(pl.DataFrame({"x": [1.0, 2.0]}))
+        out = s.wrangling.mutate({"x": pl.col("x") + 100, "y": pl.col("x") * 1000})
+        assert out._data["x"].to_list() == [101.0, 102.0]
+        assert out._data["y"].to_list() == [101000.0, 102000.0]
+
+    def test_matches_new_column_path(self):
+        s = Sample(pl.DataFrame({"x": [1.0, 2.0]}))
+        out = s.wrangling.mutate({"x2": pl.col("x") + 100, "y2": pl.col("x2") * 1000})
+        assert out._data["y2"].to_list() == [101000.0, 102000.0]
+
+    def test_self_reference_uses_old_value(self):
+        s = Sample(pl.DataFrame({"x": [1.0, 2.0]}))
+        out = s.wrangling.mutate({"x": pl.col("x") + 1})
+        assert out._data["x"].to_list() == [2.0, 3.0]
+
+    def test_mutual_redefinition_raises(self):
+        """Circular same-call redefinitions are ambiguous — error, not
+        silent old-value evaluation."""
+        s = Sample(pl.DataFrame({"a": [1.0], "b": [2.0]}))
+        with pytest.raises(MethodError, match="[Cc]ircular"):
+            s.wrangling.mutate({"a": pl.col("b") + 1, "b": pl.col("a") + 1})
+
+
+# ---------------------------------------------------------------------------
+# WR5 — clean_names leaves internal concat columns alone
+# ---------------------------------------------------------------------------
+
+
+def test_clean_names_upper_no_orphan_concat_columns():
+    from svy.core.constants import _INTERNAL_CONCAT_SUFFIX
+
+    df = pl.DataFrame(
+        {
+            "s1": ["A", "A", "B", "B"],
+            "s2": ["x", "y", "x", "y"],
+            "p1": ["1", "2", "3", "4"],
+            "p2": ["a", "b", "c", "d"],
+            "w": [1.0] * 4,
+        }
+    )
+    # Multi-column stratum/psu force internal concat columns to exist
+    s = Sample(df, Design(stratum=("s1", "s2"), psu=("p1", "p2"), wgt="w"))
+    concat_before = [c for c in s._data.columns if _INTERNAL_CONCAT_SUFFIX in c]
+    assert concat_before  # sanity: the fixture exercises the concat path
+
+    out = s.wrangling.clean_names(letter_case="upper")
+    concat_after = [c for c in out._data.columns if _INTERNAL_CONCAT_SUFFIX.upper() in c]
+    # No uppercased orphans left behind
+    assert concat_after == []
+    # Exactly one copy of each concat column (no junk duplicates)
+    concat_now = [c for c in out._data.columns if _INTERNAL_CONCAT_SUFFIX in c]
+    assert sorted(concat_now) == sorted(concat_before)
+
+
+# ---------------------------------------------------------------------------
+# WR6 — null predicates warn
+# ---------------------------------------------------------------------------
+
+
+class TestFilterNullPredicates:
+    def test_filter_warns_on_null_predicate_rows(self):
+        s = Sample(pl.DataFrame({"x": [1.0, None, 3.0, None]}))
+        out = s.wrangling.filter_records(svy.col("x") > 2)
+        assert out._data.height == 1
+        warns = [w for w in out._warnings.list() if w.code == "NULL_PREDICATE_ROWS_DROPPED"]
+        assert warns and "2 row(s)" in warns[0].detail
+
+    def test_negated_filter_also_warns(self):
+        s = Sample(pl.DataFrame({"x": [1.0, None, 3.0]}))
+        out = s.wrangling.filter_records(svy.col("x") > 2, negate=True)
+        assert out._data.height == 1
+        assert any(
+            w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list()
+        )
+
+    def test_no_warning_without_nulls(self):
+        s = Sample(pl.DataFrame({"x": [1.0, 3.0]}))
+        out = s.wrangling.filter_records(svy.col("x") > 2)
+        assert not any(
+            w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list()
+        )
+
+
+# ---------------------------------------------------------------------------
+# WR7 — mean fill on integer columns
+# ---------------------------------------------------------------------------
+
+
+class TestMeanFillIntegers:
+    def test_mean_fill_int_casts_to_float(self):
+        s = Sample(pl.DataFrame({"x": [1, None, 2]}, schema={"x": pl.Int64}))
+        out = s.wrangling.fill_null("x", strategy="mean")
+        assert out._data["x"].dtype == pl.Float64
+        assert out._data["x"].to_list() == [1.0, 1.5, 2.0]
+
+    def test_mean_fill_int_warns(self):
+        s = Sample(pl.DataFrame({"x": [1, None, 2]}, schema={"x": pl.Int64}))
+        out = s.wrangling.fill_null("x", strategy="mean")
+        assert any(w.code == "MEAN_FILL_INT_CAST" for w in out._warnings.list())
+
+    def test_mean_fill_float_unchanged(self):
+        s = Sample(pl.DataFrame({"x": [1.0, None, 2.0]}))
+        out = s.wrangling.fill_null("x", strategy="mean")
+        assert out._data["x"].dtype == pl.Float64
+        assert out._data["x"].to_list() == [1.0, 1.5, 2.0]
+        assert not any(w.code == "MEAN_FILL_INT_CAST" for w in out._warnings.list())
+
+    def test_other_strategies_keep_int(self):
+        s = Sample(pl.DataFrame({"x": [1, None, 2]}, schema={"x": pl.Int64}))
+        out = s.wrangling.fill_null("x", strategy="max")
+        assert out._data["x"].dtype == pl.Int64
+        assert out._data["x"].to_list() == [1, 2, 2]
+
+
+# ---------------------------------------------------------------------------
+# WR8 — strict cast truncation guard
+# ---------------------------------------------------------------------------
+
+
+class TestCastTruncationGuard:
+    def test_strict_float_to_int_truncation_raises(self):
+        s = Sample(pl.DataFrame({"x": [1.7, 2.0, 3.5]}))
+        with pytest.raises(MethodError, match="[Tt]runcat|[Ll]ossy"):
+            s.wrangling.cast("x", pl.Int64)
+
+    def test_strict_whole_floats_ok(self):
+        s = Sample(pl.DataFrame({"x": [1.0, 2.0, 3.0]}))
+        out = s.wrangling.cast("x", pl.Int64)
+        assert out._data["x"].dtype == pl.Int64
+        assert out._data["x"].to_list() == [1, 2, 3]
+
+    def test_non_strict_still_truncates(self):
+        s = Sample(pl.DataFrame({"x": [1.7, 2.2]}))
+        out = s.wrangling.cast("x", pl.Int64, strict=False)
+        assert out._data["x"].to_list() == [1, 2]
+
+    def test_mapping_form_guarded(self):
+        s = Sample(pl.DataFrame({"x": [1.7], "y": [2.0]}))
+        with pytest.raises(MethodError):
+            s.wrangling.cast({"x": pl.Int64, "y": pl.Int64})
+
+    def test_int_to_int_unaffected(self):
+        s = Sample(pl.DataFrame({"x": [1, 2]}, schema={"x": pl.Int64}))
+        out = s.wrangling.cast("x", pl.Int32)
+        assert out._data["x"].dtype == pl.Int32


### PR DESCRIPTION
## Summary

Round 8 review findings WR1–WR8: silent data-loss and inconsistency edges in the wrangling namespace.

- **WR1 (wrong results)** — `categorize()` nulled values equal to the outermost bin edge (`x == bins[0]` with `right=True`), silently dropping them from tabulations. The outer edge is now closed, matching R `cut(include.lowest=TRUE)`; auto-labels show the closed bracket (`[0, 10]`).
- **WR2 (deferred crash)** — `remove_columns(force=True)` cleaned every design field except `pop_size`, leaving a dangling column reference that later crashed `estimation.mean` with a bare `KeyError`. `pop_size` (string form) is now cleaned; `PopSize` objects are untouched.
- **WR3 (silent corruption)** — renaming a subset of replicate-weight columns rewrote the `RepWeights` prefix for *all* replicates (surfacing later as `REP_WEIGHT_COUNT_MISMATCH`). Partial renames now raise; full renames with a common prefix work as before.
- **WR4 (inconsistent semantics)** — `mutate({"x": x+100, "y": x*1000})` gave `y` the *old* x, while the identical pattern with a new column name gave the *new* value. Dependents now always see the same-call updated value (the review's suggested fix); self-references still use the old value; mutual redefinitions raise the existing dependency error instead of silently evaluating against old values.
- **WR5 (junk columns)** — `clean_names(letter_case="upper")` renamed the internal concat columns, orphaning the uppercase copies while fresh lowercase ones were rebuilt. Internal columns are now preserved verbatim.
- **WR6 (silent drops, maintainer chose warn)** — rows with null filter predicates are dropped by both `filter_records(pred)` and its negation under Kleene logic; a stored warning now reports the count with a fill_null hint. Semantics unchanged (matches polars/SQL/R).
- **WR7 (truncation, maintainer chose cast)** — `fill_null(strategy="mean")` on `Int64 [1, None, 2]` filled 1. Integer columns are now cast to Float64 (exact mean 1.5) with a warning recording the dtype change; other strategies keep integer dtypes.
- **WR8 (silent truncation, maintainer chose raise)** — `cast(strict=True)` silently truncated 1.7 → 1 (Polars strict only guards overflow). Lossy float→int casts now raise a typed error listing offending columns; `strict=False` is the documented escape hatch.

## Tests

24 new tests in `test_wrangling_round8_fixes.py` covering all eight findings. One existing integration test updated for the new first-bin auto-label (direct consequence of the approved WR1 edge closure). `uv run pytest tests --ignore=tests/benchmark_test.py` → 2651 passed, 1 skipped.