### PR TITLE
release: svy 0.20.1

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,14 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.20.1] — 2026-07-23
+
+Patch release on top of 0.20.0; [`svy-rs`](../svy-rs/CHANGELOG.md) (0.11.0) and [`svy-io`](../svy-io/CHANGELOG.md) (0.2.0) are unchanged.
+
+### Fixed
+
+- **`tabulate` percent and `count_total` cells used an un-centered variance.** A cell percentage is a ratio of two estimated totals, so its variance needs the centered (Hájek) linearization. Because the internal totals flag was inferred from `sum(weights) != 1`, scaling weights to sum to 100 (`units="percent"`) or to a caller-supplied `count_total` routed the standard error through the un-centered total path, dropping the numerator/denominator covariance term. Cell SEs were inflated by a `p`-dependent amount (up to ~12% on high-proportion cells) and the confidence interval fell back to Wald, which could dip below zero. `units="proportion"`, `units="percent"`, and `count_total=N` are now the same estimator scaled by a constant and agree exactly; they match `estimation.prop` and R `survey`'s `svymean(~interaction(...))`. Bare `units="count"` is unchanged and still matches R's `svytotal`, and the Rao-Scott chi-square/F test was never affected.
+
 ## [0.20.0] — 2026-07-23
 
 Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHANGELOG.md) 0.2.0. This release lands the round 7–8 review: correctness fixes across estimation, regression, weighting, size/power, categorical, and the dataset downloader, several of which shift standard errors closer to R `survey` 4.5.
@@ -74,7 +82,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.20.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.20.1...HEAD
+[0.20.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.20.1
 [0.20.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.20.0
 [0.19.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.19.1
 [0.19.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.19.0

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.20.0"
+version = "0.20.1"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -126,7 +126,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.20.0"
+__version__ = "0.20.1"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.20.0"
+version = "0.20.1"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Patch release on top of 0.20.0. **`svy` only** — `svy-rs` (0.11.0) and `svy-io` (0.2.0) are unchanged, and their dependency ranges in `packages/svy/pyproject.toml` are untouched.

## Contents

Ships #92: `tabulate` percent and `count_total` cells used an un-centered variance.

A cell percentage is a ratio of two estimated totals, so its variance needs the centered (Hájek) linearization. The internal totals flag was inferred from `sum(weights) != 1`, so scaling weights to sum to 100 (`units="percent"`) or to a caller-supplied `count_total` routed the SE through the un-centered total path, dropping the numerator/denominator covariance term.

| call | est | se before | se after |
|---|---|---|---|
| `units="proportion"` | 0.151987 | 0.011336 ✓ | unchanged |
| `units="percent"` | 15.198691 | 1.165349 ✗ | **1.133601** ✓ |
| `count_total=100` | 15.198691 | 1.165349 ✗ | **1.133601** ✓ |
| `units="count"` (bare) | 380234.001 | 29154.167 ✓ | unchanged |

`1.133601` matches `estimation.prop` and R `survey`'s `svymean(~interaction(...))`. The CI also moves from Wald (which could dip below zero) to logit. Bare counts still match R's `svytotal`; the Rao-Scott χ²/F test was never affected.

## Changes in this PR

- `packages/svy/pyproject.toml` → `0.20.1`
- `packages/svy/src/svy/__init__.py` → `__version__ = "0.20.1"`
- `packages/svy/CHANGELOG.md` → `[0.20.1]` section + link defs
- `uv.lock` → regenerated (`svy v0.20.0 -> v0.20.1`)

## After merge

Tag `svy-v0.20.1` to trigger the wheel build and PyPI publish.