### PR TITLE
fix(regression): GLM design gaps — deviance/dAIC, replicate variance, FPC, fit-path edges

### DIFF
--- a/packages/svy-rs/src/regression/api.rs
+++ b/packages/svy-rs/src/regression/api.rs
@@ -14,7 +14,18 @@ use pyo3_polars::PyDataFrame;
 
 use crate::regression::glm::{fit_glm, fit_glm_by};
 
-type GlmTuple = (String, Vec<f64>, Vec<f64>, f64, f64, f64, f64, u32, usize);
+type GlmTuple = (
+    String,
+    Vec<f64>,
+    Vec<f64>,
+    Vec<f64>,
+    f64,
+    f64,
+    f64,
+    f64,
+    u32,
+    usize,
+);
 
 fn column_to_series(df: &DataFrame, name: &str) -> PyResult<Series> {
     df.column(name)
@@ -36,6 +47,7 @@ fn optional_column_to_series(df: &DataFrame, name: &Option<String>) -> PyResult<
     weight_name,
     stratum_name=None,
     psu_name=None,
+    fpc_name=None,
     by_col=None,
     family="gaussian".to_string(),
     link="identity".to_string(),
@@ -50,6 +62,7 @@ pub fn fit_glm_rs(
     weight_name: String,
     stratum_name: Option<String>,
     psu_name: Option<String>,
+    fpc_name: Option<String>,
     by_col: Option<String>,
     family: String,
     link: String,
@@ -71,6 +84,7 @@ pub fn fit_glm_rs(
 
     let stratum = optional_column_to_series(&df, &stratum_name)?;
     let psu = optional_column_to_series(&df, &psu_name)?;
+    let fpc = optional_column_to_series(&df, &fpc_name)?;
 
     // No by_col: single fit, wrap in one-element vec for API uniformity.
     if by_col.is_none() {
@@ -83,6 +97,7 @@ pub fn fit_glm_rs(
                     &weights,
                     stratum.as_ref(),
                     psu.as_ref(),
+                    fpc.as_ref(),
                     &family,
                     &link,
                     tol,
@@ -95,6 +110,7 @@ pub fn fit_glm_rs(
             String::new(),
             result.params,
             result.cov_params,
+            result.naive_cov,
             result.scale,
             result.df_resid,
             result.deviance,
@@ -116,6 +132,7 @@ pub fn fit_glm_rs(
                 &weights,
                 stratum.as_ref(),
                 psu.as_ref(),
+                fpc.as_ref(),
                 &by_series,
                 &family,
                 &link,
@@ -132,6 +149,7 @@ pub fn fit_glm_rs(
                 level,
                 r.params,
                 r.cov_params,
+                r.naive_cov,
                 r.scale,
                 r.df_resid,
                 r.deviance,

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -71,6 +71,36 @@ impl Family {
             Family::Gaussian => y,
         }
     }
+
+    /// Unit deviance d(y, mu) — matches R's family$dev.resids (squared,
+    /// per-observation) so that sum_i w_i * d(y_i, mu_i) reproduces R's
+    /// glm/svyglm deviance on the same weight scale.
+    fn unit_deviance(&self, y: f64, mu: f64) -> f64 {
+        match self {
+            Family::Gaussian => (y - mu).powi(2),
+            Family::Binomial => {
+                let mu_c = mu.clamp(1e-10, 1.0 - 1e-10);
+                let t1 = if y > 0.0 { y * (y / mu_c).ln() } else { 0.0 };
+                let t2 = if y < 1.0 {
+                    (1.0 - y) * ((1.0 - y) / (1.0 - mu_c)).ln()
+                } else {
+                    0.0
+                };
+                2.0 * (t1 + t2)
+            }
+            Family::Poisson => {
+                let mu_c = mu.max(1e-10);
+                let t = if y > 0.0 { y * (y / mu_c).ln() } else { 0.0 };
+                2.0 * (t - (y - mu_c))
+            }
+            Family::Gamma => {
+                let mu_c = mu.max(1e-10);
+                let y_c = y.max(1e-10);
+                2.0 * (-(y_c / mu_c).ln() + (y - mu_c) / mu_c)
+            }
+            Family::InverseGaussian => (y - mu).powi(2) / (y.max(1e-10) * mu * mu),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -340,7 +370,14 @@ fn solve_linear_system(A: MatRef<'_, f64>, b: MatRef<'_, f64>) -> Mat<f64> {
     let x2 = lu.solve(b);
     for i in 0..x2.nrows() {
         if !x2[(i, 0)].is_finite() {
-            return A.thin_svd().unwrap().pseudoinverse() * b;
+            // Last resort: SVD pseudoinverse. If even the SVD fails to
+            // converge (degenerate system, e.g. a constant response in a
+            // complement domain), return the non-finite LU solution — the
+            // caller surfaces it as a fit error instead of a panic.
+            return match A.thin_svd() {
+                Ok(svd) => svd.pseudoinverse() * b,
+                Err(_) => x2,
+            };
         }
     }
     x2
@@ -389,6 +426,10 @@ fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> Mat<f64> {
 pub struct GlmResult {
     pub params: Vec<f64>,
     pub cov_params: Vec<f64>,
+    /// Model-based (inverse-information) covariance (X'WX)^-1 at the final
+    /// beta — R svyglm's naive.cov, used for the Rao-Scott/dAIC design
+    /// effects. Same weight scale as the fit (weights normalized to mean 1).
+    pub naive_cov: Vec<f64>,
     pub scale: f64,
     pub df_resid: f64,
     pub deviance: f64,
@@ -411,13 +452,14 @@ pub fn fit_glm(
     weights: &Series,
     strata: Option<&Series>,
     psu: Option<&Series>,
+    fpc: Option<&Series>,
     family_str: &str,
     link_str: &str,
     tol: f64,
     max_iter: usize,
 ) -> PolarsResult<GlmResult> {
     fit_glm_domain(
-        y, x_cols, weights, strata, psu, None, family_str, link_str, tol, max_iter,
+        y, x_cols, weights, strata, psu, fpc, None, family_str, link_str, tol, max_iter,
     )
 }
 
@@ -434,6 +476,7 @@ pub fn fit_glm_by(
     weights: &Series,
     strata: Option<&Series>,
     psu: Option<&Series>,
+    fpc: Option<&Series>,
     by_col: &Series,
     family_str: &str,
     link_str: &str,
@@ -449,9 +492,9 @@ pub fn fit_glm_by(
     // in level order (deterministic, thread-count-independent — see the policy
     // note in estimation/mod.rs). Each fit is a full, self-contained IRLS solve.
     let groups: Vec<&str> = unique_groups.iter().flatten().collect();
-    let results = groups
+    let attempts: Vec<(String, PolarsResult<GlmResult>)> = groups
         .par_iter()
-        .map(|&group_val| -> PolarsResult<(String, GlmResult)> {
+        .map(|&group_val| {
             let mask_vec: Vec<bool> = by_str
                 .iter()
                 .map(|v| v.map_or(false, |s| s == group_val))
@@ -467,17 +510,38 @@ pub fn fit_glm_by(
                 weights,
                 strata,
                 psu,
+                fpc,
                 Some(&mask_vec),
                 family_str,
                 link_str,
                 tol,
                 max_iter,
-            )?;
-
-            Ok((group_val.to_string(), res))
+            );
+            (group_val.to_string(), res)
         })
-        .collect::<PolarsResult<Vec<_>>>()?;
+        .collect();
 
+    // A level that fails to fit (e.g. a complement domain with a constant
+    // binomial response) is dropped rather than failing the whole call —
+    // the caller typically needs only one level. If every level fails,
+    // propagate the first error.
+    let mut results = Vec::with_capacity(attempts.len());
+    let mut first_err: Option<PolarsError> = None;
+    for (level, res) in attempts {
+        match res {
+            Ok(r) => results.push((level, r)),
+            Err(e) => {
+                if first_err.is_none() {
+                    first_err = Some(e);
+                }
+            }
+        }
+    }
+    if results.is_empty() {
+        if let Some(e) = first_err {
+            return Err(e);
+        }
+    }
     Ok(results)
 }
 
@@ -491,6 +555,7 @@ fn fit_glm_domain(
     weights: &Series,
     strata: Option<&Series>,
     psu: Option<&Series>,
+    fpc: Option<&Series>,
     domain_mask: Option<&[bool]>,
     family_str: &str,
     link_str: &str,
@@ -636,7 +701,7 @@ fn fit_glm_domain(
                 let w_i = w_samp[i];
                 if w_i > 0.0 {
                     let y_i = Y[(i, 0)];
-                    dev_new += w_i * (y_i - mu_i).powi(2);
+                    dev_new += w_i * family.unit_deviance(y_i, mu_i);
                 }
             }
         }
@@ -662,6 +727,17 @@ fn fit_glm_domain(
 
         if iter > 0 && (rel_dev < tol || max_delta < tol) {
             break;
+        }
+    }
+
+    // A degenerate system (e.g. constant response under binomial) must
+    // surface as an error, not NaN coefficients or a panic downstream.
+    for j in 0..k {
+        if !beta[(j, 0)].is_finite() {
+            return Err(PolarsError::ComputeError(
+                "GLM did not produce finite coefficients (degenerate or non-convergent fit)"
+                    .into(),
+            ));
         }
     }
 
@@ -738,6 +814,18 @@ fn fit_glm_domain(
         strata_obs[strata_idx[i]].push(i);
     }
 
+    // Per-row FPC factor (1 - f_h), constant within a stratum; each
+    // stratum's meat contribution is multiplied by its factor (matches R
+    // svyglm on a design with fpc=). Missing/absent -> 1.0 (no correction).
+    let fpc_rows: Option<Vec<f64>> = match fpc {
+        Some(s) => {
+            let s_cast = s.cast(&DataType::Float64)?;
+            let ca = s_cast.f64()?;
+            Some(ca.iter().map(|v| v.unwrap_or(1.0)).collect())
+        }
+        None => None,
+    };
+
     // MEAT = sum_h Var_h( PSU totals ) with svytotal-style centering.
     // Out-of-domain rows have w_irls[i] == 0 from build_irls_normal_eqs, so
     // their score contributions are naturally 0.
@@ -792,8 +880,12 @@ fn fit_glm_domain(
             mean[j] /= m as f64;
         }
 
-        // with-replacement factor m/(m-1)
-        let scale_h = (m as f64) / ((m - 1) as f64);
+        // with-replacement factor m/(m-1), times the stratum FPC (1 - f_h)
+        let fpc_h = match &fpc_rows {
+            Some(f) => strata_obs[h].first().map(|&i| f[i]).unwrap_or(1.0),
+            None => 1.0,
+        };
+        let scale_h = fpc_h * (m as f64) / ((m - 1) as f64);
 
         for a in 0..k {
             for b in 0..k {
@@ -878,10 +970,12 @@ fn fit_glm_domain(
         if n_dom <= 1 { 1.0 } else { (n_dom - 1) as f64 }
     };
 
-    // n_obs: full sample size when no domain, in-domain count when domain.
+    // n_obs: rows actually contributing to the fit — in-domain with
+    // positive weight. Zero-weight rows (e.g. missing-value rows kept for
+    // the design structure) are excluded in both branches.
     let n_obs = match domain_mask {
         Some(m) => (0..n).filter(|&i| m[i] && w_samp[i] > 0.0).count(),
-        None => n,
+        None => (0..n).filter(|&i| w_samp[i] > 0.0).count(),
     };
 
     // scale (phi) for gaussian/gamma/invgauss (reporting only).
@@ -914,7 +1008,10 @@ fn fit_glm_domain(
         1.0
     };
 
-    // null deviance proxy — weighted SSE around weighted mean over domain.
+    // Null deviance — family unit deviance at the intercept-only fit. For a
+    // GLM with only an intercept the MLE of mu is the weighted mean of y
+    // regardless of link (the constant score sum_i w_i (y_i - mu) c = 0), so
+    // this reproduces R's null.deviance on the same weight scale.
     let null_deviance = {
         // domain-restricted weighted mean
         let mut sum_wy = 0.0;
@@ -929,7 +1026,7 @@ fn fit_glm_domain(
         }
         let y_mean = if sum_w > 0.0 { sum_wy / sum_w } else { 0.0 };
 
-        let mut sse = 0.0;
+        let mut dev0 = 0.0;
         for i in 0..n {
             let in_domain = domain_mask.map_or(true, |m| m[i]);
             if !in_domain {
@@ -940,9 +1037,9 @@ fn fit_glm_domain(
                 continue;
             }
             let y_i = Y[(i, 0)];
-            sse += w_i * (y_i - y_mean).powi(2);
+            dev0 += w_i * family.unit_deviance(y_i, y_mean);
         }
-        sse
+        dev0
     };
 
     // Suppress unused-var warning when no domain restriction is active.
@@ -951,15 +1048,18 @@ fn fit_glm_domain(
     // flatten
     let params: Vec<f64> = (0..k).map(|i| beta[(i, 0)]).collect();
     let mut cov_flat = Vec::with_capacity(k * k);
+    let mut naive_flat = Vec::with_capacity(k * k);
     for r in 0..k {
         for c in 0..k {
             cov_flat.push(cov[(r, c)]);
+            naive_flat.push(bread[(r, c)]);
         }
     }
 
     Ok(GlmResult {
         params,
         cov_params: cov_flat,
+        naive_cov: naive_flat,
         scale,
         df_resid,
         deviance,

--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -303,6 +303,7 @@ def prepare_data(
     by: str | Sequence[str] | None = None,
     where: WhereArg = None,
     extra_cols: list[str] | None = None,
+    null_zero_cols: list[str] | None = None,
     drop_nulls: bool,
     cast_y_float: bool,
     select_columns: bool,
@@ -465,6 +466,11 @@ def prepare_data(
                 _domain_roles.append(x)
             if y_pair:
                 _domain_roles.append(y_pair)
+        if null_zero_cols:
+            # Caller-designated columns (e.g. regression covariates) whose
+            # nulls make the row out-of-domain (kept, weight-zeroed) instead
+            # of physically dropped — preserving PSUs/strata in the design.
+            _domain_roles.extend(null_zero_cols)
         if group:
             _domain_roles.append(group)
         if isinstance(by, str):
@@ -667,6 +673,17 @@ def prepare_data(
             _fill_targets = [y_col] if cast_y_float else []
             if x:
                 _fill_targets.append(x)
+            if null_zero_cols:
+                # Numeric caller-designated columns only: string/categorical
+                # columns cannot carry a 0.0 fill (the caller's engineered
+                # exprs handle their nulls downstream).
+                _fill_targets.extend(
+                    c
+                    for c in null_zero_cols
+                    if c in df.columns
+                    and df.schema[c].is_numeric()
+                    and c not in _fill_targets
+                )
             for c in _fill_targets:
                 if c not in df.columns:
                     continue

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -272,14 +272,33 @@ class GLM:
             where_expr = _compile_where_to_pl_expr(where)
             where_cols = list(where_expr.meta.root_names())
 
+        # Replicate weight columns (replicate variance is computed when the
+        # design carries them) and the FPC population column, both of which
+        # must survive prepare_data's projection.
+        design0 = self._sample._design
+        rep_cols: list[str] = (
+            list(design0.rep_wgts.columns) if design0.rep_wgts is not None else []
+        )
+        pop_size = design0.pop_size
+        pop_cols: list[str] = []
+        if pop_size is not None:
+            _pop_col = pop_size if isinstance(pop_size, str) else pop_size.psu
+            if isinstance(_pop_col, str):
+                pop_cols = [_pop_col]
+
         # ── Centralised data preparation ─────────────────────────────────
         # prepare_data handles: materialise, column selection, missing values,
         # weight casting, singleton filter, and correct strata/psu resolution
         # (including singleton variance columns when present).
+        # Covariate and where-clause columns go through null_zero_cols: rows
+        # with missing values are KEPT with zeroed weights (main + replicate)
+        # so the design structure (PSUs in stratum centering, df) is
+        # preserved — matching R svyglm — instead of physically dropped.
         prep = prepare_data(
             self._sample,
             y=y,
-            extra_cols=x_cols + where_cols,
+            extra_cols=x_cols + where_cols + rep_cols + pop_cols,
+            null_zero_cols=x_cols + where_cols,
             drop_nulls=drop_nulls,
             cast_y_float=True,
             apply_singleton_filter=True,
@@ -304,11 +323,24 @@ class GLM:
             bool_expr = _compile_where_to_pl_expr(where)
             df = df.with_columns(cast(pl.Expr, bool_expr).cast(pl.Utf8).alias(by_col_name))
 
-        # Filter invalid weights
-        if self._sample._design.wgt is not None:
-            df = df.filter(
-                (pl.col(w_col) > 0) & pl.col(w_col).is_not_null() & pl.col(w_col).is_finite()
+        # Drop rows with INVALID weights (null / non-finite / negative) —
+        # unconditionally: prepare_data always provides a weight column,
+        # synthesizing ones for unweighted designs. Zero-weight rows are
+        # KEPT: prepare_data zero-weights missing-value rows so they
+        # preserve the design structure while contributing nothing.
+        df = df.filter(
+            pl.col(w_col).is_not_null() & pl.col(w_col).is_finite() & (pl.col(w_col) >= 0)
+        )
+
+        # In-domain rows: where == true (when set) and positive weight.
+        # Cat level enumeration, reference validation, and response
+        # validation all use exactly the rows the fit will use.
+        _in_dom_expr = pl.col(w_col) > 0
+        if by_col_name is not None:
+            _in_dom_expr = _in_dom_expr & (
+                pl.col(by_col_name).str.to_lowercase() == "true"
             )
+        level_df = df.filter(_in_dom_expr)
 
         # ── Build feature matrix ──────────────────────────────────────────
         feature_exprs: list[pl.Expr] = []
@@ -325,15 +357,36 @@ class GLM:
                 return [pl.col(feat).cast(pl.Float64)], [feat]
 
             elif isinstance(feat, Cat):
+                # Levels enumerated over the rows the fit will use (in-domain
+                # under where=), so out-of-domain-only levels cannot create
+                # phantom all-zero dummies that inflate df and zero the Wald F.
                 levels = (
-                    df.select(pl.col(feat.name).drop_nulls().unique().sort()).to_series().to_list()
+                    level_df.select(pl.col(feat.name).drop_nulls().unique().sort())
+                    .to_series()
+                    .to_list()
                 )
 
                 if len(levels) < 2:
                     log.warning(f"Categorical '{feat.name}' has < 2 levels. Dropped.")
                     return [], []
 
-                ref_val = feat.ref if feat.ref in levels else levels[0]
+                if feat.ref is not None and feat.ref not in levels:
+                    raise ModelError(
+                        title="Reference level not found",
+                        detail=(
+                            f"Cat({feat.name!r}, ref={feat.ref!r}): the reference "
+                            f"level is not among the observed levels {levels!r}. "
+                            "A silently substituted reference would change the "
+                            "meaning of every coefficient."
+                        ),
+                        code="CAT_REF_NOT_FOUND",
+                        where="GLM.fit",
+                        param=feat.name,
+                        got=feat.ref,
+                        expected=levels,
+                        hint="Check the level's value and dtype (e.g. 1 vs '1').",
+                    )
+                ref_val = feat.ref if feat.ref is not None else levels[0]
                 levels = [ref_val] + [v for v in levels if v != ref_val]
 
                 term_info[feat.name] = {
@@ -373,6 +426,18 @@ class GLM:
             feature_exprs.extend(exprs)
             feature_names.extend(names)
 
+        # ── FPC (single-stage) ───────────────────────────────────────────
+        # Per-stratum (1 - f_h) factors matching R svyglm on a design with
+        # fpc=. Only the PSU-level factor applies (the sandwich meat is
+        # first-stage); PopSize SSU information is ignored here.
+        fpc_name: str | None = None
+        if pop_cols and pop_cols[0] in df.columns:
+            from svy.estimation._fpc import build_fpc_psu_column
+
+            df, fpc_name = build_fpc_psu_column(
+                df, pop_cols[0], s_col, p_col, "__svy_fpc_psu__"
+            )
+
         # Build final selection — include the by_col when domain is set
         final_selects = (
             [pl.col(y).cast(pl.Float64)] + feature_exprs + [pl.col(w_col).cast(pl.Float64)]
@@ -383,26 +448,39 @@ class GLM:
             final_selects.append(pl.col(p_col))
         if by_col_name and by_col_name in df.columns:
             final_selects.append(pl.col(by_col_name))
+        if fpc_name and fpc_name in df.columns:
+            final_selects.append(pl.col(fpc_name))
+        for rc in rep_cols:
+            if rc in df.columns:
+                final_selects.append(pl.col(rc).cast(pl.Float64))
 
         try:
             eng_df: pl.DataFrame = df.select(final_selects)
         except Exception as e:
             raise ValueError(f"Failed to prepare data: {e}")
 
-        # Validate response
-        y_data = eng_df.get_column(y)
+        # Zero-weight rows (kept for design structure) may carry nulls in
+        # engineered features (e.g. Cat dummies of a null value); the Rust
+        # engine requires dense y/X and these rows contribute nothing.
+        _dense_cols = [y] + [c for c in feature_names if c != "_intercept_"]
+        eng_df = eng_df.with_columns([pl.col(c).fill_null(0.0) for c in _dense_cols])
+
+        # Validate response over the rows the fit will actually use (the
+        # full frame may hold out-of-domain rows with other y values).
+        y_data = level_df.get_column(y).drop_nulls()
         self._validate_response(y_data, fam_str)
 
         # ── Call Rust ─────────────────────────────────────────────────────
         # Always returns Vec<(level, ...)> with one entry per by-level, or a
         # single entry with level="" when by_col is None.
-        try:
-            results = rs.fit_glm_rs(
+        def _run_engine(weight_name: str, fpc: str | None):
+            res = rs.fit_glm_rs(
                 y_name=y,
                 x_names=feature_names,
-                weight_name=w_col,
+                weight_name=weight_name,
                 stratum_name=s_col,
                 psu_name=p_col,
+                fpc_name=fpc,
                 by_col=by_col_name,
                 family=fam_str,
                 link=link_str,
@@ -410,32 +488,71 @@ class GLM:
                 max_iter=max_iter,
                 data=eng_df,
             )
-        except Exception as e:
-            raise RuntimeError(f"Rust GLM engine failed: {e}") from e
-
-        if not results:
-            raise RuntimeError("GLM engine returned no results.")
-
-        # ── Pick the relevant fit ─────────────────────────────────────────
-        if by_col_name is None:
-            chosen = results[0]
-        else:
-            # where supplied — pick the "true" level
-            true_results = [r for r in results if str(r[0]).lower() == "true"]
-            if not true_results:
+            if not res:
+                raise RuntimeError("GLM engine returned no results.")
+            if by_col_name is None:
+                return res[0]
+            true_res = [r for r in res if str(r[0]).lower() == "true"]
+            if not true_res:
                 raise RuntimeError(
                     "where clause produced no in-domain observations; cannot fit GLM."
                 )
-            chosen = true_results[0]
+            return true_res[0]
 
-        _level, beta, cov_flat, scale, df_resid, dev, null_dev, iters, n_obs = chosen
+        try:
+            chosen = _run_engine(w_col, fpc_name)
+        except RuntimeError:
+            raise
+        except Exception as e:
+            raise RuntimeError(f"Rust GLM engine failed: {e}") from e
+
+        (
+            _level,
+            beta,
+            cov_flat,
+            naive_flat,
+            scale,
+            df_resid,
+            dev,
+            null_dev,
+            iters,
+            n_obs,
+        ) = chosen
 
         # ── Post-process ──────────────────────────────────────────────────
         k = len(feature_names)
-        n = n_obs if where is not None else eng_df.height
+        # n counts the rows that actually contributed: in-domain, positive
+        # weight (zero-weight missing-value rows are structural only).
+        n = n_obs
         cov_mat = np.array(cov_flat).reshape(k, k)
-        se_arr = np.sqrt(np.diag(cov_mat))
+        naive_cov = np.array(naive_flat).reshape(k, k)
         params_arr = np.array(beta)
+
+        # ── R svyglm weight scale ────────────────────────────────────────
+        # The Rust engine normalizes weights over ALL rows passed; R svyglm
+        # normalizes over the fitted rows only. Deviance and the model-based
+        # information are linear in that scale; rho converts to R's scale
+        # (rho == 1 for full-sample fits with no zero-weight rows).
+        w_all = eng_df.get_column(w_col).to_numpy().astype(float)
+        if by_col_name is not None:
+            _dom_arr = (
+                eng_df.get_column(by_col_name).cast(pl.Utf8).str.to_lowercase() == "true"
+            ).to_numpy()
+            in_dom_mask = _dom_arr & (w_all > 0)
+        else:
+            in_dom_mask = w_all > 0
+        _n_in = int(in_dom_mask.sum())
+        _sum_in = float(w_all[in_dom_mask].sum())
+        _n_all = int(len(w_all))
+        _sum_all = float(w_all.sum())
+        rho = (
+            (_n_in / _sum_in) * (_sum_all / _n_all)
+            if _sum_in > 0 and _n_all > 0 and _sum_all > 0
+            else 1.0
+        )
+        dev = dev * rho
+        null_dev = null_dev * rho
+        naive_cov = naive_cov / rho
 
         # Design DF — for GLM we follow the regression convention used by
         # R's svyglm: df_resid = degf(design) - (k - 1), where k - 1 is the
@@ -443,15 +560,63 @@ class GLM:
         # estimation namespace (mean, prop, ratio) which uses the raw design
         # df since no parameters are fitted. The max(1, ...) guard protects
         # against degenerate designs with very few PSUs relative to k.
-        # When domain is set, restrict to in-domain rows for the df.
-        # (Rust returns its own df_resid; we recompute here on the Python
-        # side for the t-quantile to match the convention.)
-        if where is not None:
-            domain_df = eng_df.filter(pl.col(by_col_name).str.to_lowercase() == "true")
-            df_design = self._compute_design_df(domain_df, s_col, p_col, domain_df.height)
-        else:
-            df_design = self._compute_design_df(eng_df, s_col, p_col, n)
+        # Restricted to in-domain, positive-weight rows (Rust returns its
+        # own df_resid; we recompute here for the t-quantile convention).
+        in_dom_df = eng_df.filter(pl.Series(in_dom_mask))
+        df_design = self._compute_design_df(in_dom_df, s_col, p_col, n)
         df_design = max(1, df_design - (k - 1))
+
+        # ── Replicate variance (R svrepglm) ──────────────────────────────
+        # When the design carries replicate weights, V(beta) comes from the
+        # spread of per-replicate refits: V = sum_r c_r (b_r - mean)(...)^T
+        # with the method's coefficients (previously the replicate design
+        # silently fell back to Taylor SEs).
+        rep_wgts = design0.rep_wgts
+        if rep_wgts is not None and rep_cols:
+            rep_betas = []
+            for rc in rep_cols:
+                try:
+                    r_chosen = _run_engine(rc, None)
+                except Exception as e:
+                    raise ModelError(
+                        title="Replicate GLM fit failed",
+                        detail=f"Refit with replicate weight {rc!r} failed: {e}",
+                        code="REPLICATE_FIT_FAILED",
+                        where="GLM.fit",
+                    ) from e
+                rep_betas.append(np.asarray(r_chosen[1], dtype=float))
+            B = np.vstack(rep_betas)
+            coefs_r = np.asarray(
+                self._rep_coefficients(rep_wgts, B.shape[0]), dtype=float
+            )
+            Bc = B - B.mean(axis=0)
+            cov_mat = (Bc * coefs_r[:, None]).T @ Bc
+            rep_df = getattr(rep_wgts, "df", None)
+            if rep_df:
+                df_design = max(1, int(rep_df) - (k - 1))
+
+        se_arr = np.sqrt(np.diag(cov_mat))
+
+        # ── Design-adjusted AIC (R survey's dAIC, Lumley & Scott 2015) ───
+        # Generic families: deviance + 2*eff.p with eff.p the trace of the
+        # generalized design-effect matrix. Gaussian/identity models follow
+        # R's extractAIC_svylm: profile-likelihood -2l plus a sigma^2
+        # design-effect term. Both validated against AIC(svyglm).
+        eff_p = self._effective_parameters(naive_cov, cov_mat, intercept)
+        if fam_str == "gaussian" and link_str == "identity":
+            aic_val = self._gaussian_daic(
+                eng_df=eng_df,
+                y=y,
+                feature_names=feature_names,
+                params=params_arr,
+                w_all=w_all,
+                in_dom_mask=in_dom_mask,
+                naive_cov=naive_cov,
+                cov=cov_mat,
+                intercept=intercept,
+            )
+        else:
+            aic_val = dev + 2.0 * eff_p if eff_p is not None else None
 
         # Statistics
         stats_struct = self._build_stats(
@@ -465,6 +630,7 @@ class GLM:
             intercept,
             params_arr,
             cov_mat,
+            aic_val,
         )
 
         # Coefficients
@@ -712,6 +878,104 @@ class GLM:
                 where="GLM.fit", family=family, violation="Negative values"
             )
 
+    @staticmethod
+    def _rep_coefficients(rep_wgts, n_reps: int) -> list[float]:
+        """Per-replicate variance coefficients c_r (R svrVar's scale*rscales)."""
+        rscales = getattr(rep_wgts, "rscales", None)
+        if rscales is not None:
+            return [float(r) for r in rscales]
+        m = str(getattr(rep_wgts, "method", "")).lower()
+        if "boot" in m:
+            return [1.0 / n_reps] * n_reps
+        if "brr" in m or "balanced" in m:
+            fay = float(getattr(rep_wgts, "fay_coef", 0.0) or 0.0)
+            return [1.0 / (n_reps * (1.0 - fay) ** 2)] * n_reps
+        if "jack" in m:
+            return [(n_reps - 1.0) / n_reps] * n_reps
+        if "sdr" in m:
+            return [4.0 / n_reps] * n_reps
+        raise ModelError(
+            title="Unknown replication method",
+            detail=f"Cannot derive replicate variance coefficients for method {m!r}.",
+            code="UNKNOWN_REP_METHOD",
+            where="GLM.fit",
+        )
+
+    @staticmethod
+    def _effective_parameters(
+        naive_cov: np.ndarray, cov: np.ndarray, intercept: bool
+    ) -> float | None:
+        """
+        Rao-Scott effective parameters: tr of the generalized design-effect
+        matrix solve(V0, V) over the non-intercept coefficients — R survey's
+        eff.p in extractAIC.svyglm (Lumley & Scott 2015).
+        """
+        k = naive_cov.shape[0]
+        idx = slice(1, k) if (intercept and k > 1) else slice(0, k)
+        v0 = naive_cov[idx, idx]
+        v = cov[idx, idx]
+        if v0.size == 0:
+            return None
+        try:
+            lam = np.linalg.eigvals(np.linalg.solve(v0, v))
+            return float(np.sum(np.real(lam)))
+        except np.linalg.LinAlgError:
+            return None
+
+    @staticmethod
+    def _gaussian_daic(
+        *,
+        eng_df: pl.DataFrame,
+        y: str,
+        feature_names: list[str],
+        params: np.ndarray,
+        w_all: np.ndarray,
+        in_dom_mask: np.ndarray,
+        naive_cov: np.ndarray,
+        cov: np.ndarray,
+        intercept: bool,
+    ) -> float | None:
+        """
+        Design-adjusted AIC for gaussian/identity models — mirrors R
+        survey's extractAIC_svylm (Lumley & Scott 2015): profile Gaussian
+        -2loglik at (beta_hat, sigma2_hat) plus 2*eff.p, where eff.p adds a
+        sigma^2 design-effect term to the trace of solve(V0*sigma2, V).
+        """
+        w_norm = np.zeros_like(w_all)
+        sum_in = float(w_all[in_dom_mask].sum())
+        n_in = int(in_dom_mask.sum())
+        if sum_in <= 0 or n_in == 0:
+            return None
+        w_norm[in_dom_mask] = w_all[in_dom_mask] * (n_in / sum_in)
+        n_hat = float(w_norm.sum())  # == n_in by construction
+
+        x_mat = eng_df.select(feature_names).to_numpy()
+        y_arr = eng_df.get_column(y).to_numpy().astype(float)
+        r2_arr = (y_arr - x_mat @ params) ** 2
+        sigma2 = float((w_norm * r2_arr).sum() / n_hat)
+        if sigma2 <= 0:
+            return None
+        minus2ll = n_hat * math.log(sigma2) + n_hat + n_hat * math.log(2.0 * math.pi)
+
+        k = naive_cov.shape[0]
+        idx = slice(1, k) if (intercept and k > 1) else slice(0, k)
+        v0s = naive_cov[idx, idx] * sigma2
+        v = cov[idx, idx]
+        if v0s.size == 0:
+            return None
+        try:
+            tr_mu = float(np.trace(np.linalg.solve(v0s, v)))
+        except np.linalg.LinAlgError:
+            return None
+        # sigma^2 design effect: I_sigma2 / H_sigma2
+        i_s2 = n_hat / (2.0 * sigma2**2)
+        u = -1.0 / (2.0 * sigma2) + r2_arr / (2.0 * sigma2**2)
+        h_s2 = float((w_norm * u**2).sum())
+        if h_s2 <= 0:
+            return None
+        eff_p = tr_mu + i_s2 / h_s2
+        return minus2ll + 2.0 * eff_p
+
     def _compute_design_df(
         self, df: pl.DataFrame, s_col: str | None, p_col: str | None, n: int
     ) -> int:
@@ -740,10 +1004,16 @@ class GLM:
         intercept: bool,
         params: np.ndarray | None = None,
         cov_mat: np.ndarray | None = None,
+        aic: float | None = None,
     ) -> GLMStats:
-        """Build model statistics including the adjusted Wald F-test."""
-        aic = dev + 2 * k
-        bic = aic - 2 * k + k * math.log(n) if n > 0 else None
+        """Build model statistics including the adjusted Wald F-test.
+
+        AIC is the design-adjusted dAIC computed by the caller (R survey's
+        AIC.svyglm convention, Lumley & Scott 2015). BIC is None: R survey
+        provides no plain BIC for svyglm (its dBIC requires an explicit
+        maximal model).
+        """
+        bic = None
 
         r2 = 1.0 - dev / null_dev if null_dev > 1e-12 else None
         r2_adj = None

--- a/packages/svy/tests/svy/regression/test_glm_design_gaps.py
+++ b/packages/svy/tests/svy/regression/test_glm_design_gaps.py
@@ -1,0 +1,325 @@
+# tests/svy/regression/test_glm_design_gaps.py
+"""
+Round 8 GLM design-gap fixes (findings R6-R13).
+
+R reference values generated with survey 4.5 (2026-07-23):
+
+  api <- read.csv("apistrat.csv"); api$y_bin <- as.integer(api$api00 > 600)
+  d1  <- svydesign(ids=~1, weights=~pw, data=api)
+  m1  <- svyglm(y_bin ~ ell + meals + mobility, design=d1, family=quasibinomial())
+  deviance(m1); m1$null.deviance; AIC(m1)          # 137.2613 / 253.4408 / 143.1756699
+  mg  <- svyglm(api00 ~ ell + meals, design=d1)
+  deviance(mg); AIC(mg)                            # 1030475.410961 / 2283.0747437
+  mp  <- svyglm(enroll ~ ell + meals, design=d1, family=quasipoisson())
+  deviance(mp); AIC(mp)                            # 50539.724280 / 51351.3251693
+  dfpc<- svydesign(ids=~1, strata=~stype, weights=~pw, fpc=~fpc, data=api)
+  SE(svyglm(api00 ~ ell + meals, design=dfpc))     # 8.75949495 0.38791652 0.27576549
+  SE(svyglm(y_bin ~ ell + meals, design=dfpc, family=quasibinomial()))
+                                                   # 0.57895049 0.01493313 0.01296360
+  dnf <- svydesign(ids=~1, strata=~stype, weights=~pw, data=api)
+  rj  <- as.svrepdesign(dnf, type="JKn")
+  SE(svyglm(api00 ~ ell + meals, design=rj))       # 9.01172834 0.40647424 0.28786459
+  api2 <- api; api2$ell[1:5] <- NA
+  m2  <- svyglm(api00 ~ ell + meals, design=svydesign(ids=~1, strata=~stype,
+                weights=~pw, data=api2))
+  coef(m2); SE(m2)   # 822.39263891 -0.58973797 -3.04680103 / 8.97658993 0.41001108 0.28108227
+
+AIC(svyglm) is the Lumley-Scott dAIC; BIC(svyglm) requires a maximal
+model (no plain BIC exists), hence stats.bic is None.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+import svy
+
+from svy.core.design import RepWeights
+from svy.core.sample import Design, Sample
+from svy.core.terms import Cat
+from svy.errors.model_errors import ModelError
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
+
+RTOL = 1e-6
+RTOL_SE = 1e-6
+
+
+@pytest.fixture
+def api_strat():
+    return pl.read_csv(DATA_DIR / "apistrat.csv")
+
+
+@pytest.fixture
+def api_binary(api_strat):
+    return api_strat.with_columns((pl.col("api00") > 600).cast(pl.Int32).alias("y_bin"))
+
+
+# =============================================================================
+# R6 — family deviance, dAIC, no plain BIC
+# =============================================================================
+
+
+class TestDevianceAIC:
+    def test_binomial_deviance_matches_r(self, api_binary):
+        s = Sample(api_binary, Design(wgt="pw"))
+        m = s.glm.fit(y="y_bin", x=["ell", "meals", "mobility"], family="binomial")
+        st = m.fitted.stats
+        np.testing.assert_allclose(st.deviance, 137.2613, rtol=1e-5)
+        np.testing.assert_allclose(st.aic, 143.1756699, rtol=RTOL)
+        assert st.bic is None
+        # null deviance via R^2 = 1 - dev/null_dev
+        null_dev = st.deviance / (1.0 - st.r_squared)
+        np.testing.assert_allclose(null_dev, 253.4408, rtol=1e-5)
+
+    def test_gaussian_deviance_and_daic_match_r(self, api_strat):
+        s = Sample(api_strat, Design(wgt="pw"))
+        m = s.glm.fit(y="api00", x=["ell", "meals"])
+        st = m.fitted.stats
+        np.testing.assert_allclose(st.deviance, 1030475.410961, rtol=RTOL)
+        np.testing.assert_allclose(st.aic, 2283.0747437, rtol=RTOL)
+        assert st.bic is None
+
+    def test_poisson_deviance_matches_r(self, api_strat):
+        s = Sample(api_strat, Design(wgt="pw"))
+        m = s.glm.fit(y="enroll", x=["ell", "meals"], family="poisson")
+        st = m.fitted.stats
+        np.testing.assert_allclose(st.deviance, 50539.724280, rtol=RTOL)
+        np.testing.assert_allclose(st.aic, 51351.3251693, rtol=RTOL)
+
+
+# =============================================================================
+# R7 — replicate-weight designs use replicate variance
+# =============================================================================
+
+
+def _jkn_columns(df: pl.DataFrame, stratum: str, wgt: str) -> tuple[pl.DataFrame, int]:
+    """Deterministic JKn delete-one weights (ids=~1): replicate r zeroes row
+    r and scales same-stratum rows by n_h/(n_h-1) — R as.svrepdesign
+    type='JKn' construction."""
+    strata = df.get_column(stratum).to_list()
+    w = df.get_column(wgt).to_numpy().astype(float)
+    n = len(w)
+    from collections import Counter
+
+    n_h = Counter(strata)
+    cols = {}
+    for r in range(n):
+        h = strata[r]
+        f = n_h[h] / (n_h[h] - 1)
+        col = np.array(
+            [0.0 if i == r else (w[i] * f if strata[i] == h else w[i]) for i in range(n)]
+        )
+        cols[f"jw{r + 1}"] = col
+    return df.with_columns([pl.Series(k, v) for k, v in cols.items()]), n
+
+
+class TestReplicateGLM:
+    def test_jkn_matches_r(self, api_strat):
+        df, n = _jkn_columns(api_strat, "stype", "pw")
+        strata = api_strat.get_column("stype").to_list()
+        from collections import Counter
+
+        n_h = Counter(strata)
+        rscales = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
+        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, rscales=rscales)
+        s = Sample(df, Design(stratum="stype", wgt="pw", rep_wgts=rw))
+        m = s.glm.fit(y="api00", x=["ell", "meals"])
+        got = [c.se for c in m.fitted.coefs]
+        np.testing.assert_allclose(
+            got, [9.01172834, 0.40647424, 0.28786459], rtol=1e-4
+        )
+
+    def test_replicate_variance_differs_from_taylor(self, api_strat):
+        """Round 8 R7: a replicate design previously produced SEs identical
+        to the plain weighted (Taylor) design."""
+        df, n = _jkn_columns(api_strat, "stype", "pw")
+        strata = api_strat.get_column("stype").to_list()
+        from collections import Counter
+
+        n_h = Counter(strata)
+        rscales = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
+        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, rscales=rscales)
+        s_rep = Sample(df, Design(stratum="stype", wgt="pw", rep_wgts=rw))
+        s_tay = Sample(api_strat, Design(stratum="stype", wgt="pw"))
+        se_rep = [c.se for c in s_rep.glm.fit(y="api00", x=["ell", "meals"]).fitted.coefs]
+        se_tay = [c.se for c in s_tay.glm.fit(y="api00", x=["ell", "meals"]).fitted.coefs]
+        assert not np.allclose(se_rep, se_tay, rtol=1e-6)
+
+    def test_bootstrap_combination_self_consistent(self):
+        """V = sum_r c_r (b_r - mean)(b_r - mean)' with c_r = 1/R."""
+        rng = np.random.default_rng(5)
+        n = 60
+        df = pl.DataFrame(
+            {
+                "w": rng.uniform(1, 3, n),
+                "x": rng.normal(size=n),
+                "y": rng.normal(size=n),
+            }
+        )
+        reps = {}
+        for r in range(4):
+            m = rng.poisson(1.0, n).astype(float)
+            reps[f"bw{r + 1}"] = df.get_column("w").to_numpy() * m
+        dfr = df.with_columns([pl.Series(k, v) for k, v in reps.items()])
+        rw = RepWeights(method="bootstrap", prefix="bw", n_reps=4)
+        s = Sample(dfr, Design(wgt="w", rep_wgts=rw))
+        fit = s.glm.fit(y="y", x=["x"])
+
+        # Rebuild the expected covariance from per-replicate refits
+        betas = []
+        for r in range(4):
+            sr = Sample(dfr, Design(wgt=f"bw{r + 1}"))
+            betas.append([c.est for c in sr.glm.fit(y="y", x=["x"]).fitted.coefs])
+        B = np.array(betas)
+        Bc = B - B.mean(axis=0)
+        V = (Bc * (1.0 / 4.0)).T @ Bc
+        np.testing.assert_allclose(
+            [c.se for c in fit.fitted.coefs], np.sqrt(np.diag(V)), rtol=1e-8
+        )
+
+
+# =============================================================================
+# R8 — FPC applied in the GLM sandwich
+# =============================================================================
+
+
+class TestGLMFpc:
+    def test_gaussian_fpc_matches_r(self, api_strat):
+        s = Sample(api_strat, Design(stratum="stype", wgt="pw", pop_size="fpc"))
+        m = s.glm.fit(y="api00", x=["ell", "meals"])
+        got = [c.se for c in m.fitted.coefs]
+        np.testing.assert_allclose(got, [8.75949495, 0.38791652, 0.27576549], rtol=RTOL_SE)
+
+    def test_binomial_fpc_matches_r(self, api_binary):
+        s = Sample(api_binary, Design(stratum="stype", wgt="pw", pop_size="fpc"))
+        m = s.glm.fit(y="y_bin", x=["ell", "meals"], family="binomial")
+        got = [c.se for c in m.fitted.coefs]
+        np.testing.assert_allclose(got, [0.57895049, 0.01493313, 0.01296360], rtol=1e-5)
+
+    def test_fpc_changes_ses(self, api_strat):
+        """Round 8 R8: pop_size was silently ignored (identical SEs)."""
+        s_f = Sample(api_strat, Design(stratum="stype", wgt="pw", pop_size="fpc"))
+        s_n = Sample(api_strat, Design(stratum="stype", wgt="pw"))
+        se_f = [c.se for c in s_f.glm.fit(y="api00", x=["ell", "meals"]).fitted.coefs]
+        se_n = [c.se for c in s_n.glm.fit(y="api00", x=["ell", "meals"]).fitted.coefs]
+        assert all(f < n for f, n in zip(se_f, se_n))
+
+
+# =============================================================================
+# R9 — absent Cat reference level raises
+# =============================================================================
+
+
+class TestCatRefValidation:
+    def test_absent_ref_raises(self, api_strat):
+        s = Sample(api_strat, Design(wgt="pw"))
+        with pytest.raises(ModelError, match="[Rr]eference"):
+            s.glm.fit(y="api00", x=[Cat("stype", ref="Z")])
+
+    def test_dtype_mismatch_ref_raises(self, api_strat):
+        data = api_strat.with_columns(
+            pl.col("stype").replace_strict({"E": 1, "M": 2, "H": 3}).alias("stype_num")
+        )
+        s = Sample(data, Design(wgt="pw"))
+        with pytest.raises(ModelError, match="[Rr]eference"):
+            s.glm.fit(y="api00", x=[Cat("stype_num", ref="1")])  # str vs int
+
+    def test_present_ref_works(self, api_strat):
+        s = Sample(api_strat, Design(wgt="pw"))
+        m = s.glm.fit(y="api00", x=[Cat("stype", ref="M")])
+        terms = [c.term for c in m.fitted.coefs]
+        assert "stype_M" not in terms  # M is the reference
+
+
+# =============================================================================
+# R10 — Cat levels enumerated in-domain under where=
+# =============================================================================
+
+
+def test_cat_levels_enumerated_in_domain(api_strat):
+    """A level existing only outside the domain must not create a phantom
+    all-zero dummy (est 0, se 0) or inflate df."""
+    data = api_strat.with_columns(
+        pl.when(pl.col("awards") == "No")
+        .then(pl.lit("Z"))
+        .otherwise(pl.col("stype"))
+        .alias("stype2")
+    )
+    s = Sample(data, Design(wgt="pw"))
+    m = s.glm.fit(
+        y="api00",
+        x=["ell", Cat("stype2")],
+        where=svy.col("awards") == "Yes",
+    )
+    terms = [c.term for c in m.fitted.coefs]
+    assert not any(t.endswith("_Z") for t in terms)
+
+
+# =============================================================================
+# R11 — response validated on in-domain rows only
+# =============================================================================
+
+
+def test_response_validated_in_domain(api_binary):
+    """Rows excluded by where= must not fail binomial 0/1 validation."""
+    data = api_binary.with_columns(
+        pl.when(pl.col("awards") == "No")
+        .then(pl.lit(2))
+        .otherwise(pl.col("y_bin"))
+        .alias("y_mixed")
+    )
+    s = Sample(data, Design(wgt="pw"))
+    # y == 2 exists only out-of-domain; R fits this fine
+    m = s.glm.fit(
+        y="y_mixed",
+        x=["ell", "meals"],
+        family="binomial",
+        where=svy.col("awards") == "Yes",
+    )
+    assert m.fitted is not None
+
+    # ...but in-domain invalid y still raises
+    with pytest.raises(ModelError):
+        s.glm.fit(y="y_mixed", x=["ell", "meals"], family="binomial")
+
+
+# =============================================================================
+# R12 — covariate nulls keep-and-zero-weight (design preserved)
+# =============================================================================
+
+
+def test_null_covariate_matches_r(self=None):
+    api = pl.read_csv(DATA_DIR / "apistrat.csv")
+    api2 = api.with_columns(
+        pl.when(pl.int_range(pl.len()) < 5).then(None).otherwise(pl.col("ell")).alias("ell")
+    )
+    s = Sample(api2, Design(stratum="stype", wgt="pw"))
+    m = s.glm.fit(y="api00", x=["ell", "meals"])
+    got_c = [c.est for c in m.fitted.coefs]
+    got_s = [c.se for c in m.fitted.coefs]
+    np.testing.assert_allclose(got_c, [822.39263891, -0.58973797, -3.04680103], rtol=1e-6)
+    np.testing.assert_allclose(got_s, [8.97658993, 0.41001108, 0.28108227], rtol=1e-6)
+
+
+# =============================================================================
+# R13 — n/df counted over contributing rows
+# =============================================================================
+
+
+def test_unweighted_null_y_counts(api_strat=None):
+    rng = np.random.default_rng(1)
+    n = 100
+    df = pl.DataFrame({"x": rng.normal(size=n), "y": rng.normal(size=n)})
+    df = df.with_columns(
+        pl.when(pl.int_range(pl.len()) < 10).then(None).otherwise(pl.col("y")).alias("y")
+    )
+    s = Sample(df)  # unweighted design
+    m = s.glm.fit(y="y", x=["x"])
+    st = m.fitted.stats
+    assert st.n == 90
+    # df = (n_in - 1) - (k - 1) = 89 - 1 = 88
+    assert m.fitted.coefs[0].wald.df == 88


### PR DESCRIPTION
## Summary

Round 8 findings R6–R13 — the final cluster of the 2026-07 review. Requires a native rebuild (`uv run maturin develop --uv --release` in packages/svy-rs).

### R6 — deviance/AIC/BIC were wrong for every non-Gaussian family
The engine computed `dev = Σw(y−μ)²` for all families and built AIC/BIC/R² on it (binomial read 87.0 where the true scale is ~880 population / 137 R-scale). Per maintainer decision the target is **match R survey exactly**:
- family unit deviance in Rust; reported on svyglm's normalized-weight scale — `deviance(svyglm)` matches to 1e-12;
- **AIC = Lumley–Scott dAIC**: `deviance + 2·eff.p` with eff.p = tr of the generalized design-effect matrix `solve(naive.cov, vcov)` (non-intercept block), and the profile-likelihood variant with the σ² design-effect term for gaussian/identity (`extractAIC_svylm`) — `AIC(svyglm)` matches to ~1e-9 for binomial, gaussian, and poisson;
- **`stats.bic` is now `None`** — R survey has no plain svyglm BIC (dBIC needs an explicit maximal model). Public output change: deviance/AIC values change for all non-Gaussian fits, and BIC is gone. No test pinned the old values.

### R7 — replicate designs silently fell back to Taylor (maintainer: implement)
Replicate-weight designs now get true replicate variance: per-replicate refits combined as `Σ c_r(β_r−β̄)(β_r−β̄)'` with method coefficients (bootstrap 1/R, BRR Fay, JK (R−1)/R, SDR 4/R; `RepWeights.rscales` override honored — same conventions as the estimation namespace). Validated against `svyglm` on an R `as.svrepdesign(type="JKn")` design using R's own exported weights: SEs match to 1e-9 (test reconstructs the deterministic JKn weights).

### R8 — FPC silently ignored (maintainer: implement)
`design.pop_size` now feeds per-stratum (1−f_h) factors into the Rust sandwich meat (single-stage). Validated against R `svydesign(..., fpc=~fpc)` + svyglm: gaussian and binomial SEs match to ~1e-6.

### R9–R13 — fit-path edges
- **R9** (maintainer: raise): absent `Cat(ref=...)` levels raise a typed error listing observed levels — dtype mismatches (`ref=1` vs `"1"`) surface immediately.
- **R10**: Cat levels enumerate on in-domain rows under `where=` — no phantom all-zero dummies, correct df.
- **R11**: response validated on in-domain rows only (a `where=` excluding invalid y values now fits, as R does). Fixing this exposed a latent crash: the complement-domain fit could panic the process on degenerate data (constant binomial response) — the Rust solver now returns a clean error and `fit_glm_by` drops failed complement levels.
- **R12**: covariate nulls keep-and-zero-weight via prepare_data's new `null_zero_cols` (instead of physically dropping rows), preserving PSUs in stratum centering — coefficients and SEs match R svyglm with NA covariates to 1e-6.
- **R13**: the invalid-weight filter runs unconditionally; `n`/df count contributing rows for unweighted designs too (100 rows with 10 null y → n=90, df=88).

## Tests
16 new tests in `test_glm_design_gaps.py` with the generating R code in the file header. No existing tests changed (none pinned the old deviance/AIC values; the existing missing-data test passes unchanged since `n` still counts contributing rows). Full suite: 2643 passed, 1 skipped; Rust: 77 passed.