### PR TITLE
fix(estimation): return NaN confidence bounds when df <= 0 (#96)

### DIFF
--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -435,6 +435,24 @@ class Estimation:
         }
         return aliases.get(m, m)
 
+    @staticmethod
+    def _t_crit(alpha: float, df: float) -> float:
+        """Two-sided t critical value, or NaN when df <= 0.
+
+        R's ``qt(1 - alpha/2, 0)`` is NaN: with no residual degrees of freedom
+        the interval width is undefined. Returning NaN — rather than the old
+        fallback to a normal 1.96 — makes a domain resting on a single PSU
+        report NaN bounds, matching survey, instead of a zero-width CI that
+        reads as a point estimate known with certainty (issue #96).
+        """
+        return float(stats.t.ppf(1 - alpha / 2, df)) if df > 0 else float("nan")
+
+    @staticmethod
+    def _t_crit_arr(alpha: float, df_arr: np.ndarray) -> np.ndarray:
+        """Vectorised :meth:`_t_crit`; NaN wherever df <= 0."""
+        pos = df_arr > 0
+        return np.where(pos, stats.t.ppf(1 - alpha / 2, np.where(pos, df_arr, 1.0)), np.nan)
+
     def _compute_prop_ci(
         self,
         p: float,
@@ -493,7 +511,7 @@ class Estimation:
         if method == "logit":
             if p <= 0 or p >= 1:
                 return (p, p)
-            t_crit = stats.t.ppf(1 - alpha / 2, df) if df > 0 else 1.96
+            t_crit = self._t_crit(alpha, df)
             scale = se / (p * (1.0 - p)) if se > 0 else 0
             logit_p = math.log(p / (1 - p))
             lci = 1.0 / (1.0 + math.exp(-(logit_p - t_crit * scale)))
@@ -611,7 +629,15 @@ class Estimation:
             # Uses the score-test inversion with effective sample size.
             # Replaces n with n_eff = p(1-p)/se² and uses t-quantile for df.
             # Reference: Wilson (1927); Franco et al. (2019, JSSAM).
-            if p <= 0 or p >= 1 or se <= 0:
+            if p <= 0 or p >= 1:
+                return (p, p)
+            # No residual df: width undefined (issue #96). Checked before the
+            # se <= 0 short-circuit, because a lone-PSU cell has se == 0 as the
+            # same artifact and must go NaN, not to a point — matching the logit
+            # branch. The max/min clamps below would otherwise swallow the NaN.
+            if df <= 0:
+                return (float("nan"), float("nan"))
+            if se <= 0:
                 return (p, p)
 
             # Effective sample size
@@ -624,7 +650,7 @@ class Estimation:
                 n_eff = n_eff * (t_n / t_df) ** 2
 
             # Wilson score interval: roots of the score-test quadratic
-            z = stats.t.ppf(1 - alpha / 2, df) if df > 0 else 1.96
+            z = self._t_crit(alpha, df)
             z2 = z * z
             denom = 1 + z2 / n_eff
             center = (p + z2 / (2 * n_eff)) / denom
@@ -662,10 +688,7 @@ class Estimation:
         )
         deff_arr = result_df["deff"].to_numpy() if (deff and "deff" in result_df.columns) else None
 
-        pos_df = df_arr > 0
-        t_crits = np.where(
-            pos_df, stats.t.ppf(1.0 - alpha / 2.0, np.where(pos_df, df_arr, 1.0)), 1.96
-        )
+        t_crits = self._t_crit_arr(alpha, df_arr)
 
         with np.errstate(divide="ignore", invalid="ignore"):
             cv_arr = np.where(est_arr != 0, se_arr / est_arr, np.inf)
@@ -817,14 +840,16 @@ class Estimation:
             df_val = int(df_vals[i])
             dv = domain_vals[i]
 
-            t_crit = stats.t.ppf(1.0 - alpha / 2.0, df_val) if df_val > 0 else 1.96
-            p_lower = max(0.0, 0.5 - t_crit * se_p)
-            p_upper = min(1.0, 0.5 + t_crit * se_p)
-
+            t_crit = self._t_crit(alpha, df_val)
             cached = domain_cache.get(dv)
-            if cached is None:
+            if df_val <= 0 or cached is None:
+                # No residual df (issue #96) or an empty domain: the interval
+                # is undefined. Skip the CDF inversion, whose probability
+                # arguments would otherwise be silently clamped into [0, 1].
                 lci = uci = float("nan")
             else:
+                p_lower = max(0.0, 0.5 - t_crit * se_p)
+                p_upper = min(1.0, 0.5 + t_crit * se_p)
                 y_sorted, cdf = cached
                 lci = self._invert_cdf_sorted(y_sorted, cdf, p_lower)
                 uci = self._invert_cdf_sorted(y_sorted, cdf, p_upper)
@@ -840,6 +865,7 @@ class Estimation:
                     lci=lci,
                     uci=uci,
                     deff=None,
+                    df=df_val,
                     by=by_tuple,
                     by_level=(dv,) if dv is not None else None,
                     y_level=None,
@@ -887,10 +913,7 @@ class Estimation:
         se_arr = result_df["se"].to_numpy()
         df_arr = result_df["df"].to_numpy().astype(np.float64)
 
-        pos_df = df_arr > 0
-        t_crits = np.where(
-            pos_df, stats.t.ppf(1.0 - alpha / 2.0, np.where(pos_df, df_arr, 1.0)), 1.96
-        )
+        t_crits = self._t_crit_arr(alpha, df_arr)
         lci_arr = est_arr - t_crits * se_arr
         uci_arr = est_arr + t_crits * se_arr
         with np.errstate(divide="ignore", invalid="ignore"):
@@ -1178,8 +1201,15 @@ class Estimation:
             return self._taylor_multi(
                 ys,
                 single_call=lambda yy: self.mean(
-                    yy, by=by, where=where, method=method, deff=deff, fay_coef=fay_coef,
-                    as_factor=as_factor, variance_center=variance_center, alpha=alpha,
+                    yy,
+                    by=by,
+                    where=where,
+                    method=method,
+                    deff=deff,
+                    fay_coef=fay_coef,
+                    as_factor=as_factor,
+                    variance_center=variance_center,
+                    alpha=alpha,
                     drop_nulls=drop_nulls,
                 ),
                 batched_call=lambda prep: _taylor_mean_multi(
@@ -1187,7 +1217,11 @@ class Estimation:
                 ),
                 prep_y=(ys[0] if ys else ""),
                 prep_extra_cols=ys[1:],
-                by=by, where=where, method=method, as_factor=as_factor, drop_nulls=drop_nulls,
+                by=by,
+                where=where,
+                method=method,
+                as_factor=as_factor,
+                drop_nulls=drop_nulls,
             )
 
         target_method = self._resolve_method(method)
@@ -1202,9 +1236,7 @@ class Estimation:
             select_columns=True,
             # Ungrouped replication only: the mask path covers the ungrouped
             # kernels. Grouped (by=) replication keeps the zeroing path.
-            domain_mask_for_replication=(
-                target_method != EstimationMethod.TAYLOR and by is None
-            ),
+            domain_mask_for_replication=(target_method != EstimationMethod.TAYLOR and by is None),
         )
 
         try:
@@ -1273,8 +1305,15 @@ class Estimation:
             return self._taylor_multi(
                 ys,
                 single_call=lambda yy: self.total(
-                    yy, by=by, where=where, method=method, deff=deff, fay_coef=fay_coef,
-                    as_factor=as_factor, variance_center=variance_center, alpha=alpha,
+                    yy,
+                    by=by,
+                    where=where,
+                    method=method,
+                    deff=deff,
+                    fay_coef=fay_coef,
+                    as_factor=as_factor,
+                    variance_center=variance_center,
+                    alpha=alpha,
                     drop_nulls=drop_nulls,
                 ),
                 batched_call=lambda prep: _taylor_total_multi(
@@ -1282,7 +1321,11 @@ class Estimation:
                 ),
                 prep_y=(ys[0] if ys else ""),
                 prep_extra_cols=ys[1:],
-                by=by, where=where, method=method, as_factor=as_factor, drop_nulls=drop_nulls,
+                by=by,
+                where=where,
+                method=method,
+                as_factor=as_factor,
+                drop_nulls=drop_nulls,
             )
 
         target_method = self._resolve_method(method)
@@ -1297,9 +1340,7 @@ class Estimation:
             select_columns=True,
             # Ungrouped replication only: the mask path covers the ungrouped
             # kernels. Grouped (by=) replication keeps the zeroing path.
-            domain_mask_for_replication=(
-                target_method != EstimationMethod.TAYLOR and by is None
-            ),
+            domain_mask_for_replication=(target_method != EstimationMethod.TAYLOR and by is None),
         )
 
         try:
@@ -1367,8 +1408,15 @@ class Estimation:
             return self._taylor_multi(
                 ys,
                 single_call=lambda yy: self.prop(
-                    yy, by=by, where=where, method=method, ci_method=ci_method, deff=deff,
-                    fay_coef=fay_coef, variance_center=variance_center, alpha=alpha,
+                    yy,
+                    by=by,
+                    where=where,
+                    method=method,
+                    ci_method=ci_method,
+                    deff=deff,
+                    fay_coef=fay_coef,
+                    variance_center=variance_center,
+                    alpha=alpha,
                     drop_nulls=drop_nulls,
                 ),
                 batched_call=lambda prep: _taylor_prop_multi(
@@ -1376,7 +1424,11 @@ class Estimation:
                 ),
                 prep_y=(ys[0] if ys else ""),
                 prep_extra_cols=ys[1:],
-                by=by, where=where, method=method, drop_nulls=drop_nulls, cast_y_float=False,
+                by=by,
+                where=where,
+                method=method,
+                drop_nulls=drop_nulls,
+                cast_y_float=False,
             )
 
         target_method = self._resolve_method(method)
@@ -1391,9 +1443,7 @@ class Estimation:
             select_columns=True,
             # Ungrouped replication only: the mask path covers the ungrouped
             # kernels. Grouped (by=) replication keeps the zeroing path.
-            domain_mask_for_replication=(
-                target_method != EstimationMethod.TAYLOR and by is None
-            ),
+            domain_mask_for_replication=(target_method != EstimationMethod.TAYLOR and by is None),
         )
 
         try:
@@ -1484,17 +1534,31 @@ class Estimation:
             return self._taylor_multi(
                 pairs,
                 single_call=lambda pr: self.ratio(
-                    pr[0], pr[1], by=by, where=where, method=method, deff=deff,
-                    fay_coef=fay_coef, variance_center=variance_center, alpha=alpha,
+                    pr[0],
+                    pr[1],
+                    by=by,
+                    where=where,
+                    method=method,
+                    deff=deff,
+                    fay_coef=fay_coef,
+                    variance_center=variance_center,
+                    alpha=alpha,
                     drop_nulls=drop_nulls,
                 ),
                 batched_call=lambda prep: _taylor_ratio_multi(
-                    self, prep=prep, ys=[p[0] for p in pairs], xs=[p[1] for p in pairs],
-                    deff=deff, alpha=alpha,
+                    self,
+                    prep=prep,
+                    ys=[p[0] for p in pairs],
+                    xs=[p[1] for p in pairs],
+                    deff=deff,
+                    alpha=alpha,
                 ),
                 prep_y=(ys[0] if ys else ""),
                 prep_extra_cols=list(dict.fromkeys([*ys[1:], *xs])),
-                by=by, where=where, method=method, drop_nulls=drop_nulls,
+                by=by,
+                where=where,
+                method=method,
+                drop_nulls=drop_nulls,
             )
 
         target_method = self._resolve_method(method)
@@ -1510,9 +1574,7 @@ class Estimation:
             select_columns=True,
             # Ungrouped replication only: the mask path covers the ungrouped
             # kernels. Grouped (by=) replication keeps the zeroing path.
-            domain_mask_for_replication=(
-                target_method != EstimationMethod.TAYLOR and by is None
-            ),
+            domain_mask_for_replication=(target_method != EstimationMethod.TAYLOR and by is None),
         )
 
         try:
@@ -1580,8 +1642,14 @@ class Estimation:
             return self._taylor_multi(
                 ys,
                 single_call=lambda yy: self.median(
-                    yy, by=by, where=where, method=method, fay_coef=fay_coef,
-                    q_method=q_method, variance_center=variance_center, alpha=alpha,
+                    yy,
+                    by=by,
+                    where=where,
+                    method=method,
+                    fay_coef=fay_coef,
+                    q_method=q_method,
+                    variance_center=variance_center,
+                    alpha=alpha,
                     drop_nulls=drop_nulls,
                 ),
                 batched_call=lambda prep: _taylor_median_multi(
@@ -1589,7 +1657,10 @@ class Estimation:
                 ),
                 prep_y=(ys[0] if ys else ""),
                 prep_extra_cols=ys[1:],
-                by=by, where=where, method=method, drop_nulls=drop_nulls,
+                by=by,
+                where=where,
+                method=method,
+                drop_nulls=drop_nulls,
             )
 
         target_method = self._resolve_method(method)

--- a/packages/svy/tests/svy/estimation/test_degrees_of_freedom.py
+++ b/packages/svy/tests/svy/estimation/test_degrees_of_freedom.py
@@ -29,6 +29,8 @@ These assertions read ``ParamEst.df`` directly rather than inverting a
 t-quantile from the CI, which is what made this rule untestable before.
 """
 
+import math
+
 import polars as pl
 import pytest
 
@@ -281,3 +283,67 @@ def test_user_supplied_rep_df_overrides_everywhere(jkn):
     sample = _rep_sample(jkn, df=9)
     assert _df_of(sample, method="replication") == 9
     assert _df_of(sample, method="replication", where=col("dom") == 1) == 9
+
+
+# ---------------------------------------------------------------------------
+# df == 0 — NaN bounds, not a zero-width CI (issue #96)
+# ---------------------------------------------------------------------------
+#
+# `d_one_psu_in_b` keeps stratum B as a single PSU while the full design stays
+# clean (3 PSUs per stratum), so the B cell has 0 residual df — the case R
+# reports as qt(., 0) = NaN. Before the fix svy substituted z = 1.96, and with
+# se = 0 for a lone PSU produced a zero-width interval reading as certainty.
+
+
+def test_mean_df_zero_cell_has_nan_ci(toy):
+    """A by-cell that collapses to one PSU gets NaN bounds; its neighbour does not."""
+    sample = Sample(toy, Design(wgt="w", stratum="stratum", psu="psu"))
+    cells = {
+        p.by_level[0]: p
+        for p in sample.estimation.mean(
+            "y", by="stratum", where=col("d_one_psu_in_b") == 1
+        ).estimates
+    }
+    b = cells["B"]
+    assert b.df == 0
+    assert math.isnan(b.lci) and math.isnan(b.uci)
+    a = cells["A"]
+    assert a.df > 0
+    assert not math.isnan(a.lci) and not math.isnan(a.uci)
+
+
+@pytest.mark.parametrize("ci_method", ["logit", "wilson"])
+def test_prop_df_zero_cell_has_nan_ci(toy, ci_method):
+    """Proportion CIs that lean on the t-quantile go NaN at df 0, matching R's
+    svyciprop(method="logit"); the design carries no information for the width.
+
+    Uses ``row == 1`` so every cell has p = 0.5 — an interior proportion, not
+    the degenerate p in {0, 1} that returns a point regardless of df.
+    """
+    d = toy.with_columns((pl.col("row") == 1).cast(pl.Int64).alias("hi"))
+    sample = Sample(d, Design(wgt="w", stratum="stratum", psu="psu"))
+    b_rows = [
+        p
+        for p in sample.estimation.prop(
+            "hi", by="stratum", where=col("d_one_psu_in_b") == 1, ci_method=ci_method
+        ).estimates
+        if p.by_level[0] == "B"
+    ]
+    assert b_rows
+    for p in b_rows:
+        assert p.df == 0
+        assert math.isnan(p.lci) and math.isnan(p.uci)
+
+
+def test_median_df_zero_cell_has_nan_ci(toy):
+    """The median path clamps its CDF-inversion probabilities, so it needs the
+    explicit df<=0 guard rather than NaN propagation."""
+    sample = Sample(toy, Design(wgt="w", stratum="stratum", psu="psu"))
+    cells = {
+        p.by_level[0]: p
+        for p in sample.estimation.median(
+            "y", by="stratum", where=col("d_one_psu_in_b") == 1
+        ).estimates
+    }
+    assert cells["B"].df == 0
+    assert math.isnan(cells["B"].lci) and math.isnan(cells["B"].uci)


### PR DESCRIPTION
Closes #96.

## Problem

A domain resting on a single PSU has zero residual degrees of freedom. The CI code substituted a normal quantile (`z = 1.96`) there instead of a t-quantile, and combined with `se = 0` for a lone PSU produced a zero-width interval:

```
stratum B   est=23.0000  se=0.0000  df=0  lci=23.0000  uci=23.0000
```

That reads as a point estimate known with certainty — anti-conservative in exactly the case with no information about the sampling variance. R returns `NaN` from `qt(0.975, 0)`.

Confirmed against R survey 4.5 on a single-PSU domain:

```
mean         SE: 0    ci: NA NA
prop logit        ci: NaN NaN
```

## Fix

`df <= 0` now yields NaN bounds. Five call sites in `estimation/base.py`:

- **mean/total/ratio arrays** and the **logit proportion** propagate the NaN t-quantile directly (`est ± t·se`, or `nan * 0 = nan` through the logit scale).
- **Wilson proportion** and the **median** clamp their bounds with `max`/`min`, which would swallow the NaN and return `[0, 1]` or a CDF endpoint, so each gets an explicit `df <= 0` guard. The Wilson guard runs *before* its `se <= 0` short-circuit, because a lone-PSU cell has `se = 0` as the same artifact and must go NaN rather than to a point — matching logit.

The t-quantile substitution is centralised in `_t_crit` / `_t_crit_arr`.

**Beta and Korn-Graubard are untouched.** They are Clopper-Pearson from an effective `n` and only *skip* a df-adjustment when `df <= 0`, so they still produce a valid interval without a design df — there is no `1.96` substitution to correct.

Also populates `ParamEst.df` on the median grouped path, which the df-exposure change in #95 missed (it was `None` there).

## Tests

Added to `test_degrees_of_freedom.py`: a df-0 cell (a stratum collapsed to one PSU by a domain, with the full design still clean) returns NaN bounds for mean, logit/wilson proportion and median, while a df>0 neighbour in the same call stays finite. The proportion test uses an interior p = 0.5 so it exercises the df path rather than the p ∈ {0, 1} boundary short-circuit.

Full suite: 2781 passed, 1 skipped.

## Note

GLM under `where=` is still unverified against R (flagged in #96). GLM has no `by=` and its df goes through the domain-aware `_compute_design_df`, so it is likely fine, but nobody has confirmed it — out of scope here.