### PR TITLE
release: svy 0.21.0, svy-rs 0.12.0

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.12.0] — 2026-07-24
+
+### Fixed
+
+- **A by-group's degrees of freedom are counted on that group's own PSUs and strata.** The five grouped Taylor kernels (mean, total, ratio, prop, median) computed one frame-level df and broadcast it to every row — `vec![df_val; n_groups]` — so the per-group `domain_mask` that drives the estimate and the scores never reached the df. A `where=` domain was unaffected, because a filter arrives as zero weights and `degrees_of_freedom` already masks on those; the two paths therefore disagreed for the same subpopulation. On a 4×4×5 design (full df 12), `by="dom"` reported 12 for both groups where R's `degf(subset(...))` gives 7 and 3, and `by="stratum"` inside a domain reported 7 for all four cells against R's 1, 3, 3, 0. The error ran one way — a cell inherited the df of a larger population — so **every grouped confidence interval was too narrow**, by 22% on the smallest domain of a realistic fixture. `degrees_of_freedom` gains a `degrees_of_freedom_in_domain` variant taking an optional membership mask; the existing signature delegates to it with `None`, so there is still one implementation of the rule.
+- **Zero-weight rows no longer inflate `n` in the domain SRS variance.** `srs_variance_mean_domain`, `srs_variance_total_domain` and `srs_variance_ratio_domain` counted every in-domain row when building `n`, including rows carrying zero weight. Under `drop_nulls` a missing-`y` row is kept and zero-weighted rather than dropped, so those rows understated the SRS variance and inflated `deff` by exactly the row-count ratio (293/290, 187/185, 291/286 on the synthetic education fixture) while groups with no dropped rows were exact. The ungrouped `srs_variance_mean` already excluded them and its comment asserted the `_domain` variants did the same.
+
 ## [0.11.0] — 2026-07-23
 
 ### Changed
@@ -56,7 +63,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 Baseline for this changelog. For earlier history, see the [Git tags](https://github.com/samplics-org/svy/tags).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.11.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.12.0...HEAD
+[0.12.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.12.0
 [0.11.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.11.0
 [0.10.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.10.0
 [0.9.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.9.0

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -3562,7 +3562,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svy_rs"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash",
  "approx",

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svy_rs"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2024"
 repository = "https://gitlab.com/samplics/svy"
 homepage = "https://gitlab.com/samplics/svy"

--- a/packages/svy-rs/pyproject.toml
+++ b/packages/svy-rs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy_rs"
-version = "0.11.0"
+version = "0.12.0"
 description = "Internal Rust extension for the svy package. Do not depend on this directly."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,24 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.21.0] — 2026-07-24
+
+Requires [`svy-rs`](../svy-rs/CHANGELOG.md) 0.12.0, which carries the two variance-estimation fixes below; [`svy-io`](../svy-io/CHANGELOG.md) 0.2.0 is unchanged. Grouped confidence intervals and domain design effects change in this release — point estimates and standard errors do not.
+
+### Fixed
+
+- **`by=` groups now use their own degrees of freedom.** A by-group is a domain, so its df must be counted on the PSUs and strata that group covers. It was instead given the df of the surrounding analysis — the full design with no filter, or the `where=` mask with one — so the same subpopulation got a different interval depending on whether it was reached through `by=` or `where=`. Confidence intervals for grouped means, totals, ratios, proportions and medians were consistently **too narrow**; the effect is negligible for groups spanning most of the sample and large for small ones (22% on a 10-record domain with 6 df rather than 56). `est`, `se`, `cv` are unaffected. Verified against R `survey` 4.5 `degf(subset(design, ...))`.
+- **Design effects no longer count zero-weight rows.** Under `drop_nulls`, rows with a missing response are kept and zero-weighted rather than dropped; they were still counted in the domain SRS variance's `n`, inflating `deff` for any group containing them (~1–2% on the synthetic fixtures). Only `deff` is affected.
+
+### Removed
+
+- **`Estimate.degrees_freedom`.** Degrees of freedom are a per-row property — a domain or by-group is counted on its own active PSUs and strata, so grouped results legitimately carry a different df per cell. The scalar could not represent that: it was `min()` across rows, so a grouped estimate reported its *smallest* group, and for a by-group inside a domain that meant a headline df of 0. Use `ParamEst.df` (also a `df` column in `to_polars()`) for the per-row value, and `n_psus - n_strata` for the full-design df, which stays at design level under a domain filter.
+- **`EstimateData.degrees_freedom`** leaves the serialized payload; `SCHEMA_VERSION` moves to `svy-result/0.2`. Strictly a field removal warrants a major bump under the policy in `serialize/DESIGN.md`; 0.2 was chosen deliberately because no known consumer binds to the field, and the reasoning is recorded there.
+
+### Added
+
+- **`ParamEst.df`** — the design df backing each row's t-quantile, carried through `to_polars()` and the serialized payload. It is deliberately not shown in the printed table: it is constant for most results, so a column would repeat one number down the page and widen every table.
+
 ## [0.20.1] — 2026-07-23
 
 Patch release on top of 0.20.0; [`svy-rs`](../svy-rs/CHANGELOG.md) (0.11.0) and [`svy-io`](../svy-io/CHANGELOG.md) (0.2.0) are unchanged.
@@ -82,7 +100,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.20.1...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.21.0...HEAD
+[0.21.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.21.0
 [0.20.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.20.1
 [0.20.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.20.0
 [0.19.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.19.1

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.20.1"
+version = "0.21.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -26,7 +26,7 @@ dependencies = [
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
   "svy-io>=0.2.0,<0.3.0",
-  "svy-rs>=0.11.0,<0.12.0",
+  "svy-rs>=0.12.0,<0.13.0",
 ]
 
 [project.urls]

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -126,7 +126,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.20.1"
+__version__ = "0.21.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.20.1"
+version = "0.21.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },
@@ -2431,7 +2431,7 @@ dev = [
 
 [[package]]
 name = "svy-rs"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "packages/svy-rs" }
 dependencies = [
     { name = "polars", extra = ["pyarrow"] },


### PR DESCRIPTION
Release branch for the domain-df work merged in #94 and #95.

## Versions

| package | from | to |
|---|---|---|
| svy-rs | 0.11.0 | 0.12.0 |
| svy pin on svy-rs | `>=0.11.0,<0.12.0` | `>=0.12.0,<0.13.0` |
| svy | 0.20.1 | 0.21.0 |

**svy-rs takes a minor, not a patch.** svy 0.20.1 pins `svy-rs>=0.11.0,<0.12.0`, so a 0.11.1 would be picked up by every existing install on the next sync and would silently change domain df, `by=` confidence intervals and `deff` — with no svy upgrade to account for the movement. Clearing the boundary keeps the behaviour change behind an explicit svy upgrade.

**svy takes a minor, not a patch**, because `Estimate.degrees_freedom` is removed from the public API and `EstimateData.degrees_freedom` from the serialized payload (`SCHEMA_VERSION` → `svy-result/0.2`).

Both svy-rs version strings move together — `Cargo.toml` for the crate and `pyproject.toml` for the Python distribution. maturin reads the latter, so bumping only `Cargo.toml` leaves the version the pin resolves against untouched (caught during this bump).

## Contents

- version bumps, the pin, the hardcoded `__version__`, `Cargo.lock` and `uv.lock`
- changelogs promoted from `[Unreleased]`, with the user-facing framing: grouped CIs and domain `deff` change, point estimates and standard errors do not

Full suite green at the release versions: 2777 passed, 1 skipped, with `svy 0.21.0` / `svy_rs 0.12.0` resolved.

## Tagging (after merge)

1. `svy-rs-v0.12.0` first; wait until it is actually live on PyPI
2. then `svy-v0.21.0` — svy's pin means tagging it early leaves a window where `pip install svy` fails

Publish is `needs:`-gated on every wheel job, so a flaky macOS runner skips the whole upload rather than shipping something partial; `gh run rerun <id> --failed` recovers it.