### PR TITLE
Document that applying a spec needs overwrite=True

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -36,10 +36,12 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
   from svy_spec.resolve import resolve
 
   sample = svy.Sample(data, design, catalog=catalog)
-  sample.meta.update(to_metadata_store(resolve(spec), catalog=catalog))
+  sample.meta.update(to_metadata_store(resolve(spec), catalog=catalog), overwrite=True)
   ```
 
-  Use `update` rather than a loop over `set`: it merges per field, so anything you have already recorded on the data side — missing codes, corrected labels — survives the spec being applied.
+  Use `update` rather than a loop over `set`: it merges per field, so a field the spec does not model — missing codes you declared, notes you added — is never cleared by applying it.
+
+  Pass `overwrite=True` when the spec is the authority, which it is here. `Sample.__init__` runs `infer_from_dataframe`, which sets `mtype` by guessing from each column's storage type; under the default fill-only merge that guess wins and the spec's declared level never lands, so an ordered single-select stays *Numerical Discrete* instead of becoming *Categorical Ordinal*. Apply the spec first, then any adjustments of your own.
 
   `MetadataSource.QUESTIONNAIRE` stays — it is what the bridge sets, and it remains the right provenance for a field-collected variable.
 

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -1476,6 +1476,16 @@ class MetadataStore:
         Self
             For method chaining.
 
+        Notes
+        -----
+        Merging a store built from an instrument spec wants ``overwrite=True``.
+        A `Sample` runs `infer_from_dataframe` at construction, which sets
+        `mtype` by guessing from each column's storage type — so under the
+        default that guess is already present and the spec's *declared* level
+        never lands. An ordered single-select stays `NUMERICAL_DISCRETE` rather
+        than becoming `CATEGORICAL_ORDINAL`. Apply the authoritative source
+        first and make local adjustments after it.
+
         Examples
         --------
         >>> store.update(other)                    # fill gaps only


### PR DESCRIPTION
Docs only — no behaviour change. The migration path published in the 0.21.1 changelog produces a subtly wrong result.

## The problem

`Sample.__init__` runs `infer_from_dataframe`, which sets `mtype` by guessing from each column's storage type. So by the time a spec is merged in, `mtype` is already set, and the default fill-only `update()` keeps the guess:

```
what the spec says      : Categorical Ordinal
overwrite=False  -> mtype=Numerical Discrete    label='Mood (recoded)'
overwrite=True   -> mtype=Categorical Ordinal   label='How do you feel?'
```

An ordered single-select stays *Numerical Discrete*. That is the one distinction `svy_spec.bridge` exists to carry — the questionnaire model it replaced had no notion of ordering, so every Likert item arrived nominal and everything downstream had to be told again. The documented call was quietly discarding the reason for the feature.

## The fix

`overwrite=True` in the changelog snippet, plus a `Notes` section on `MetadataStore.update` so the guidance sits where the method is used rather than only in a changelog. Missing codes survive in either mode — that property is unchanged and still tested.

The rule of thumb: apply the authoritative source first, make local adjustments after.

## How it surfaced

svy-spec's dev environment had been resolving `svy>=0.18` to the **0.18.2 wheel from PyPI**, not this repo. 0.18.2 has no `update()` at all, so nothing on that side could exercise the path. Pointing it at a local editable install of 0.21.1 showed it immediately.

## Checks

2794 passed, 1 skipped. `ruff check` / `format --check` clean on the touched file.