### PR TITLE
fix(categorical): use centered ratio variance for percent and count_total tabulate SEs

### DIFF
--- a/packages/svy/src/svy/categorical/base.py
+++ b/packages/svy/src/svy/categorical/base.py
@@ -229,29 +229,44 @@ class Categorical:
 
         # Scale weights for units.
         #
-        # Proportions and percents are the SAME ratio (Hajek) estimator —
-        # percent is just proportion x 100 for display. Both must use the
-        # centered variance from ``estimate_proportions`` (which subtracts the
-        # cell proportion before forming the score), so that the SE matches
-        # ``estimation.prop`` and R's ``svymean(~interaction(...))``.
+        # There are two distinct estimands here, and they need different
+        # variances:
         #
-        # ``compute_totals`` below is inferred from ``sum(weights) != 1``, so if
-        # percent weights were scaled to sum to 100 the run would route to the
-        # un-centered ``estimate_totals`` path and inflate the SE by the dropped
-        # covariance term. To avoid that, percent (without an explicit known
-        # population total) is computed on the 0-1 proportion scale and scaled
-        # to 0-100 afterwards via ``_display_scale``. Counts, and an explicit
-        # ``count_total`` (a known/fixed denominator), keep the total path.
+        # 1. A *proportion of the estimated total* — ``proportion``,
+        #    ``percent``, or scaling to a caller-supplied ``count_total`` N.
+        #    All three are the same ratio (Hajek) estimator ``p_hat`` times a
+        #    constant (1, 100, or N), so the variance is ``scale^2 *
+        #    Var(p_hat)`` using the CENTERED score from
+        #    ``estimate_proportions`` (which subtracts the cell proportion
+        #    before forming the score). This matches ``estimation.prop`` and
+        #    R's ``svymean(~interaction(...))``.
+        # 2. A *population total* — bare ``count`` with no ``count_total``.
+        #    The estimand is the total itself, including uncertainty in its
+        #    overall scale, so the un-centered ``estimate_totals`` path is
+        #    correct (it matches R's ``svytotal``).
+        #
+        # ``compute_totals`` below is inferred from ``sum(weights) != 1``, so
+        # any regime in group (1) must hand the Rust backend weights that sum
+        # to 1; the display scaling is re-applied afterwards via
+        # ``_display_scale``. Scaling the weights themselves (e.g. to sum to
+        # 100 for percent) would route to the un-centered path and inflate the
+        # SE by the dropped numerator/denominator covariance term.
         _units = _normalize_units(units)
         wgt_arr = concat_data[weight_col].to_numpy().copy()
-        if count_total is None and _units is _TableUnits.PERCENT:
+        if count_total is not None:
+            wgt_arr = _scale_weights_for_units(
+                wgt_arr, units=_TableUnits.PROPORTION, count_total=None
+            )
+            _display_scale = float(count_total)
+        elif _units is _TableUnits.PERCENT:
             wgt_arr = _scale_weights_for_units(
                 wgt_arr, units=_TableUnits.PROPORTION, count_total=None
             )
             _display_scale = 100.0
         else:
+            # PROPORTION (0-1, centered) or bare COUNT (raw weights, totals).
             wgt_arr = _scale_weights_for_units(
-                wgt_arr, units=_units, count_total=count_total
+                wgt_arr, units=_units, count_total=None
             )
             _display_scale = 1.0
         concat_data = concat_data.with_columns(
@@ -333,10 +348,11 @@ class Categorical:
                 est_arr,
             )
 
-        # Percent is computed on the 0-1 proportion scale (centered variance
-        # and logit CI above); rescale the estimate, SE, and CI bounds to
-        # 0-100 for display. ``cv = se / est`` is scale-invariant, so it is
-        # left unchanged.
+        # Percent and ``count_total`` scaling are computed on the 0-1
+        # proportion scale (centered variance and logit CI above); rescale the
+        # estimate, SE, and CI bounds by the display factor (100, or the
+        # caller's N). ``cv = se / est`` is scale-invariant, so it is left
+        # unchanged.
         if _display_scale != 1.0:
             est_arr = est_arr * _display_scale
             se_arr = se_arr * _display_scale

--- a/packages/svy/src/svy/categorical/base.py
+++ b/packages/svy/src/svy/categorical/base.py
@@ -227,10 +227,33 @@ class Categorical:
         if not design.wgt:
             concat_data = concat_data.with_columns(pl.lit(1.0).alias(weight_col))
 
-        # Scale weights for units
+        # Scale weights for units.
+        #
+        # Proportions and percents are the SAME ratio (Hajek) estimator —
+        # percent is just proportion x 100 for display. Both must use the
+        # centered variance from ``estimate_proportions`` (which subtracts the
+        # cell proportion before forming the score), so that the SE matches
+        # ``estimation.prop`` and R's ``svymean(~interaction(...))``.
+        #
+        # ``compute_totals`` below is inferred from ``sum(weights) != 1``, so if
+        # percent weights were scaled to sum to 100 the run would route to the
+        # un-centered ``estimate_totals`` path and inflate the SE by the dropped
+        # covariance term. To avoid that, percent (without an explicit known
+        # population total) is computed on the 0-1 proportion scale and scaled
+        # to 0-100 afterwards via ``_display_scale``. Counts, and an explicit
+        # ``count_total`` (a known/fixed denominator), keep the total path.
         _units = _normalize_units(units)
         wgt_arr = concat_data[weight_col].to_numpy().copy()
-        wgt_arr = _scale_weights_for_units(wgt_arr, units=_units, count_total=count_total)
+        if count_total is None and _units is _TableUnits.PERCENT:
+            wgt_arr = _scale_weights_for_units(
+                wgt_arr, units=_TableUnits.PROPORTION, count_total=None
+            )
+            _display_scale = 100.0
+        else:
+            wgt_arr = _scale_weights_for_units(
+                wgt_arr, units=_units, count_total=count_total
+            )
+            _display_scale = 1.0
         concat_data = concat_data.with_columns(
             pl.Series(name="__svy_scaled_wgt__", values=wgt_arr)
         )
@@ -309,6 +332,16 @@ class Categorical:
                 1.0 / (1.0 + np.exp(-(logit + t_crit * scale))),
                 est_arr,
             )
+
+        # Percent is computed on the 0-1 proportion scale (centered variance
+        # and logit CI above); rescale the estimate, SE, and CI bounds to
+        # 0-100 for display. ``cv = se / est`` is scale-invariant, so it is
+        # left unchanged.
+        if _display_scale != 1.0:
+            est_arr = est_arr * _display_scale
+            se_arr = se_arr * _display_scale
+            lci_arr = lci_arr * _display_scale
+            uci_arr = uci_arr * _display_scale
 
         cell_rows = [
             CellEst(

--- a/packages/svy/tests/svy/categorical/test_tabulation.py
+++ b/packages/svy/tests/svy/categorical/test_tabulation.py
@@ -214,6 +214,58 @@ def test_percent_cell_se_uses_centered_ratio_variance(df_basic, mock_design):
         assert math.isclose(cell.se, ref["se"] * 100.0, rel_tol=1e-10, abs_tol=1e-9)
 
 
+@pytest.mark.parametrize("total", [100.0, 1_000_000.0])
+def test_count_total_scaling_uses_centered_variance(df_basic, mock_design, total):
+    """Scaling to a caller-supplied total N is ``N x p_hat`` with N constant,
+    so every cell must equal the proportion cell scaled by N — SE included."""
+    sample = Sample(data=df_basic, design=mock_design)
+    prop = sample.categorical.tabulate(
+        rowvar="row", colvar="col", units=TableUnits.PROPORTION, drop_nulls=True
+    )
+    scaled = sample.categorical.tabulate(
+        rowvar="row",
+        colvar="col",
+        units=TableUnits.COUNT,
+        count_total=total,
+        drop_nulls=True,
+    )
+    prop_cells, scaled_cells = _by_cell(prop), _by_cell(scaled)
+    assert prop_cells.keys() == scaled_cells.keys()
+    for key, pc in prop_cells.items():
+        sc = scaled_cells[key]
+        for attr in ("est", "se", "lci", "uci"):
+            assert math.isclose(
+                getattr(pc, attr) * total,
+                getattr(sc, attr),
+                rel_tol=1e-10,
+                abs_tol=1e-9,
+            ), f"{attr} mismatch at {key}"
+
+
+def test_count_total_100_matches_percent(df_basic, mock_design):
+    """``count_total=100`` and ``units='percent'`` are the same estimand and
+    must not disagree on the SE."""
+    sample = Sample(data=df_basic, design=mock_design)
+    pct = sample.categorical.tabulate(
+        rowvar="row", colvar="col", units=TableUnits.PERCENT, drop_nulls=True
+    )
+    scaled = sample.categorical.tabulate(
+        rowvar="row",
+        colvar="col",
+        units=TableUnits.COUNT,
+        count_total=100,
+        drop_nulls=True,
+    )
+    pct_cells, scaled_cells = _by_cell(pct), _by_cell(scaled)
+    assert pct_cells.keys() == scaled_cells.keys()
+    for key, pc in pct_cells.items():
+        sc = scaled_cells[key]
+        for attr in ("est", "se", "lci", "uci"):
+            assert math.isclose(
+                getattr(pc, attr), getattr(sc, attr), rel_tol=1e-10, abs_tol=1e-9
+            ), f"{attr} mismatch at {key}"
+
+
 def test_count_cell_se_unaffected_matches_total(df_basic, mock_design):
     """Count units keep the total estimator (SE == design SE of the weighted
     indicator total); the percent fix must not touch this path."""

--- a/packages/svy/tests/svy/categorical/test_tabulation.py
+++ b/packages/svy/tests/svy/categorical/test_tabulation.py
@@ -147,6 +147,98 @@ def test_units_count_one_way_custom_total(df_basic, mock_design):
     assert math.isclose(_sum_estimates(tbl), target, rel_tol=1e-12, abs_tol=1e-9)
 
 
+# ------ Regression: percent must be proportion x 100 (centered variance) -------
+#
+# Percent is the same ratio (Hajek) estimator as proportion, just scaled by 100
+# for display. A prior bug scaled the weights so they summed to 100, which
+# flipped the internal ``compute_totals`` flag and routed percent through the
+# un-centered total-variance path — inflating the SE by the dropped num/denom
+# covariance term (and switching the CI from logit to Wald). These tests pin the
+# invariant so percent can never again diverge from proportion.
+
+
+def _by_cell(tbl: Table) -> dict[tuple[str | None, str | None], CellEst]:
+    return {(c.rowvar, c.colvar): c for c in (tbl.estimates or [])}
+
+
+@pytest.mark.parametrize("colvar", [None, "col"])
+def test_percent_is_proportion_scaled_by_100(df_basic, mock_design, colvar):
+    sample = Sample(data=df_basic, design=mock_design)
+    prop = sample.categorical.tabulate(
+        rowvar="row", colvar=colvar, units=TableUnits.PROPORTION, drop_nulls=True
+    )
+    pct = sample.categorical.tabulate(
+        rowvar="row", colvar=colvar, units=TableUnits.PERCENT, drop_nulls=True
+    )
+    prop_cells, pct_cells = _by_cell(prop), _by_cell(pct)
+    assert prop_cells.keys() == pct_cells.keys()
+    for key, pc in prop_cells.items():
+        cc = pct_cells[key]
+        for attr in ("est", "se", "lci", "uci"):
+            assert math.isclose(
+                getattr(pc, attr) * 100.0,
+                getattr(cc, attr),
+                rel_tol=1e-12,
+                abs_tol=1e-9,
+            ), f"{attr} mismatch at {key}"
+        # cv is scale-invariant and must be identical
+        assert math.isclose(pc.cv, cc.cv, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def test_percent_cell_se_uses_centered_ratio_variance(df_basic, mock_design):
+    """A cell SE must equal the design SE of the cell's 0/1 indicator mean.
+
+    This is the centered (Hajek) linearization used by ``estimation.mean`` and
+    by R's ``svymean(~interaction(...))``. It guards against reverting to the
+    un-centered ``svytotal``-based SE (``SE(total)/sum(weights)``).
+    """
+    import svy
+
+    sample = Sample(data=df_basic, design=mock_design)
+    pct = sample.categorical.tabulate(
+        rowvar="row", colvar="col", units=TableUnits.PERCENT, drop_nulls=True
+    )
+    for cell in pct.estimates or []:
+        indicator = sample.wrangling.mutate(
+            {
+                "__ind__": svy.when(
+                    (svy.col("row") == cell.rowvar)
+                    & (svy.col("col") == cell.colvar)
+                )
+                .then(1)
+                .otherwise(0)
+            }
+        )
+        ref = indicator.estimation.mean("__ind__").to_polars().row(0, named=True)
+        assert math.isclose(cell.est, ref["est"] * 100.0, rel_tol=1e-10, abs_tol=1e-9)
+        assert math.isclose(cell.se, ref["se"] * 100.0, rel_tol=1e-10, abs_tol=1e-9)
+
+
+def test_count_cell_se_unaffected_matches_total(df_basic, mock_design):
+    """Count units keep the total estimator (SE == design SE of the weighted
+    indicator total); the percent fix must not touch this path."""
+    import svy
+
+    sample = Sample(data=df_basic, design=mock_design)
+    cnt = sample.categorical.tabulate(
+        rowvar="row", colvar="col", units=TableUnits.COUNT, drop_nulls=True
+    )
+    for cell in cnt.estimates or []:
+        indicator = sample.wrangling.mutate(
+            {
+                "__ind__": svy.when(
+                    (svy.col("row") == cell.rowvar)
+                    & (svy.col("col") == cell.colvar)
+                )
+                .then(1)
+                .otherwise(0)
+            }
+        )
+        ref = indicator.estimation.total("__ind__").to_polars().row(0, named=True)
+        assert math.isclose(cell.est, ref["est"], rel_tol=1e-10, abs_tol=1e-9)
+        assert math.isclose(cell.se, ref["se"], rel_tol=1e-10, abs_tol=1e-9)
+
+
 @pytest.fixture
 def df_multikey():
     # Construct a small dataset with two-key strata and two-key PSUs.


### PR DESCRIPTION
## Summary

`tabulate()` reported **inflated per-cell standard errors** for any table scaled as a proportion of the estimated total — `units="percent"` and `count_total=N` — while the **point estimates were correct**. Three calls producing the *identical* estimate disagreed on the SE:

World Bank synthetic survey, `urbrur × electricity`, Rural·No cell:

| call | est | se (before) | se (after) |
|---|---|---|---|
| `units="proportion"` | 0.151987 | 0.011336 ✓ | 0.011336 |
| `units="percent"` | 15.198691 | **1.165349** ✗ | **1.133601** ✓ |
| `units="count", count_total=100` | 15.198691 | **1.165349** ✗ | **1.133601** ✓ |
| `units="count"` (bare) | 380234.001 | 29154.167 ✓ | 29154.167 (unchanged) |

`1.133601` matches svy's own `estimation.prop` and R's `svymean(~interaction(...))`. The buggy `1.165349` equals `SE(svytotal)/Σweights` — the un-centered total variance.

## Root cause

The internal `compute_totals` flag is derived from `sum(weights) != 1`. Percent scaled weights to sum to **100** and `count_total=N` scaled them to sum to **N**, both flipping `compute_totals` to `True` and routing the SE through the un-centered `estimate_totals` path (`scores_total`). That drops the numerator/denominator covariance term of the ratio (Hájek) linearization, inflating the SE by a `p`-dependent amount (up to ~12% on high-proportion cells here). It also switched the CI from logit to Wald, which could fall **below 0**.

`units="proportion"` escaped only because normalizing to sum 1 kept `compute_totals = False`.

## Fix (Python-only; `svy-rs` unchanged)

Separate the two estimands explicitly:

1. **Proportion of the estimated total** — `proportion`, `percent`, or `count_total=N`. All are `p̂ × scale` for a constant scale (1, 100, N), so they now share the **centered** path: compute on the 0–1 scale (centered variance + logit CI), then rescale `est`/`se`/`lci`/`uci` by the display factor. `cv` is scale-invariant and untouched.
2. **Population total** — bare `units="count"`. Estimand is the total itself including scale uncertainty, so the **un-centered** `estimate_totals` path is correct and is left unchanged (matches R's `svytotal`).

The **Rao-Scott χ²/F test is unaffected** — it is built from `estimate_proportions`' covariance matrix, not these per-cell SEs.

Note `tabulate(units="count", count_total=Ŵ)` now differs from bare `tabulate(units="count")`. That is intentional: supplying a total declares it known, which removes the scale uncertainty.

## Tests

- **No existing tests modified.** (The three pre-existing `count_total` tests assert only the sum of estimates, which is unchanged.)
- New regression tests in `test_tabulation.py`:
  - `percent == proportion × 100` for `est`/`se`/`lci`/`uci` (one- and two-way)
  - `count_total=N` cells == proportion cells × N (N = 100 and 1e6)
  - `count_total=100` == `units="percent"`
  - percent/proportion cell SE == design SE of the cell **indicator mean** (centered variance) — guards against reverting to the un-centered total SE
  - count cell SE == design SE of the weighted **total** (the count path must stay un-centered)
- Confirmed every new test **fails** on the pre-fix code and **passes** after.
- Full svy suite: `2750 passed, 1 skipped`; ruff clean.

## Optional follow-up (not in this PR)

`svy-rs`'s `tabulate_rs` still takes a `compute_totals: bool` that couples "display scaling" to "variance estimator." Replacing it with an explicit variance-kind enum would prevent this class of misuse, but isn't needed for the fix.