### PR TITLE
Let a CategoryScheme carry a hierarchy

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -31,6 +31,21 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Fixed
 
+- **Category-keyed dicts could not round-trip, in four places.** JSON object keys are always strings, so `dict[Category, str]` writes `{101: "Banjul"}` as `{"101": "Banjul"}` and decodes it with a *string* key. Every join against an integer-coded column then misses. Each field is now `(code, label)` pairs, with a mapping still accepted when constructing and a dict-view property for lookup:
+
+  | field | was | now |
+  |---|---|---|
+  | `VariableMeta.value_labels` | corrupted silently | pairs; `.labels` for lookup |
+  | `ResolvedLabels.value_labels` | corrupted silently | pairs; `.labels` |
+  | `Label.categories` | raised on decode | pairs; `.label_map` |
+  | `MissingDef.kinds` | raised on decode | pairs; `.kind_map` |
+
+  The two silent ones are the dangerous half: a store of variable metadata written and read back had string codes, no error, and every value label quietly stopped matching its column.
+
+  `Label.categories` also **dropped `_MissingType` from its union**. msgspec refuses to decode any union containing a custom type, so the struct raised regardless of the key problem — and nothing ever set the field to the sentinel, since `None` already meant "no value labels". It bought no distinction and cost the ability to decode at all.
+
+  `MissingDef.__post_init__` **loses its repair step**. That was added to recover integer codes from decoded string keys; with pairs there is nothing to repair, and the subset check now means what it says.
+
 - **A `MissingDef` carrying `kinds` could not survive JSON.** JSON object keys are always strings, so `dict[Category, MissingKind]` encodes `{98: DONT_KNOW}` as `{"98": "dnk"}` and decodes it back with a *string* key — while `codes`, a JSON array, returns as `int`. The subset check in `__post_init__` then saw `{'98'} - {98}` and raised, so neither a `MissingDef` with kinds nor any `VariableMeta` holding one could be decoded at all:
 
   ```

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -10,23 +10,24 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Added
 
-- **`CategoryScheme.parents`** — a hierarchy, as `(code, parent_code)` pairs. It lets one scheme describe a cascading list — region → district → ward → enumeration area — so a survey can reference it by concept instead of inlining thousands of codes.
-
-  That matters because a geography is revised on its own cycle. Inlined into a specification, a census redraw that adds sixty enumeration areas changes the document's content hash and shows up as sixty changes to review, while the questionnaire is untouched. Held in the catalog, it does not.
+- **`CategoryScheme` holds one entry per code** rather than several collections keyed by it. `SchemeEntry(code, label, parent, missing)` replaces `mapping`, `missing` and `missing_kinds`, and carries a hierarchy besides.
 
   ```python
-  CategoryScheme(
-      concept="gm_district", locale="en",
-      mapping={101: "Banjul", 102: "Kanifing", 201: "Lower Saloum"},
-      parents=((101, 1), (102, 1), (201, 2)),      # district -> region
-  )
-  scheme.parent_of(201)     # 2
-  scheme.children_of(1)     # (101, 102)
+  CategoryScheme(concept="sex", entries={1: "Male", 2: "Female"})     # a dict is still accepted
+
+  CategoryScheme(concept="gm_district", entries=[
+      SchemeEntry(code=101, label="Banjul", parent=1),                 # district -> region
+      SchemeEntry(code=99, label="Refused", missing=MissingKind.REFUSED),
+  ])
   ```
 
-  **Pairs rather than a `dict`, unlike `mapping` and `missing_kinds`.** JSON object keys are always strings, so a `Category`-keyed dict survives only through `LabellingCatalog`'s custom encoder — put a scheme through plain msgspec and `{101: "Banjul"}` returns as `{"101": "Banjul"}`, silently. A dict here would inherit that and depend on the encoder being extended in step, which is exactly what did not happen for `MissingDef`. Pairs are correct by any route, and there is a test asserting it.
+  Two problems went with the old shape. Three of the collections were dicts or sets keyed by `Category`, and **JSON object keys are always strings** — so `{101: "Banjul"}` returned as `{"101": "Banjul"}` unless it went through a hand-written encoder, silently and with no error. And because the collections could disagree, ~77 lines of `validate_scheme_missing` and `normalize_scheme_missing` existed only to check that they did not.
 
-  Validation covers the child side only: a code with a parent must exist in this scheme's `mapping`. Parent codes belong to a *different* scheme — the region list — which this one cannot see, so checking them here would reject every real hierarchy.
+  One entry per code removes both. Every field is JSON-native, so **the bespoke encoder is gone** — `to_bytes` is a single `msgspec.json.encode` — and a scheme keeps its code types by any route, which a test asserts rather than trusting the encoder to be remembered. The invariants those 77 lines checked are now unrepresentable: a missing code outside the scheme, or a kind for a code that is not missing, cannot be written down. Both functions remain as no-op seams; NaN and duplicate codes are rejected in `__post_init__`, where a caller cannot skip them by forgetting to validate.
+
+  New lookups: `labels`, `codes`, `substantive`, `missing_codes`, `kind_of`, `codes_of_kind`, `parent_of`, `children_of`, `entry`. `make_scheme` still takes the facets apart — `mapping=`, `missing=`, `missing_kinds=`, `parents=` — and folds them, for callers who hold the pieces separately.
+
+  **The hierarchy is what forced the question.** A cascading list — region → district → ward → enumeration area — could not be described at all, so a survey specification had to inline every code. Inlined, a census redraw adding sixty EAs changes the spec's content hash and reads as sixty changes to a questionnaire nobody touched. Held in the catalog, it does not.
 
 ### Fixed
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,26 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Added
+
+- **`CategoryScheme.parents`** — a hierarchy, as `(code, parent_code)` pairs. It lets one scheme describe a cascading list — region → district → ward → enumeration area — so a survey can reference it by concept instead of inlining thousands of codes.
+
+  That matters because a geography is revised on its own cycle. Inlined into a specification, a census redraw that adds sixty enumeration areas changes the document's content hash and shows up as sixty changes to review, while the questionnaire is untouched. Held in the catalog, it does not.
+
+  ```python
+  CategoryScheme(
+      concept="gm_district", locale="en",
+      mapping={101: "Banjul", 102: "Kanifing", 201: "Lower Saloum"},
+      parents=((101, 1), (102, 1), (201, 2)),      # district -> region
+  )
+  scheme.parent_of(201)     # 2
+  scheme.children_of(1)     # (101, 102)
+  ```
+
+  **Pairs rather than a `dict`, unlike `mapping` and `missing_kinds`.** JSON object keys are always strings, so a `Category`-keyed dict survives only through `LabellingCatalog`'s custom encoder — put a scheme through plain msgspec and `{101: "Banjul"}` returns as `{"101": "Banjul"}`, silently. A dict here would inherit that and depend on the encoder being extended in step, which is exactly what did not happen for `MissingDef`. Pairs are correct by any route, and there is a test asserting it.
+
+  Validation covers the child side only: a code with a parent must exist in this scheme's `mapping`. Parent codes belong to a *different* scheme — the region list — which this one cannot see, so checking them here would reject every real hierarchy.
+
 ### Fixed
 
 - **A `MissingDef` carrying `kinds` could not survive JSON.** JSON object keys are always strings, so `dict[Category, MissingKind]` encodes `{98: DONT_KNOW}` as `{"98": "dnk"}` and decodes it back with a *string* key — while `codes`, a JSON array, returns as `int`. The subset check in `__post_init__` then saw `{'98'} - {98}` and raised, so neither a `MissingDef` with kinds nor any `VariableMeta` holding one could be decoded at all:

--- a/packages/svy/src/svy/categorical/table.py
+++ b/packages/svy/src/svy/categorical/table.py
@@ -740,7 +740,7 @@ class Table:
         if resolve_labels and self._metadata is not None:
             row_resolved = self._metadata.resolve_labels(self.rowvar)
             if row_resolved.has_value_labels:
-                _row_label_map = {str(k): str(v) for k, v in row_resolved.value_labels.items()}
+                _row_label_map = {str(k): str(v) for k, v in row_resolved.labels.items()}
                 df = df.with_columns(
                     pl.col("rowvar").replace_strict(_row_label_map, default=pl.col("rowvar"))
                 )
@@ -748,7 +748,7 @@ class Table:
             if self.colvar is not None:
                 col_resolved = self._metadata.resolve_labels(self.colvar)
                 if col_resolved.has_value_labels:
-                    _col_label_map = {str(k): str(v) for k, v in col_resolved.value_labels.items()}
+                    _col_label_map = {str(k): str(v) for k, v in col_resolved.labels.items()}
                     df = df.with_columns(
                         pl.col("colvar").replace_strict(_col_label_map, default=pl.col("colvar"))
                     )

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -985,7 +985,7 @@ class Sample:
         for var in self._metadata:
             resolved = self._metadata.resolve_labels(var)
             if resolved.has_value_labels:
-                result[var] = dict(resolved.value_labels)
+                result[var] = resolved.labels
         return result
 
     # ════════════════════════════════════════════════════════════════════════

--- a/packages/svy/src/svy/engine/io/core.py
+++ b/packages/svy/src/svy/engine/io/core.py
@@ -200,8 +200,7 @@ def build_metadata_for_export(
         if resolved.has_value_labels:
             # ensure codes are JSON-serializable primitives; texts are str
             value_labels[var] = {
-                _py_scalar(k): ("" if v is None else str(v))
-                for k, v in resolved.value_labels.items()
+                _py_scalar(k): ("" if v is None else str(v)) for k, v in resolved.labels.items()
             }
 
     return {"var_labels": var_labels, "value_labels": value_labels}

--- a/packages/svy/src/svy/engine/io/sas.py
+++ b/packages/svy/src/svy/engine/io/sas.py
@@ -108,7 +108,7 @@ def _write_sas(
             # Get value labels (direct or resolved from scheme)
             resolved = store.resolve_labels(var)
             if resolved.has_value_labels:
-                entry["values"] = dict(resolved.value_labels)
+                entry["values"] = resolved.labels
 
             # Get missing codes
             if meta.missing is not None:

--- a/packages/svy/src/svy/engine/io/spss.py
+++ b/packages/svy/src/svy/engine/io/spss.py
@@ -103,7 +103,7 @@ def _write_spss(
             # Get value labels (direct or resolved from scheme)
             resolved = store.resolve_labels(var)
             if resolved.has_value_labels:
-                entry["values"] = dict(resolved.value_labels)
+                entry["values"] = resolved.labels
 
             # Get missing codes
             if meta.missing is not None:

--- a/packages/svy/src/svy/engine/io/stata.py
+++ b/packages/svy/src/svy/engine/io/stata.py
@@ -117,7 +117,7 @@ def _write_stata(
             # Get value labels (direct or resolved from scheme)
             resolved = store.resolve_labels(var)
             if resolved.has_value_labels:
-                value_labels[var] = dict(resolved.value_labels)
+                value_labels[var] = resolved.labels
 
     # 2. Prepare Table
     table = to_writer_table(df)

--- a/packages/svy/src/svy/errors/label_errors.py
+++ b/packages/svy/src/svy/errors/label_errors.py
@@ -137,6 +137,29 @@ class LabelError(SvyError):
         )
 
     @classmethod
+    def duplicate_code(
+        cls,
+        *,
+        where: Optional[str],
+        code: object,
+        docs_url: Optional[str] = None,
+    ) -> "LabelError":
+        return cls(
+            title="Duplicate category code",
+            detail=(
+                f"The code {code!r} appears more than once. A scheme holds one "
+                f"entry per code, so a second would silently shadow the first."
+            ),
+            code="LABEL_DUPLICATE_CODE",
+            where=where,
+            param="entries",
+            expected="each code once",
+            got=repr(code),
+            hint="Remove the duplicate, or merge the two entries.",
+            docs_url=docs_url,
+        )
+
+    @classmethod
     def invalid_locale(
         cls,
         *,

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -60,12 +60,43 @@ class CategoryScheme(msgspec.Struct, kw_only=True, frozen=True):
     missing: set[Category] | None = None
     missing_kinds: dict[Category, MissingKind] | None = None
 
+    #: Hierarchy, as ``(code, parent_code)`` pairs — a district and the region
+    #: it sits in. This is what lets a *cascading* list (region → district →
+    #: ward → enumeration area) be referenced by concept instead of inlined
+    #: into a survey specification, which matters because a geography is
+    #: revised on its own cycle: a census redraw should not read as a change to
+    #: the questionnaire.
+    #:
+    #: **Pairs rather than a dict**, unlike ``mapping`` and ``missing_kinds``.
+    #: JSON object keys are always strings, so a ``Category``-keyed dict only
+    #: survives through ``LabellingCatalog``'s custom encoder — put a scheme
+    #: through plain msgspec and ``{101: "Banjul"}`` comes back as
+    #: ``{"101": "Banjul"}``, silently and with no error. A dict here would
+    #: inherit that, and would depend on the encoder being extended in step —
+    #: which is exactly what did not happen for ``MissingDef``. Pairs are
+    #: correct by any route.
+    #:
+    #: Parent codes belong to a *different* scheme, so they are not validated
+    #: here; only that each child code exists in this ``mapping``.
+    parents: tuple[tuple[Category, Category], ...] | None = None
+
     def __post_init__(self):
         # Auto-generate id if not provided
         if self.id is None:
             generated_id = f"{self.concept}:{self.locale or 'default'}"
             # For frozen structs, use object.__setattr__
             object.__setattr__(self, "id", generated_id)
+
+    def parent_of(self, code: Category) -> Category | None:
+        """The parent of one code, or None if this scheme declares no hierarchy."""
+        for child, parent in self.parents or ():
+            if child == code:
+                return parent
+        return None
+
+    def children_of(self, parent: Category) -> tuple[Category, ...]:
+        """Every code under a given parent, in declaration order."""
+        return tuple(child for child, p in self.parents or () if p == parent)
 
     def clone(self, **overrides) -> Self:
         return replace(self, **overrides)
@@ -153,6 +184,17 @@ def validate_scheme_missing(s: CategoryScheme, *, strict: bool = True) -> None:
                     where="labels.validate_scheme_missing",
                     offending_keys=sorted(diff2),
                 )
+
+    if s.parents is not None:
+        # only the child side: a parent code belongs to a different scheme, and
+        # this one has no way to see it
+        orphans = {child for child, _ in s.parents} - keys
+        if orphans and strict:
+            raise LabelError.invalid_missing_codes(
+                where="labels.validate_scheme_missing",
+                param="parents",
+                not_in_mapping=sorted(orphans, key=repr),
+            )
 
 
 def normalize_scheme_missing(s: CategoryScheme) -> CategoryScheme:
@@ -404,6 +446,10 @@ class LabellingCatalog:
             "missing_kind_pairs": (
                 [[k, mk.value] for k, mk in s.missing_kinds.items()] if s.missing_kinds else None
             ),
+            # already pairs, so this survives a plain msgspec round-trip too —
+            # the encoder is belt and braces rather than the only thing holding
+            # the types up, which is the point of the shape
+            "parent_pairs": [[c, p] for c, p in s.parents] if s.parents else None,
         }
 
     @staticmethod
@@ -412,6 +458,8 @@ class LabellingCatalog:
         missing_set = set(d.get("missing_list") or []) or None
         mk_pairs = d.get("missing_kind_pairs") or []
         missing_kinds = {k: MissingKind(mv) for k, mv in mk_pairs} if mk_pairs else None
+        parent_pairs = d.get("parent_pairs") or []
+        parents = tuple((c, p) for c, p in parent_pairs) if parent_pairs else None
         sch = CategoryScheme(
             id=d["id"],
             concept=d["concept"],
@@ -421,6 +469,7 @@ class LabellingCatalog:
             ordered=bool(d.get("ordered", False)),
             missing=missing_set,
             missing_kinds=missing_kinds,
+            parents=parents,
         )
         # Validate on load as well
         validate_scheme_missing(sch, strict=True)

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -120,9 +120,12 @@ class CategoryScheme(msgspec.Struct, kw_only=True, frozen=True):
     ordered: bool = False
 
     def __post_init__(self):
-        object.__setattr__(self, "entries", _coerce_entries(self.entries))
+        # force_setattr, not object.__setattr__: the latter raises "can't apply
+        # this __setattr__" on a frozen msgspec Struct under 3.11 and 3.12, and
+        # works on 3.13+, so a matrix is the only thing that catches it.
+        force_setattr(self, "entries", _coerce_entries(self.entries))
         if self.id is None:
-            object.__setattr__(self, "id", f"{self.concept}:{self.locale or 'default'}")
+            force_setattr(self, "id", f"{self.concept}:{self.locale or 'default'}")
 
         seen: set[Category] = set()
         for entry in self.entries:

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -6,7 +6,7 @@ import logging
 import math
 import threading
 
-from typing import Any, Iterable, Mapping, Self
+from typing import Iterable, Mapping, Self
 
 import msgspec
 import polars as pl
@@ -38,68 +38,135 @@ class Label(msgspec.Struct, frozen=True):
         return replace(self, **overrides)
 
 
-class CategoryScheme(msgspec.Struct, kw_only=True, frozen=True):
-    """
-    One value-label scheme for a given (concept, locale), with optional missing semantics.
+class SchemeEntry(msgspec.Struct, frozen=True):
+    """One category: its code, its label, and everything else about that code.
 
-    JSON Persistence Note
-    ---------------------
-    JSON object keys must be strings, and sets are not JSON-native. The catalog
-    serializes schemes using a custom encoder (pairs for mappings; lists for sets),
-    see LabellingCatalog.to_bytes/from_bytes.
+    Everything a scheme knows about a code lives here rather than in a separate
+    collection keyed by it. That is what makes the scheme's invariants
+    unrepresentable instead of checked: a missing code that is not in the
+    scheme, or a kind for a code that is not missing, cannot be written down.
+    """
+
+    code: Category
+    label: str
+    #: The code's parent in another scheme — a district's region. This is what
+    #: lets a cascading list (region → district → ward → enumeration area) be
+    #: referenced by concept rather than inlined into a survey specification,
+    #: which matters because a geography is revised on its own cycle: a census
+    #: redraw should not read as a change to the questionnaire.
+    #:
+    #: Not validated here. The parent belongs to a *different* scheme, which
+    #: this one has no way to see.
+    parent: Category | None = None
+    #: Set when this code is a non-substantive answer, and says why. ``None``
+    #: means an ordinary category.
+    missing: MissingKind | None = None
+
+    @property
+    def is_missing(self) -> bool:
+        return self.missing is not None
+
+
+class CategoryScheme(msgspec.Struct, kw_only=True, frozen=True):
+    """One value-label scheme for a given (concept, locale).
+
+    A **list of entries**, not four parallel collections keyed by code. The
+    previous shape held ``mapping``, ``missing``, ``missing_kinds`` and a
+    hierarchy separately, which had two costs. Three of the four were dicts or
+    sets keyed by ``Category``, and JSON object keys are always strings — so
+    ``{101: "Banjul"}`` returned as ``{"101": "Banjul"}`` unless it went through
+    a bespoke encoder, silently and with no error. And because the four could
+    disagree, seventy-odd lines existed only to check that they did not.
+
+    One entry per code removes both. Every field here is JSON-native, so the
+    scheme round-trips through plain msgspec with no custom encoder at all, and
+    the invariants hold by construction rather than by validation.
+
+    A dict is still accepted when constructing, since ``{101: "Banjul"}`` reads
+    better than a list of structs for the common case::
+
+        CategoryScheme(concept="sex", entries={1: "Male", 2: "Female"})
+        CategoryScheme(concept="gm_district", entries=[
+            SchemeEntry(code=101, label="Banjul", parent=1),
+            SchemeEntry(code=99, label="Refused", missing=MissingKind.REFUSED),
+        ])
     """
 
     concept: str
-    mapping: dict[Category, str]
+    entries: tuple[SchemeEntry, ...] = ()
     id: str | None = None
     locale: str | None = None
     title: str | None = None
     ordered: bool = False
 
-    # Missing semantics
-    missing: set[Category] | None = None
-    missing_kinds: dict[Category, MissingKind] | None = None
-
-    #: Hierarchy, as ``(code, parent_code)`` pairs — a district and the region
-    #: it sits in. This is what lets a *cascading* list (region → district →
-    #: ward → enumeration area) be referenced by concept instead of inlined
-    #: into a survey specification, which matters because a geography is
-    #: revised on its own cycle: a census redraw should not read as a change to
-    #: the questionnaire.
-    #:
-    #: **Pairs rather than a dict**, unlike ``mapping`` and ``missing_kinds``.
-    #: JSON object keys are always strings, so a ``Category``-keyed dict only
-    #: survives through ``LabellingCatalog``'s custom encoder — put a scheme
-    #: through plain msgspec and ``{101: "Banjul"}`` comes back as
-    #: ``{"101": "Banjul"}``, silently and with no error. A dict here would
-    #: inherit that, and would depend on the encoder being extended in step —
-    #: which is exactly what did not happen for ``MissingDef``. Pairs are
-    #: correct by any route.
-    #:
-    #: Parent codes belong to a *different* scheme, so they are not validated
-    #: here; only that each child code exists in this ``mapping``.
-    parents: tuple[tuple[Category, Category], ...] | None = None
-
     def __post_init__(self):
-        # Auto-generate id if not provided
+        object.__setattr__(self, "entries", _coerce_entries(self.entries))
         if self.id is None:
-            generated_id = f"{self.concept}:{self.locale or 'default'}"
-            # For frozen structs, use object.__setattr__
-            object.__setattr__(self, "id", generated_id)
+            object.__setattr__(self, "id", f"{self.concept}:{self.locale or 'default'}")
+
+        seen: set[Category] = set()
+        for entry in self.entries:
+            if _is_nan(entry.code):
+                raise LabelError.nan_key_forbidden(where="CategoryScheme")
+            if entry.code in seen:
+                raise LabelError.duplicate_code(where="CategoryScheme", code=entry.code)
+            seen.add(entry.code)
+
+    # -- lookups -----------------------------------------------------------
+
+    def entry(self, code: Category) -> SchemeEntry | None:
+        for e in self.entries:
+            if e.code == code:
+                return e
+        return None
+
+    @property
+    def codes(self) -> tuple[Category, ...]:
+        return tuple(e.code for e in self.entries)
+
+    @property
+    def labels(self) -> dict[Category, str]:
+        """Every code and its label, including non-substantive ones."""
+        return {e.code: e.label for e in self.entries}
+
+    @property
+    def substantive(self) -> tuple[SchemeEntry, ...]:
+        """Entries that are real answers — what a frequency table's base is."""
+        return tuple(e for e in self.entries if e.missing is None)
+
+    @property
+    def missing_codes(self) -> frozenset[Category]:
+        return frozenset(e.code for e in self.entries if e.missing is not None)
+
+    def kind_of(self, code: Category) -> MissingKind | None:
+        entry = self.entry(code)
+        return entry.missing if entry else None
+
+    def codes_of_kind(self, *kinds: MissingKind) -> frozenset[Category]:
+        wanted = set(kinds)
+        return frozenset(e.code for e in self.entries if e.missing in wanted)
 
     def parent_of(self, code: Category) -> Category | None:
-        """The parent of one code, or None if this scheme declares no hierarchy."""
-        for child, parent in self.parents or ():
-            if child == code:
-                return parent
-        return None
+        entry = self.entry(code)
+        return entry.parent if entry else None
 
     def children_of(self, parent: Category) -> tuple[Category, ...]:
         """Every code under a given parent, in declaration order."""
-        return tuple(child for child, p in self.parents or () if p == parent)
+        return tuple(e.code for e in self.entries if e.parent == parent)
 
     def clone(self, **overrides) -> Self:
         return replace(self, **overrides)
+
+
+def _coerce_entries(value) -> tuple[SchemeEntry, ...]:
+    """Accept a dict, pairs, or entries; store entries.
+
+    The dict is authoring sugar and never reaches serialization, so the
+    string-key problem it would otherwise carry cannot arise.
+    """
+    if isinstance(value, Mapping):
+        return tuple(SchemeEntry(code=c, label=lbl) for c, lbl in value.items())
+    return tuple(v if isinstance(v, SchemeEntry) else SchemeEntry(*v) for v in value)
 
 
 # =============================
@@ -146,78 +213,29 @@ def _is_nan(x: object) -> bool:
 
 
 def validate_scheme_missing(s: CategoryScheme, *, strict: bool = True) -> None:
+    """Retained as a no-op seam.
+
+    Everything it used to check is now unrepresentable. A missing code outside
+    the scheme, a kind for a code that is not missing, a NaN code, a duplicate —
+    each was a way for four parallel collections to disagree, and there is one
+    collection now. NaN and duplicate codes are rejected in ``__post_init__``,
+    where they cannot be skipped by a caller who forgets to validate.
     """
-    Ensures:
-      - No NaN keys in mapping (brittle as dict keys).
-      - missing ⊆ mapping.keys()
-      - missing_kinds keys ⊆ mapping.keys()
-      - If both provided, missing_kinds.keys() ⊆ missing
-    """
-    keys = set(s.mapping.keys())
-
-    for k in keys:
-        if _is_nan(k):
-            raise LabelError.nan_key_forbidden(where="labels.validate_scheme_missing")
-
-    if s.missing is not None:
-        diff = set(s.missing) - keys
-        if diff and strict:
-            raise LabelError.invalid_missing_codes(
-                where="labels.validate_scheme_missing",
-                param="missing",
-                not_in_mapping=sorted(diff),
-            )
-
-    if s.missing_kinds is not None:
-        kkeys = set(s.missing_kinds.keys())
-        diff = kkeys - keys
-        if diff and strict:
-            raise LabelError.invalid_missing_codes(
-                where="labels.validate_scheme_missing",
-                param="missing_kinds",
-                not_in_mapping=sorted(diff),
-            )
-        if s.missing is not None:
-            diff2 = kkeys - set(s.missing)
-            if diff2 and strict:
-                raise LabelError.inconsistent_missing_kinds(
-                    where="labels.validate_scheme_missing",
-                    offending_keys=sorted(diff2),
-                )
-
-    if s.parents is not None:
-        # only the child side: a parent code belongs to a different scheme, and
-        # this one has no way to see it
-        orphans = {child for child, _ in s.parents} - keys
-        if orphans and strict:
-            raise LabelError.invalid_missing_codes(
-                where="labels.validate_scheme_missing",
-                param="parents",
-                not_in_mapping=sorted(orphans, key=repr),
-            )
+    return None
 
 
 def normalize_scheme_missing(s: CategoryScheme) -> CategoryScheme:
-    """If only missing_kinds given, derive missing as its keys."""
-    if s.missing is None and s.missing_kinds:
-        return CategoryScheme(
-            id=s.id,
-            concept=s.concept,
-            mapping=s.mapping,
-            locale=s.locale,
-            title=s.title,
-            ordered=s.ordered,
-            missing=set(s.missing_kinds.keys()),
-            missing_kinds=s.missing_kinds,
-        )
+    """Retained as a no-op seam.
+
+    There is nothing left to derive: ``missing`` used to be recoverable from
+    ``missing_kinds``, and both are now one field on the entry.
+    """
     return s
 
 
 def missing_codes_by_kind(s: CategoryScheme, kinds: set[MissingKind]) -> set[Category]:
     """Collect codes matching any of the requested kinds."""
-    if not s.missing_kinds:
-        return set()
-    return {code for code, mk in s.missing_kinds.items() if mk in kinds}
+    return set(s.codes_of_kind(*kinds))
 
 
 # =============================
@@ -228,34 +246,70 @@ def missing_codes_by_kind(s: CategoryScheme, kinds: set[MissingKind]) -> set[Cat
 def make_scheme(
     *,
     concept: str,
-    mapping: Mapping[Category, str],
+    mapping: Mapping[Category, str] | None = None,
+    entries: Iterable[SchemeEntry] | Mapping[Category, str] | None = None,
     locale: str | None = None,
     title: str | None = None,
     ordered: bool = False,
-    missing: set[Category] | None = None,
-    missing_kinds: dict[Category, MissingKind] | None = None,
+    missing: Iterable[Category] | None = None,
+    missing_kinds: Mapping[Category, MissingKind] | None = None,
+    parents: Mapping[Category, Category] | None = None,
     id: str | None = None,
 ) -> CategoryScheme:
+    """Build a scheme with a predictable id (``concept:locale``).
+
+    Takes the four facets separately — labels, which codes are missing, why, and
+    the hierarchy — and folds them into one entry per code, which is how the
+    scheme stores them. That is a convenience for callers who already hold the
+    pieces apart; constructing ``CategoryScheme`` directly is the direct route.
+
+    ``mapping`` and ``entries`` are the same argument under two names, since the
+    former reads better for a plain code→label list.
     """
-    Factory to create a CategoryScheme with a predictable id (concept:locale).
-    Pass an explicit id to override.
-    """
+    source = entries if entries is not None else (mapping or {})
     concept_key = _norm_concept(concept)
     loc = _norm_locale(locale)
     sid = id if id is not None else (f"{concept_key}:{loc}" if loc else concept_key)
-    scheme = CategoryScheme(
+
+    kinds = dict(missing_kinds or {})
+    flagged = set(missing or ()) | set(kinds)
+    parent_of = dict(parents or {})
+
+    built = []
+    for entry in _coerce_entries(source):
+        built.append(
+            SchemeEntry(
+                code=entry.code,
+                label=entry.label,
+                parent=entry.parent if entry.parent is not None else parent_of.get(entry.code),
+                missing=(
+                    entry.missing
+                    if entry.missing is not None
+                    else (
+                        kinds.get(entry.code, MissingKind.NO_ANSWER)
+                        if entry.code in flagged
+                        else None
+                    )
+                ),
+            )
+        )
+
+    stray = flagged - {e.code for e in built}
+    if stray:
+        raise LabelError.invalid_missing_codes(
+            where="labels.make_scheme",
+            param="missing",
+            not_in_mapping=sorted(stray, key=repr),
+        )
+
+    return CategoryScheme(
         id=sid,
         concept=concept_key,
-        mapping=dict(mapping),
+        entries=tuple(built),
         locale=loc,
         title=title,
         ordered=ordered,
-        missing=missing,
-        missing_kinds=missing_kinds,
     )
-    # Strict validation to catch issues early
-    validate_scheme_missing(scheme, strict=True)
-    return normalize_scheme_missing(scheme)
 
 
 # =============================
@@ -388,7 +442,7 @@ class LabellingCatalog:
             if (s.id is not None and ql in s.id.lower())
             or ql in s.concept.lower()
             or (s.title and ql in s.title.lower())
-            or any(ql in v.lower() for v in s.mapping.values())
+            or any(ql in e.label.lower() for e in s.entries)
         ]
         xs.sort(key=lambda s: (s.concept, s.locale or ""))
         return xs
@@ -410,7 +464,7 @@ class LabellingCatalog:
     def to_label(
         self, var_label: str, scheme_id: str, *, overrides: Mapping[Category, str] | None = None
     ) -> Label:
-        base = dict(self.get(scheme_id).mapping)
+        base = self.get(scheme_id).labels
         if overrides:
             base.update(overrides)
         return Label(label=var_label, categories=base)
@@ -424,7 +478,7 @@ class LabellingCatalog:
         overrides: Mapping[Category, str] | None = None,
     ) -> Label:
         s = self.pick(concept, locale=locale)
-        base = dict(s.mapping)
+        base = s.labels
         if overrides:
             base.update(overrides)
         return Label(label=var_label, categories=base)
@@ -433,52 +487,15 @@ class LabellingCatalog:
     # Persistence (JSON-friendly)
     # -----------------------------
 
-    @staticmethod
-    def _scheme_to_jsonable(s: CategoryScheme) -> dict[str, Any]:
-        return {
-            "id": s.id,
-            "concept": s.concept,
-            "mapping_pairs": [[k, v] for k, v in s.mapping.items()],
-            "locale": s.locale,
-            "title": s.title,
-            "ordered": s.ordered,
-            "missing_list": list(s.missing) if s.missing is not None else None,
-            "missing_kind_pairs": (
-                [[k, mk.value] for k, mk in s.missing_kinds.items()] if s.missing_kinds else None
-            ),
-            # already pairs, so this survives a plain msgspec round-trip too —
-            # the encoder is belt and braces rather than the only thing holding
-            # the types up, which is the point of the shape
-            "parent_pairs": [[c, p] for c, p in s.parents] if s.parents else None,
-        }
-
-    @staticmethod
-    def _scheme_from_jsonable(d: Mapping[str, Any]) -> CategoryScheme:
-        mapping = {k: v for k, v in d.get("mapping_pairs") or []}
-        missing_set = set(d.get("missing_list") or []) or None
-        mk_pairs = d.get("missing_kind_pairs") or []
-        missing_kinds = {k: MissingKind(mv) for k, mv in mk_pairs} if mk_pairs else None
-        parent_pairs = d.get("parent_pairs") or []
-        parents = tuple((c, p) for c, p in parent_pairs) if parent_pairs else None
-        sch = CategoryScheme(
-            id=d["id"],
-            concept=d["concept"],
-            mapping=mapping,
-            locale=d.get("locale"),
-            title=d.get("title"),
-            ordered=bool(d.get("ordered", False)),
-            missing=missing_set,
-            missing_kinds=missing_kinds,
-            parents=parents,
-        )
-        # Validate on load as well
-        validate_scheme_missing(sch, strict=True)
-        return normalize_scheme_missing(sch)
+    # The bespoke encoder is gone. It existed because `mapping`, `missing` and
+    # `missing_kinds` were dicts and sets keyed by Category, and JSON object
+    # keys are always strings — so a scheme could only survive a round trip
+    # through pairs-and-lists written by hand. One entry per code makes every
+    # field JSON-native, and msgspec handles it.
 
     def to_bytes(self) -> bytes:
         try:
-            payload = [self._scheme_to_jsonable(s) for s in self._schemes.values()]
-            return msgspec.json.encode(payload)
+            return msgspec.json.encode(list(self._schemes.values()))
         except Exception as e:
             raise LabelError.serialization_error(
                 where="labels.LabellingCatalog.to_bytes",
@@ -490,8 +507,7 @@ class LabellingCatalog:
         cls, data: bytes, *, name: str = "loaded", locale: str | None = None
     ) -> "LabellingCatalog":
         try:
-            raw = msgspec.json.decode(data, type=list[dict[str, Any]])
-            schemes = [cls._scheme_from_jsonable(d) for d in raw]
+            schemes = msgspec.json.decode(data, type=list[CategoryScheme])
             return cls(schemes, name=name, locale=locale)
         except Exception as e:
             raise LabelError.serialization_error(
@@ -583,13 +599,13 @@ def is_missing_value(
         return False
 
     if kinds is None:
-        return bool(scheme.missing and (value in scheme.missing))
+        return value in scheme.missing_codes
 
-    if not scheme.missing_kinds:
+    if not scheme.missing_codes:
         return False
     if value is None:
         return False
-    k = scheme.missing_kinds.get(value)
+    k = scheme.kind_of(value)
     return (k in kinds) if k is not None else False
 
 
@@ -623,8 +639,10 @@ def display_text(
     """Return display label (or empty/null_text for NA)."""
     if value is None or _is_nan(value):
         return null_text
-    if scheme and value in scheme.mapping:
-        return scheme.mapping[value]
+    if scheme is not None:
+        entry = scheme.entry(value)
+        if entry is not None:
+            return entry.label
     return str(value)
 
 
@@ -647,10 +665,10 @@ def polars_mask(col, scheme: CategoryScheme | None, kinds: set[MissingKind] | No
     # Guarded NaN check via permissive cast
     mask = mask | expr.cast(pl.Float64, strict=False).is_nan()
     if scheme:
-        if kinds is None and scheme.missing:
-            mask = mask | expr.is_in(list(scheme.missing))
-        elif kinds and scheme.missing_kinds:
-            codes = [code for code, mk in scheme.missing_kinds.items() if mk in kinds]
+        if kinds is None and scheme.missing_codes:
+            mask = mask | expr.is_in(list(scheme.missing_codes))
+        elif kinds and scheme.missing_codes:
+            codes = list(scheme.codes_of_kind(*kinds))
             if codes:
                 mask = mask | expr.is_in(codes)
     # Null-safe: under Kleene logic `False | null = null`, and a null mask
@@ -677,5 +695,5 @@ def polars_to_display(col, scheme: CategoryScheme | None, alias: str | None = No
 
     expr = pl.col(col) if isinstance(col, str) else col
     alias = alias or (f"{col}_label" if isinstance(col, str) else "label")
-    mapping = scheme.mapping if scheme else {}
+    mapping = scheme.labels if scheme else {}
     return expr.replace(mapping).cast(pl.Utf8).alias(alias)

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -11,11 +11,12 @@ from typing import Iterable, Mapping, Self
 import msgspec
 import polars as pl
 
-from msgspec.structs import replace
+from msgspec.structs import force_setattr, replace
 
 from svy.core.enumerations import MissingKind
-from svy.core.types import Category, _MissingType
+from svy.core.types import Category
 from svy.errors.label_errors import LabelError
+from svy.metadata.variable_meta import ValueLabel, _coerce_labels
 
 
 log = logging.getLogger(__name__)
@@ -29,10 +30,29 @@ class Label(msgspec.Struct, frozen=True):
     -----
     Label/value-labels are intended for variables measured as
     NOMINAL, ORDINAL, or BOOLEAN (see MeasurementType).
+
+    ``categories`` holds ``ValueLabel`` pairs and accepts a dict when
+    constructing. It was ``dict[Category, str] | None | _MissingType``, which
+    could not be decoded at all — two defects stacked. A ``Category``-keyed
+    dict loses its code types through JSON (see ``ValueLabel``), and msgspec
+    refuses any union containing a custom type, so the struct raised on every
+    round trip regardless.
+
+    The ``_MissingType`` member is gone with it. Nothing ever set this field to
+    the sentinel — ``None`` already means "no value labels" — so it bought no
+    distinction and cost the ability to decode.
     """
 
     label: str
-    categories: dict[Category, str] | None | _MissingType = None
+    categories: tuple[ValueLabel, ...] | None = None
+
+    def __post_init__(self) -> None:
+        force_setattr(self, "categories", _coerce_labels(self.categories))
+
+    @property
+    def label_map(self) -> dict[Category, str]:
+        """The categories as a mapping, for lookup. Empty when unset."""
+        return {vl.code: vl.label for vl in self.categories or ()}
 
     def clone(self, **overrides) -> Self:
         return replace(self, **overrides)

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -925,10 +925,10 @@ class MetadataStore:
         elif meta.scheme_ref is not None and self._catalog is not None:
             try:
                 scheme = meta.scheme_ref.resolve(self._catalog)
-                value_labels = dict(scheme.mapping)
+                value_labels = scheme.labels
                 # Also get missing from scheme if not defined on meta
                 if meta.missing is None and scheme.missing:
-                    missing_codes = frozenset(scheme.missing)
+                    missing_codes = scheme.missing_codes
             except Exception as e:
                 log.warning(
                     f"Failed to resolve scheme {meta.scheme_ref.concept!r} "

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -60,6 +60,41 @@ def _normalize_codes(codes: Iterable[Category] | None) -> frozenset[Category]:
 
 
 # =============================================================================
+# ValueLabel: one code and its display text
+# =============================================================================
+
+
+class ValueLabel(msgspec.Struct, frozen=True):
+    """One code and the text shown for it.
+
+    A *pair*, not an entry in a ``dict[Category, str]``. JSON object keys are
+    always strings, so a Category-keyed dict returns ``{"1": "Male"}`` for
+    ``{1: "Male"}`` — silently, with no error, and every join against an
+    integer-coded column then misses. Holding the code as a value keeps its
+    type through serialization by any route.
+
+    This is the same shape, and the same reason, as ``CategoryScheme``'s
+    ``SchemeEntry`` and svy-spec's ``ChoiceOption``.
+    """
+
+    code: Category
+    label: str
+
+
+def _coerce_labels(value) -> tuple[ValueLabel, ...] | None:
+    """Accept a dict, pairs, or ValueLabels; store pairs.
+
+    The dict is authoring sugar — ``{1: "Male"}`` reads better than a list of
+    structs — and never reaches serialization, so it carries none of the risk.
+    """
+    if value is None:
+        return None
+    if isinstance(value, Mapping):
+        return tuple(ValueLabel(code=c, label=lbl) for c, lbl in value.items())
+    return tuple(v if isinstance(v, ValueLabel) else ValueLabel(*v) for v in value)
+
+
+# =============================================================================
 # MissingDef: Unified missing value definition
 # =============================================================================
 
@@ -78,9 +113,9 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
     ----------
     codes : frozenset[Category]
         All values that should be treated as missing.
-    kinds : dict[Category, MissingKind] | None
-        Optional mapping of codes to their semantic meaning.
-        Keys must be a subset of `codes`.
+    kinds : tuple[tuple[Category, MissingKind], ...] | None
+        Optional (code, kind) pairs giving each code's semantic meaning. A
+        mapping is accepted and coerced. Codes must be a subset of `codes`.
     na_is_missing : bool
         Whether to treat None/null as missing (default True).
     nan_is_missing : bool
@@ -107,48 +142,41 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
     """
 
     codes: frozenset[Category] = frozenset()
-    kinds: dict[Category, MissingKind] | None = None
+    #: ``(code, kind)`` pairs. Pairs rather than a dict for the reason
+    #: ``ValueLabel`` exists: a Category-keyed dict does not survive JSON. This
+    #: field used to be one, and the mismatch it caused — string keys against
+    #: integer codes — made the subset check below raise on every decode.
+    kinds: tuple[tuple[Category, MissingKind], ...] | None = None
     na_is_missing: bool = True
     nan_is_missing: bool = True
 
     def __post_init__(self) -> None:
-        """Validate that kinds keys are a subset of codes, repairing JSON keys.
+        """Coerce a kinds mapping to pairs, then check it against ``codes``.
 
-        JSON object keys are always strings, so a ``dict[Category, MissingKind]``
-        encodes ``{98: DONT_KNOW}`` as ``{"98": "dnk"}`` and decodes it back with
-        a *string* key, while ``codes`` — a JSON array — comes back as ``int``.
-        The subset check then fails and a ``MissingDef`` carrying kinds could not
-        survive a round trip at all.
+        This used to carry a repair step: ``kinds`` was a ``dict[Category,
+        MissingKind]``, JSON object keys are always strings, and the decoded
+        ``{"98": ...}`` never matched the integer ``98`` in ``codes`` — so the
+        check below raised on every round trip. Pairs keep the code's type, so
+        there is nothing to repair and the check means what it says.
 
-        The sibling class solves this with a bespoke encoder: ``CategoryScheme``
-        is serialized by ``LabellingCatalog`` as pairs and lists precisely
-        because "JSON object keys must be strings, and sets are not
-        JSON-native". Nothing serializes ``VariableMeta`` centrally, so the
-        repair happens here instead — a decoded key is matched back to the code
-        it was written from before the subset check runs.
+        A dict is still accepted here, since ``{98: DONT_KNOW}`` reads better
+        than a list of tuples.
         """
         if self.kinds is None:
             return
+        if isinstance(self.kinds, Mapping):
+            force_setattr(self, "kinds", tuple(self.kinds.items()))
+        else:
+            force_setattr(self, "kinds", tuple(tuple(k) for k in self.kinds))
 
-        invalid = set(self.kinds.keys()) - self.codes
+        invalid = {code for code, _ in self.kinds} - self.codes
         if invalid:
-            by_text = {}
-            for code in self.codes:
-                # ambiguous only if two codes share a text form, e.g. 1 and "1";
-                # recovering either would be a guess, so recover neither
-                by_text[str(code)] = None if str(code) in by_text else code
+            raise ValueError(f"missing_kinds contains codes not in codes: {invalid}")
 
-            repaired = {}
-            for key, kind in self.kinds.items():
-                if key in self.codes:
-                    repaired[key] = kind
-                elif isinstance(key, str) and by_text.get(key) is not None:
-                    repaired[by_text[key]] = kind
-                else:
-                    raise ValueError(f"missing_kinds contains codes not in codes: {invalid}")
-            # not object.__setattr__: that raises "can't apply this __setattr__"
-            # on a frozen Struct under 3.11 and 3.12
-            force_setattr(self, "kinds", repaired)
+    @property
+    def kind_map(self) -> dict[Category, MissingKind]:
+        """The pairs as a mapping, for lookup."""
+        return dict(self.kinds or ())
 
     def __eq__(self, other: object) -> bool:
         """Custom equality that handles NaN in frozensets."""
@@ -169,11 +197,8 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
             return True
         if self.kinds is None or other.kinds is None:
             return False
-        if set(self.kinds.keys()) != set(other.kinds.keys()):
+        if self.kind_map != other.kind_map:
             return False
-        for k, v in self.kinds.items():
-            if other.kinds.get(k) != v:
-                return False
 
         return True
 
@@ -182,7 +207,7 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
         # Convert codes to a hashable representation
         code_tuple = tuple(sorted(str(c) for c in self.codes))
         kinds_tuple = (
-            tuple(sorted((str(k), v.value) for k, v in self.kinds.items())) if self.kinds else None
+            tuple(sorted((str(k), v.value) for k, v in self.kinds)) if self.kinds else None
         )
         return hash((code_tuple, kinds_tuple, self.na_is_missing, self.nan_is_missing))
 
@@ -251,7 +276,7 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
         if not self.kinds:
             return False
 
-        kind = self.kinds.get(value)
+        kind = self.kind_map.get(value)
         return kind in kinds if kind is not None else False
 
     def by_kind(self, *kinds: MissingKind) -> frozenset[Category]:
@@ -277,7 +302,7 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
             return frozenset()
 
         kind_set = set(kinds)
-        return frozenset(code for code, kind in self.kinds.items() if kind in kind_set)
+        return frozenset(code for code, kind in self.kinds if kind in kind_set)
 
     def user_missing(self) -> frozenset[Category]:
         """
@@ -357,7 +382,7 @@ class MissingDef(msgspec.Struct, frozen=True, eq=False):
         """
         return cls(
             codes=frozenset(kinds.keys()),
-            kinds=dict(kinds),
+            kinds=tuple(kinds.items()),
             na_is_missing=na_is_missing,
             nan_is_missing=nan_is_missing,
         )
@@ -480,7 +505,10 @@ class VariableMeta(msgspec.Struct, frozen=True):
 
     name: str
     label: str | None = None
-    value_labels: dict[Category, str] | None = None
+    #: ``(code, label)`` pairs. A dict is accepted when constructing and
+    #: coerced; ``labels`` gives the mapping back for lookup. Pairs because a
+    #: Category-keyed dict does not survive JSON — see ``ValueLabel``.
+    value_labels: tuple[ValueLabel, ...] | None = None
     scheme_ref: SchemeRef | None = None
     mtype: MeasurementType = MeasurementType.STRING
     categories: tuple[Category, ...] | None = None
@@ -491,11 +519,17 @@ class VariableMeta(msgspec.Struct, frozen=True):
     source: MetadataSource = MetadataSource.INFERRED
 
     def __post_init__(self) -> None:
-        """Validate that value_labels and scheme_ref aren't both set."""
+        """Coerce labels to pairs; a variable cannot have both sources."""
+        force_setattr(self, "value_labels", _coerce_labels(self.value_labels))
         if self.value_labels is not None and self.scheme_ref is not None:
             raise ValueError(
                 f"Variable {self.name!r}: cannot specify both value_labels and scheme_ref"
             )
+
+    @property
+    def labels(self) -> dict[Category, str]:
+        """The value labels as a mapping, for lookup. Empty when unset."""
+        return {vl.code: vl.label for vl in self.value_labels or ()}
 
     @property
     def has_labels(self) -> bool:
@@ -608,8 +642,17 @@ class ResolvedLabels(msgspec.Struct, frozen=True):
     """
 
     var_label: str = ""
-    value_labels: dict[Category, str] = msgspec.field(default_factory=dict)
+    #: ``(code, label)`` pairs; ``labels`` is the mapping view. See
+    #: ``ValueLabel`` for why this is not a dict.
+    value_labels: tuple[ValueLabel, ...] = ()
     missing_codes: frozenset[Category] = frozenset()
+
+    def __post_init__(self) -> None:
+        force_setattr(self, "value_labels", _coerce_labels(self.value_labels) or ())
+
+    @property
+    def labels(self) -> dict[Category, str]:
+        return {vl.code: vl.label for vl in self.value_labels}
 
     @property
     def has_var_label(self) -> bool:
@@ -643,7 +686,7 @@ class ResolvedLabels(msgspec.Struct, frozen=True):
         if _is_nan(value):
             return null_text
 
-        return self.value_labels.get(value, str(value))
+        return self.labels.get(value, str(value))
 
     def display_series(
         self,
@@ -684,14 +727,14 @@ class ResolvedLabels(msgspec.Struct, frozen=True):
             # Use map_dict for partial replacement (returns null for unmapped)
             result = df.select(
                 pl.col(name)
-                .replace_strict(self.value_labels, default=None)
+                .replace_strict(self.labels, default=None)
                 .fill_null(pl.col(name).cast(pl.Utf8))
                 .fill_null(null_text)
                 .alias(name)
             ).to_series()
         else:
             result = df.select(
-                pl.col(name).replace_strict(self.value_labels, default=null_text).alias(name)
+                pl.col(name).replace_strict(self.labels, default=null_text).alias(name)
             ).to_series()
 
         return result
@@ -704,7 +747,7 @@ class ResolvedLabels(msgspec.Struct, frozen=True):
 
     def non_missing_labels(self) -> dict[Category, str]:
         """Get value labels excluding missing codes."""
-        return {k: v for k, v in self.value_labels.items() if k not in self.missing_codes}
+        return {k: v for k, v in self.labels.items() if k not in self.missing_codes}
 
 
 # =============================================================================
@@ -921,7 +964,7 @@ class MetadataStore:
 
         # Resolve value labels
         if meta.value_labels is not None:
-            value_labels = dict(meta.value_labels)
+            value_labels = meta.labels
         elif meta.scheme_ref is not None and self._catalog is not None:
             try:
                 scheme = meta.scheme_ref.resolve(self._catalog)
@@ -1699,7 +1742,7 @@ class MetadataStore:
                 # Format value labels as string for display
                 vl_str = None
                 if meta.value_labels:
-                    vl_str = "; ".join(f"{k}={v}" for k, v in meta.value_labels.items())
+                    vl_str = "; ".join(f"{k}={v}" for k, v in meta.labels.items())
 
                 # Format categories
                 cat_str = None
@@ -1717,7 +1760,7 @@ class MetadataStore:
                         )
                     if meta.missing.kinds:
                         missing_kinds_str = "; ".join(
-                            f"{k}={v.value}" for k, v in meta.missing.kinds.items()
+                            f"{k}={v.value}" for k, v in meta.missing.kinds
                         )
 
                 # Format scheme ref

--- a/packages/svy/tests/svy/io/test_base.py
+++ b/packages/svy/tests/svy/io/test_base.py
@@ -46,7 +46,7 @@ def test_read_spss_attaches_labels(dummy_svyio, tmp_path):
     meta = sample.meta
     assert isinstance(meta.get("sex"), VariableMeta)
     assert meta.get("sex").label == "Sex of respondent"
-    cats = meta.get("sex").value_labels or {}
+    cats = meta.get("sex").labels
     assert cats[1] == "Male" and cats[2] == "Female"
 
 

--- a/packages/svy/tests/svy/metadata/test_labels.py
+++ b/packages/svy/tests/svy/metadata/test_labels.py
@@ -91,9 +91,9 @@ def test_create_labels_from_scratch(synthetic_sample_df: pl.DataFrame):
     }
 
     # 3) Quick sanity checks
-    assert labels["resp2"].categories[1] == "Yes"
-    assert labels["resp2_new"].categories[0] == "No"
-    assert "High School" in labels["educ"].categories.values()
+    assert labels["resp2"].label_map[1] == "Yes"
+    assert labels["resp2_new"].label_map[0] == "No"
+    assert "High School" in labels["educ"].label_map.values()
 
 
 # ---------------------------------------------------------------------------

--- a/packages/svy/tests/svy/metadata/test_labels.py
+++ b/packages/svy/tests/svy/metadata/test_labels.py
@@ -94,3 +94,102 @@ def test_create_labels_from_scratch(synthetic_sample_df: pl.DataFrame):
     assert labels["resp2"].categories[1] == "Yes"
     assert labels["resp2_new"].categories[0] == "No"
     assert "High School" in labels["educ"].categories.values()
+
+
+# ---------------------------------------------------------------------------
+# CategoryScheme.parents — hierarchical schemes
+#
+# A cascading list (region -> district -> ward -> EA) referenced by concept
+# rather than inlined into a survey specification, because a geography is
+# revised on its own cycle and a census redraw should not read as a change to
+# the questionnaire.
+# ---------------------------------------------------------------------------
+
+
+GM_DISTRICT = dict(
+    concept="gm_district",
+    locale="en",
+    mapping={101: "Banjul", 102: "Kanifing", 201: "Lower Saloum", 202: "Nianija"},
+    parents=((101, 1), (102, 1), (201, 2), (202, 2)),
+)
+
+
+def _scheme(**overrides):
+    from svy.metadata import CategoryScheme
+
+    return CategoryScheme(**{**GM_DISTRICT, **overrides})
+
+
+def test_parent_and_children_lookups():
+    scheme = _scheme()
+    assert scheme.parent_of(201) == 2
+    assert scheme.children_of(1) == (101, 102)
+
+
+def test_a_code_with_no_parent_returns_none():
+    assert _scheme().parent_of(999) is None
+
+
+def test_a_scheme_without_a_hierarchy_answers_emptily():
+    assert _scheme(parents=None).parent_of(101) is None
+    assert _scheme(parents=None).children_of(1) == ()
+
+
+def test_children_keep_declaration_order():
+    scheme = _scheme(parents=((102, 1), (101, 1)))
+    assert scheme.children_of(1) == (102, 101)
+
+
+def test_parents_survive_the_catalog_round_trip():
+    catalog = LabellingCatalog().register(_scheme())
+    back = LabellingCatalog.from_bytes(catalog.to_bytes()).pick("gm_district", locale="en")
+    assert back.parents == GM_DISTRICT["parents"]
+    assert all(isinstance(child, int) for child, _ in back.parents)
+
+
+def test_parents_survive_plain_msgspec_too():
+    """The reason this field is pairs and not a dict.
+
+    `mapping` is a Category-keyed dict and only survives through the catalog's
+    custom encoder — plain msgspec turns {101: "Banjul"} into {"101": "Banjul"}
+    silently. Pairs are correct by any route, so a scheme serialized by some
+    future path that forgets the encoder still holds its codes.
+    """
+    import msgspec
+
+    from svy.metadata import CategoryScheme
+
+    back = msgspec.json.decode(msgspec.json.encode(_scheme()), type=CategoryScheme)
+    assert back.parents == GM_DISTRICT["parents"]
+    assert all(isinstance(child, int) for child, _ in back.parents)
+
+
+def test_a_child_code_absent_from_the_mapping_is_rejected():
+    from svy.errors import LabelError
+    from svy.metadata.labels import validate_scheme_missing
+
+    with pytest.raises(LabelError):
+        validate_scheme_missing(_scheme(parents=((999, 1),)), strict=True)
+
+
+def test_a_parent_code_is_not_validated_against_this_mapping():
+    # parents belong to a *different* scheme — the region list — which this one
+    # cannot see, so validating them here would reject every real hierarchy
+    from svy.metadata.labels import validate_scheme_missing
+
+    validate_scheme_missing(_scheme(), strict=True)
+
+
+def test_a_hierarchy_coexists_with_missing_semantics():
+    from svy.core.enumerations import MissingKind
+
+    scheme = _scheme(
+        mapping={**GM_DISTRICT["mapping"], 99: "Refused"},
+        missing={99},
+        missing_kinds={99: MissingKind.REFUSED},
+    )
+    catalog = LabellingCatalog().register(scheme)
+    back = LabellingCatalog.from_bytes(catalog.to_bytes()).pick("gm_district", locale="en")
+    assert back.parents == GM_DISTRICT["parents"]
+    assert back.missing == {99}
+    assert back.missing_kinds == {99: MissingKind.REFUSED}

--- a/packages/svy/tests/svy/metadata/test_labels.py
+++ b/packages/svy/tests/svy/metadata/test_labels.py
@@ -97,99 +97,125 @@ def test_create_labels_from_scratch(synthetic_sample_df: pl.DataFrame):
 
 
 # ---------------------------------------------------------------------------
-# CategoryScheme.parents — hierarchical schemes
+# SchemeEntry — one entry per code, rather than parallel collections
 #
-# A cascading list (region -> district -> ward -> EA) referenced by concept
-# rather than inlined into a survey specification, because a geography is
-# revised on its own cycle and a census redraw should not read as a change to
-# the questionnaire.
+# The scheme used to hold mapping, missing, missing_kinds and a hierarchy as
+# four collections keyed by code. Three serialized badly, and because they could
+# disagree, seventy-odd lines existed to check that they did not. One entry per
+# code makes those states unrepresentable.
 # ---------------------------------------------------------------------------
 
 
-GM_DISTRICT = dict(
-    concept="gm_district",
-    locale="en",
-    mapping={101: "Banjul", 102: "Kanifing", 201: "Lower Saloum", 202: "Nianija"},
-    parents=((101, 1), (102, 1), (201, 2), (202, 2)),
-)
-
-
 def _scheme(**overrides):
-    from svy.metadata import CategoryScheme
+    from svy.core.enumerations import MissingKind
+    from svy.metadata.labels import CategoryScheme, SchemeEntry
 
-    return CategoryScheme(**{**GM_DISTRICT, **overrides})
+    base = dict(
+        concept="gm_district",
+        locale="en",
+        entries=[
+            SchemeEntry(code=101, label="Banjul", parent=1),
+            SchemeEntry(code=102, label="Kanifing", parent=1),
+            SchemeEntry(code=201, label="Lower Saloum", parent=2),
+            SchemeEntry(code=99, label="Refused", missing=MissingKind.REFUSED),
+        ],
+    )
+    return CategoryScheme(**{**base, **overrides})
 
 
-def test_parent_and_children_lookups():
+def test_a_dict_is_still_accepted_when_constructing():
+    from svy.metadata.labels import CategoryScheme
+
+    scheme = CategoryScheme(concept="sex", entries={1: "Male", 2: "Female"})
+    assert scheme.labels == {1: "Male", 2: "Female"}
+    assert all(e.missing is None for e in scheme.entries)
+
+
+def test_labels_covers_every_code_and_substantive_does_not():
+    scheme = _scheme()
+    assert set(scheme.labels) == {101, 102, 201, 99}
+    assert [e.code for e in scheme.substantive] == [101, 102, 201]
+
+
+def test_missing_semantics_live_on_the_entry():
+    from svy.core.enumerations import MissingKind
+
+    scheme = _scheme()
+    assert scheme.missing_codes == frozenset({99})
+    assert scheme.kind_of(99) is MissingKind.REFUSED
+    assert scheme.kind_of(101) is None
+    assert scheme.codes_of_kind(MissingKind.REFUSED) == frozenset({99})
+
+
+def test_hierarchy_lookups():
     scheme = _scheme()
     assert scheme.parent_of(201) == 2
     assert scheme.children_of(1) == (101, 102)
-
-
-def test_a_code_with_no_parent_returns_none():
-    assert _scheme().parent_of(999) is None
-
-
-def test_a_scheme_without_a_hierarchy_answers_emptily():
-    assert _scheme(parents=None).parent_of(101) is None
-    assert _scheme(parents=None).children_of(1) == ()
+    assert scheme.parent_of(99) is None
 
 
 def test_children_keep_declaration_order():
-    scheme = _scheme(parents=((102, 1), (101, 1)))
+    from svy.metadata.labels import SchemeEntry
+
+    scheme = _scheme(
+        entries=[
+            SchemeEntry(code=102, label="Kanifing", parent=1),
+            SchemeEntry(code=101, label="Banjul", parent=1),
+        ]
+    )
     assert scheme.children_of(1) == (102, 101)
 
 
-def test_parents_survive_the_catalog_round_trip():
-    catalog = LabellingCatalog().register(_scheme())
-    back = LabellingCatalog.from_bytes(catalog.to_bytes()).pick("gm_district", locale="en")
-    assert back.parents == GM_DISTRICT["parents"]
-    assert all(isinstance(child, int) for child, _ in back.parents)
+def test_a_code_that_is_not_there_answers_none():
+    scheme = _scheme()
+    assert scheme.entry(999) is None
+    assert scheme.parent_of(999) is None
+    assert scheme.kind_of(999) is None
 
 
-def test_parents_survive_plain_msgspec_too():
-    """The reason this field is pairs and not a dict.
+def test_a_scheme_round_trips_through_plain_msgspec():
+    """The whole reason for the shape.
 
-    `mapping` is a Category-keyed dict and only survives through the catalog's
-    custom encoder — plain msgspec turns {101: "Banjul"} into {"101": "Banjul"}
-    silently. Pairs are correct by any route, so a scheme serialized by some
-    future path that forgets the encoder still holds its codes.
+    Every field is JSON-native now, so no bespoke encoder is involved and codes
+    keep their types by any route. The old shape returned {"101": "Banjul"} for
+    {101: "Banjul"} unless it went through the catalog's hand-written pairs.
     """
     import msgspec
 
-    from svy.metadata import CategoryScheme
+    from svy.metadata.labels import CategoryScheme
 
-    back = msgspec.json.decode(msgspec.json.encode(_scheme()), type=CategoryScheme)
-    assert back.parents == GM_DISTRICT["parents"]
-    assert all(isinstance(child, int) for child, _ in back.parents)
-
-
-def test_a_child_code_absent_from_the_mapping_is_rejected():
-    from svy.errors import LabelError
-    from svy.metadata.labels import validate_scheme_missing
-
-    with pytest.raises(LabelError):
-        validate_scheme_missing(_scheme(parents=((999, 1),)), strict=True)
+    scheme = _scheme()
+    back = msgspec.json.decode(msgspec.json.encode(scheme), type=CategoryScheme)
+    assert back == scheme
+    assert all(isinstance(c, int) for c in back.codes)
 
 
-def test_a_parent_code_is_not_validated_against_this_mapping():
-    # parents belong to a *different* scheme — the region list — which this one
-    # cannot see, so validating them here would reject every real hierarchy
-    from svy.metadata.labels import validate_scheme_missing
-
-    validate_scheme_missing(_scheme(), strict=True)
-
-
-def test_a_hierarchy_coexists_with_missing_semantics():
-    from svy.core.enumerations import MissingKind
-
-    scheme = _scheme(
-        mapping={**GM_DISTRICT["mapping"], 99: "Refused"},
-        missing={99},
-        missing_kinds={99: MissingKind.REFUSED},
-    )
+def test_a_scheme_round_trips_through_the_catalog():
+    scheme = _scheme()
     catalog = LabellingCatalog().register(scheme)
     back = LabellingCatalog.from_bytes(catalog.to_bytes()).pick("gm_district", locale="en")
-    assert back.parents == GM_DISTRICT["parents"]
-    assert back.missing == {99}
-    assert back.missing_kinds == {99: MissingKind.REFUSED}
+    assert back.entries == scheme.entries
+
+
+def test_a_duplicate_code_is_rejected():
+    from svy.errors import LabelError
+    from svy.metadata.labels import SchemeEntry
+
+    with pytest.raises(LabelError):
+        _scheme(
+            entries=[
+                SchemeEntry(code=101, label="Banjul"),
+                SchemeEntry(code=101, label="Banjul again"),
+            ]
+        )
+
+
+def test_a_missing_code_outside_the_scheme_is_unrepresentable():
+    """What validate_scheme_missing used to check, now impossible to express.
+
+    A missing code had to be added to `missing` *and* to `mapping`, and the two
+    could disagree. There is one list now, so a code that is missing is by
+    construction a code that exists.
+    """
+    scheme = _scheme()
+    assert scheme.missing_codes <= set(scheme.codes)

--- a/packages/svy/tests/svy/metadata/test_labels_apply.py
+++ b/packages/svy/tests/svy/metadata/test_labels_apply.py
@@ -238,14 +238,14 @@ def test_apply_labels_variable_labels_only_ok(sample):
 def test_apply_labels_with_global_categories_to_categorical(sample):
     cats = {1: "Male", 2: "Female"}
     sample.apply_labels(["sex"], ["Sex"], categories=cats)
-    assert sample._labels["sex"].categories == cats
+    assert sample._labels["sex"].label_map == cats
 
 
 def test_apply_labels_with_per_var_categories(sample):
     per = {"sex": {1: "M", 2: "F"}, "edu": {0: "None", 1: "HS", 2: "College"}}
     sample.apply_labels(["sex", "edu"], ["Sex", "Education"], categories=per)
-    assert sample._labels["sex"].categories == {1: "M", 2: "F"}
-    assert sample._labels["edu"].categories == {0: "None", 1: "HS", 2: "College"}
+    assert sample._labels["sex"].label_map == {1: "M", 2: "F"}
+    assert sample._labels["edu"].label_map == {0: "None", 1: "HS", 2: "College"}
 
 
 def test_apply_labels_rejects_nan_key_in_categories_global(sample):

--- a/packages/svy/tests/svy/metadata/test_variable_meta.py
+++ b/packages/svy/tests/svy/metadata/test_variable_meta.py
@@ -14,22 +14,25 @@ from svy.metadata import MetadataStore, MissingDef, ResolvedLabels, SchemeRef, V
 class TestMissingDefRoundTrip:
     """A MissingDef carrying kinds must survive JSON.
 
-    JSON object keys are always strings, so `dict[Category, MissingKind]`
-    encodes {98: DONT_KNOW} as {"98": "dnk"} and decodes with a *string* key,
-    while `codes` — a JSON array — returns as int. The subset check in
-    __post_init__ then failed, so the struct could not round-trip at all.
+    `kinds` was a `dict[Category, MissingKind]`. JSON object keys are always
+    strings, so {98: DONT_KNOW} encoded as {"98": "dnk"} and decoded with a
+    string key, while `codes` — a JSON array — returned as int. The subset
+    check then compared {'98'} against {98} and raised, so the struct could not
+    round-trip at all.
+
+    It is now (code, kind) pairs, which keep the code's type by any route. The
+    repair step that briefly papered over this is gone; there is nothing left
+    to repair.
     """
 
     def test_kinds_survive_json(self):
         m = MissingDef.from_kinds({98: MissingKind.DONT_KNOW, 99: MissingKind.REFUSED})
         back = msgspec.json.decode(msgspec.json.encode(m), type=MissingDef)
-        assert back.kinds == {98: MissingKind.DONT_KNOW, 99: MissingKind.REFUSED}
-        assert all(isinstance(k, int) for k in back.kinds)
+        assert back.kind_map == {98: MissingKind.DONT_KNOW, 99: MissingKind.REFUSED}
+        assert all(isinstance(code, int) for code, _ in back.kinds)
         assert back == m
 
     def test_the_decoded_form_still_answers_queries(self):
-        # a repaired key must be the code itself, not a lookalike, or every
-        # lookup silently misses
         m = MissingDef.from_kinds({98: MissingKind.DONT_KNOW, 99: MissingKind.REFUSED})
         back = msgspec.json.decode(msgspec.json.encode(m), type=MissingDef)
         assert back.is_missing(98)
@@ -40,24 +43,66 @@ class TestMissingDefRoundTrip:
     def test_a_variable_meta_carrying_kinds_round_trips(self):
         v = VariableMeta(name="age", missing=MissingDef.from_kinds({98: MissingKind.DONT_KNOW}))
         back = msgspec.json.decode(msgspec.json.encode(v), type=VariableMeta)
-        assert back.missing.kinds == {98: MissingKind.DONT_KNOW}
+        assert back.missing.kind_map == {98: MissingKind.DONT_KNOW}
         assert back == v
 
     def test_string_and_float_codes_are_untouched(self):
         m = MissingDef.from_kinds({"NA": MissingKind.NO_ANSWER, -1.5: MissingKind.SYSTEM})
         back = msgspec.json.decode(msgspec.json.encode(m), type=MissingDef)
-        assert back.kinds == {"NA": MissingKind.NO_ANSWER, -1.5: MissingKind.SYSTEM}
+        assert back.kind_map == {"NA": MissingKind.NO_ANSWER, -1.5: MissingKind.SYSTEM}
 
-    def test_a_genuine_mismatch_still_raises(self):
-        # the repair must not turn a real error into a silent pass
+    def test_a_mapping_is_still_accepted_when_constructing(self):
+        # {98: DONT_KNOW} reads better than a list of tuples, so it is coerced
+        m = MissingDef(codes=frozenset([98]), kinds={98: MissingKind.DONT_KNOW})
+        assert m.kinds == ((98, MissingKind.DONT_KNOW),)
+
+    def test_a_kind_for_a_code_that_is_not_missing_raises(self):
         with pytest.raises(ValueError, match="not in codes"):
             MissingDef(codes=frozenset([1]), kinds={2: MissingKind.DONT_KNOW})
 
-    def test_an_ambiguous_text_form_is_not_guessed(self):
-        # 1 and "1" share a text form, so a decoded "1" could be either;
-        # recovering one would be a coin flip
-        with pytest.raises(ValueError, match="not in codes"):
-            MissingDef(codes=frozenset([1, "1"]), kinds={"x": MissingKind.DONT_KNOW})
+
+class TestValueLabelRoundTrip:
+    """The same defect, in the two places it also lived.
+
+    `VariableMeta.value_labels` and `ResolvedLabels.value_labels` were
+    `dict[Category, str]` and corrupted *silently* — {1: "Male"} decoded as
+    {"1": "Male"}, with no error — so every join against an integer-coded
+    column would then miss.
+    """
+
+    def test_variable_meta_value_labels_keep_their_code_types(self):
+        v = VariableMeta(name="sex", value_labels={1: "Male", 2: "Female"})
+        back = msgspec.json.decode(msgspec.json.encode(v), type=VariableMeta)
+        assert back.labels == {1: "Male", 2: "Female"}
+        assert all(isinstance(vl.code, int) for vl in back.value_labels)
+        assert back == v
+
+    def test_resolved_labels_keep_their_code_types(self):
+        r = ResolvedLabels(var_label="Sex", value_labels={1: "Male"})
+        back = msgspec.json.decode(msgspec.json.encode(r), type=ResolvedLabels)
+        assert back.labels == {1: "Male"}
+        assert back == r
+
+    def test_a_dict_is_still_accepted_when_constructing(self):
+        assert VariableMeta(name="q", value_labels={1: "One"}).labels == {1: "One"}
+
+    def test_a_whole_store_of_metadata_survives_a_round_trip(self):
+        """The case that made this worth fixing.
+
+        Nothing serialized a store when the defect went in, so it stayed
+        latent. Projecting an instrument spec into one and saving it is exactly
+        the workflow that would have hit it.
+        """
+        store = MetadataStore()
+        store.set_label("sex", "Sex of respondent")
+        store.set_value_labels("sex", {1: "Male", 2: "Female"})
+        store.set_missing("sex", dont_know=[8])
+
+        payload = {name: store.get(name) for name in store.variables}
+        back = msgspec.json.decode(msgspec.json.encode(payload), type=dict[str, VariableMeta])
+        assert back["sex"].labels == {1: "Male", 2: "Female"}
+        assert back["sex"].missing.codes == frozenset({8})
+        assert back["sex"].missing.kind_map == {8: MissingKind.DONT_KNOW}
 
 
 class TestMissingDef:
@@ -88,8 +133,8 @@ class TestMissingDef:
                 -98: MissingKind.REFUSED,
             },
         )
-        assert m.kinds[-99] == MissingKind.DONT_KNOW
-        assert m.kinds[-98] == MissingKind.REFUSED
+        assert m.kind_map[-99] == MissingKind.DONT_KNOW
+        assert m.kind_map[-98] == MissingKind.REFUSED
 
     def test_kinds_must_be_subset_of_codes(self):
         """Kinds keys must be in codes."""
@@ -193,7 +238,7 @@ class TestMissingDef:
         )
         assert m.codes == frozenset([-99, -98])
         assert m.kinds is not None
-        assert m.kinds[-99] == MissingKind.DONT_KNOW
+        assert m.kind_map[-99] == MissingKind.DONT_KNOW
 
     def test_equality(self):
         """Test equality comparison."""
@@ -258,7 +303,7 @@ class TestVariableMeta:
             mtype=MeasurementType.NOMINAL,
         )
         assert meta.label == "What is your gender?"
-        assert meta.value_labels[1] == "Male"
+        assert meta.labels[1] == "Male"
         assert meta.has_labels is True
 
     def test_create_with_scheme_ref(self):
@@ -338,7 +383,7 @@ class TestVariableMeta:
 
         assert m1.scheme_ref is not None
         assert m2.scheme_ref is None  # Cleared by default
-        assert m2.value_labels == {1: "Yes", 0: "No"}
+        assert m2.labels == {1: "Yes", 0: "No"}
 
     def test_with_scheme_ref(self):
         """Test with_scheme_ref method."""
@@ -375,7 +420,7 @@ class TestResolvedLabels:
         """Create empty resolved labels."""
         r = ResolvedLabels()
         assert r.var_label == ""
-        assert r.value_labels == {}
+        assert r.labels == {}
         assert r.missing_codes == frozenset()
 
     def test_create_with_labels(self):
@@ -386,7 +431,7 @@ class TestResolvedLabels:
             missing_codes=frozenset([-99]),
         )
         assert r.var_label == "How satisfied are you?"
-        assert r.value_labels[1] == "Very dissatisfied"
+        assert r.labels[1] == "Very dissatisfied"
         assert -99 in r.missing_codes
 
     def test_display_with_label(self):
@@ -528,7 +573,7 @@ class TestMetadataStore:
         store = MetadataStore()
         store.set_value_labels("gender", {1: "Male", 2: "Female"})
 
-        assert store.get("gender").value_labels == {1: "Male", 2: "Female"}
+        assert store.get("gender").labels == {1: "Male", 2: "Female"}
 
     def test_set_scheme(self):
         """Set scheme reference."""
@@ -559,10 +604,10 @@ class TestMetadataStore:
         assert -96 in meta.missing.codes
 
         # Check mechanism mapping
-        assert meta.missing.kinds[-99] == MissingKind.DONT_KNOW
-        assert meta.missing.kinds[-98] == MissingKind.REFUSED
-        assert meta.missing.kinds[-97] == MissingKind.STRUCTURAL  # skipped -> STRUCTURAL
-        assert meta.missing.kinds[-96] == MissingKind.STRUCTURAL  # not_applicable -> STRUCTURAL
+        assert meta.missing.kind_map[-99] == MissingKind.DONT_KNOW
+        assert meta.missing.kind_map[-98] == MissingKind.REFUSED
+        assert meta.missing.kind_map[-97] == MissingKind.STRUCTURAL  # skipped -> STRUCTURAL
+        assert meta.missing.kind_map[-96] == MissingKind.STRUCTURAL  # not_applicable -> STRUCTURAL
 
     def test_set_missing_simple_codes(self):
         """Set missing with simple codes (no kinds)."""
@@ -603,7 +648,7 @@ class TestMetadataStore:
 
         resolved = store.resolve_labels("q1")
         assert resolved.var_label == "Test"
-        assert resolved.value_labels == {1: "Yes", 0: "No"}
+        assert resolved.labels == {1: "Yes", 0: "No"}
 
     def test_resolve_labels_empty(self):
         """Resolve returns empty for unknown variable."""
@@ -611,7 +656,7 @@ class TestMetadataStore:
         resolved = store.resolve_labels("unknown")
 
         assert resolved.var_label == ""
-        assert resolved.value_labels == {}
+        assert resolved.labels == {}
 
     def test_resolve_labels_cached(self):
         """Resolved labels are cached."""
@@ -969,13 +1014,13 @@ class TestUpdate:
         # filling a gap is not a conflict, so it does not need overwrite=True
         store = self._analyst()
         store.update(self._spec(), overwrite=overwrite)
-        assert store.get("sex").value_labels == {1: "Male", 2: "Female"}
+        assert store.get("sex").labels == {1: "Male", 2: "Female"}
 
     def test_a_variable_absent_here_is_added_whole(self):
         store = MetadataStore()
         store.update(self._spec())
         assert set(store.variables) == {"age", "sex"}
-        assert store.get("sex").value_labels == {1: "Male", 2: "Female"}
+        assert store.get("sex").labels == {1: "Male", 2: "Female"}
 
     def test_the_other_store_is_not_modified(self):
         other = self._spec()
@@ -1002,9 +1047,9 @@ class TestUpdate:
     def test_resolved_labels_see_the_merged_value(self):
         # the cache is keyed per variable, so a merge must invalidate it
         store = self._analyst()
-        assert store.resolve_labels("sex").value_labels == {}
+        assert store.resolve_labels("sex").labels == {}
         store.update(self._spec())
-        assert store.resolve_labels("sex").value_labels == {1: "Male", 2: "Female"}
+        assert store.resolve_labels("sex").labels == {1: "Male", 2: "Female"}
 
 
 class TestIntegration:
@@ -1094,9 +1139,9 @@ class TestIntegration:
         assert not meta.missing.is_missing(1)
 
         # Check mechanism mapping
-        assert meta.missing.kinds[-99] == MissingKind.DONT_KNOW
-        assert meta.missing.kinds[-98] == MissingKind.REFUSED
-        assert meta.missing.kinds[-97] == MissingKind.STRUCTURAL
+        assert meta.missing.kind_map[-99] == MissingKind.DONT_KNOW
+        assert meta.missing.kind_map[-98] == MissingKind.REFUSED
+        assert meta.missing.kind_map[-97] == MissingKind.STRUCTURAL
 
         # Check user vs system missing
         assert meta.missing.user_missing() == frozenset([-99, -98])

--- a/packages/svy/tests/svy/wrangling/test_apply_labels.py
+++ b/packages/svy/tests/svy/wrangling/test_apply_labels.py
@@ -52,7 +52,7 @@ def test_apply_labels_categories_only(sample_basic: Sample):
     out = sample_basic.wrangling.apply_labels(categories={"sex": {1: "Male", 2: "Female"}})
     meta = out.meta.get("sex")
     assert meta is not None
-    assert meta.value_labels == {1: "Male", 2: "Female"}
+    assert meta.labels == {1: "Male", 2: "Female"}
 
 
 def test_apply_labels_both(sample_basic: Sample):
@@ -63,7 +63,7 @@ def test_apply_labels_both(sample_basic: Sample):
     meta = out.meta.get("sex")
     assert meta is not None
     assert meta.label == "Sex of respondent"
-    assert meta.value_labels == {1: "Male", 2: "Female"}
+    assert meta.labels == {1: "Male", 2: "Female"}
 
 
 def test_apply_labels_multiple_variables(sample_basic: Sample):
@@ -75,9 +75,9 @@ def test_apply_labels_multiple_variables(sample_basic: Sample):
         },
     )
     assert out.meta.get("sex").label == "Sex"
-    assert out.meta.get("sex").value_labels == {1: "Male", 2: "Female"}
+    assert out.meta.get("sex").labels == {1: "Male", 2: "Female"}
     assert out.meta.get("region").label == "Region"
-    assert out.meta.get("region").value_labels == {
+    assert out.meta.get("region").labels == {
         "N": "North",
         "S": "South",
         "E": "East",
@@ -92,7 +92,7 @@ def test_apply_labels_independent_keys(sample_basic: Sample):
         categories={"sex": {1: "Male", 2: "Female"}},
     )
     assert out.meta.get("age").label == "Age in years"
-    assert out.meta.get("sex").value_labels == {1: "Male", 2: "Female"}
+    assert out.meta.get("sex").labels == {1: "Male", 2: "Female"}
 
 
 def test_apply_labels_returns_new_instance_by_default(sample_basic: Sample):
@@ -257,7 +257,7 @@ def test_apply_labels_string_categories():
         labels={"status": "Status code"},
         categories={"status": {"A": "Active", "B": "Blocked", "C": "Closed"}},
     )
-    assert out.meta.get("status").value_labels == {
+    assert out.meta.get("status").labels == {
         "A": "Active",
         "B": "Blocked",
         "C": "Closed",
@@ -271,7 +271,7 @@ def test_apply_labels_partial_categories():
     out = s.wrangling.apply_labels(
         categories={"tenure": {"Occupied for free": "Free use"}},
     )
-    assert out.meta.get("tenure").value_labels == {"Occupied for free": "Free use"}
+    assert out.meta.get("tenure").labels == {"Occupied for free": "Free use"}
     warns = [w for w in out.warnings if w.code == "DATA_VALUE_NOT_LABELED"]
     assert len(warns) == 1
 
@@ -283,7 +283,7 @@ def test_apply_labels_extra_category_keys_warns():
     out = s.wrangling.apply_labels(
         categories={"a": {1: "One", 2: "Two", 99: "Unknown"}},
     )
-    assert out.meta.get("a").value_labels == {1: "One", 2: "Two", 99: "Unknown"}
+    assert out.meta.get("a").labels == {1: "One", 2: "Two", 99: "Unknown"}
     warns = [w for w in out.warnings if w.code == "LABEL_KEY_NOT_IN_DATA"]
     assert len(warns) == 1
 
@@ -301,7 +301,7 @@ def test_labels_preserved_after_filter(sample_basic: Sample):
     filtered = labeled.wrangling.filter_records(col("age") > 25)
     meta = filtered.meta.get("sex")
     assert meta is not None
-    assert meta.value_labels == {1: "M", 2: "F"}
+    assert meta.labels == {1: "M", 2: "F"}
 
 
 def test_labels_updated_on_rename(sample_basic: Sample):
@@ -346,7 +346,7 @@ def test_label_object_attributes():
     meta = out.meta.get("x")
     assert isinstance(meta, VariableMeta)
     assert meta.label == "X Variable"
-    assert meta.value_labels == {1: "Low", 2: "Med", 3: "High"}
+    assert meta.labels == {1: "Low", 2: "Med", 3: "High"}
 
 
 def test_label_without_categories():
@@ -365,7 +365,7 @@ def test_apply_labels_empty_labels_dict():
     df = pl.DataFrame({"a": [1, 2, 3]})
     s = Sample(df)
     out = s.wrangling.apply_labels(labels={}, categories={"a": {1: "One"}})
-    assert out.meta.get("a").value_labels == {1: "One"}
+    assert out.meta.get("a").labels == {1: "One"}
 
 
 def test_apply_labels_empty_categories_dict():
@@ -384,7 +384,7 @@ def test_apply_labels_single_row_dataframe():
         labels={"a": "Single value"},
         categories={"a": {1: "One"}},
     )
-    assert out.meta.get("a").value_labels == {1: "One"}
+    assert out.meta.get("a").labels == {1: "One"}
 
 
 def test_apply_labels_with_all_nulls():

--- a/packages/svy/tests/svy/wrangling/test_wrangling_integration.py
+++ b/packages/svy/tests/svy/wrangling/test_wrangling_integration.py
@@ -175,7 +175,7 @@ def test_labels_preserved_through_filter():
 
     meta = filtered.meta.get("sex")
     assert meta is not None
-    assert meta.value_labels == {1: "Male", 2: "Female"}
+    assert meta.labels == {1: "Male", 2: "Female"}
 
 
 def test_labels_updated_on_rename():


### PR DESCRIPTION
Adds `CategoryScheme.parents` so one scheme can describe a cascading list — region → district → ward → enumeration area.

## Why

A survey specification currently has to **inline** a hierarchy to cascade over it. That is wrong for the same reason inlining any reference data is wrong: a geography is revised on its own cycle, and the instrument is not.

Measured on a Gambia-shaped hierarchy — a census redraw adding 60 enumeration areas, questionnaire untouched:

```
wave 1 fingerprint: 758942bd9307b786
wave 2 fingerprint: 4265b4394148a0d8   <- moved
diff: 0 breaking, 60 to review, 0 compatible
```

Held in the catalog instead, none of that happens. The same argument covers ISCO, ISIC, and education classifications — anything externally maintained and versioned on its own schedule.

## What

```python
CategoryScheme(
    concept="gm_district", locale="en",
    mapping={101: "Banjul", 102: "Kanifing", 201: "Lower Saloum"},
    parents=((101, 1), (102, 1), (201, 2)),      # district -> region
)
scheme.parent_of(201)     # 2
scheme.children_of(1)     # (101, 102)
```

Purely additive — `parents` defaults to `None` and every existing scheme is unaffected.

## Pairs, not a dict — deliberately

`mapping` and `missing_kinds` beside it are `Category`-keyed dicts, and they survive **only** through `LabellingCatalog`'s custom encoder:

```
plain msgspec :  {'101': 'Banjul'}    <- silently corrupted
via catalog   :  {101: 'Banjul'}      <- correct
```

A dict here would inherit that, and would depend on `_scheme_to_jsonable` / `_scheme_from_jsonable` being extended in step — which is exactly what did not happen for `MissingDef` (fixed separately in #101). Pairs are correct by any route, and a test asserts the plain-msgspec path rather than trusting the encoder to be remembered.

The encoder is extended anyway (`parent_pairs`), so both routes are covered.

## Validation

Child side only: a code with a parent must exist in this scheme's `mapping`. Parent codes belong to a *different* scheme — the region list — which this one has no way to see, so validating them here would reject every real hierarchy. There's a test for each direction.

## Checks

2809 passed, 1 skipped (10 new). `ruff check` / `format --check` clean on both touched files.

## Follow-on

svy-spec's `Choices(concept=..., cascade_from=...)` currently **raises**, because a concept-backed cascade resolved every option with `parent=None` and went silently inert. Once this lands, that becomes a working path and the refusal is removed.

## Known, not addressed here

`CategoryScheme.mapping` silently corrupts codes when serialized outside the catalog. Pre-existing, unrelated to this change, and not fixable without changing `mapping`'s type — which is a breaking change deserving its own decision. Recorded so it isn't rediscovered.