### PR TITLE
fix(svy-rs): compute GLM sandwich scores via the direct estimating function

### DIFF
--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -854,13 +854,17 @@ fn fit_glm_domain(
             let y_i = Y[(i, 0)];
             let mu_i = mu[i];
             let d = link.mu_eta(mu_i, eta[i]);
+            let v = family.variance(mu_i).max(1e-12);
 
-            // Working residual
-            let working_resid = (y_i - mu_i) / (d + d.signum() * 1e-12);
+            // Score contribution (estimating function): w (y - mu) (dmu/deta) / V.
+            // Computed directly instead of w_irls * working_resid: the
+            // working-residual guard (d + eps) biased scores wherever
+            // dmu/deta is small (visible at ~1e-7 in SEs), while for
+            // canonical links d/V cancels exactly.
+            let s_i = w_i * (y_i - mu_i) * d / v;
 
-            // Score contribution: X * w_irls * working_resid
             for j in 0..k {
-                totals[li][j].add(w_irls_i * X[(i, j)] * working_resid);
+                totals[li][j].add(s_i * X[(i, j)]);
             }
         }
 


### PR DESCRIPTION
## Summary

Found while investigating why the svy-vs-R validation notebook's logistic regression tables differed in the 6th decimal: svy's Taylor GLM SEs carried a systematic ~1e-7 relative error.

Root cause: the sandwich meat built PSU score contributions as `w_irls * working_resid` where the working residual divides by `d + sign(d)*1e-12`. Wherever dμ/dη is small (fitted probabilities near 0/1 under logit), that guard scales the score by d/(d+ε) — a bias, not just rounding. R computes the same product without the guard.

Fix: scores use the direct estimating-function form `w·(y−μ)·(dμ/dη)/V(μ)`; for canonical links dμ/dη and V cancel exactly (logit score is literally `w·(y−μ)·x`). Verification on the World Bank synthetic dataset (18,919 households, stratified-clustered):

- before: SEs vs first-principles sandwich / R svyglm (matched IRLS tolerance): ~1e-7 relative
- after: ~1e-10 relative (agreement limited only by β̂ convergence)

Notes:
- Coefficients are untouched (the fit path is unchanged); only V(β̂) moves at the 1e-7 level, well inside every existing test tolerance.
- R users comparing against svy should tighten R's IRLS control (`control=list(epsilon=1e-12)`): R's default epsilon=1e-8 stops early enough to leave ~1e-5 discrepancies in its *own* SEs — svy computes the variance at the fully converged coefficients.

Full suite: 2740 passed, 1 skipped; Rust: 78 passed. Requires a native rebuild.