### PR TITLE
Fix a silent label bug, and delete 171 lines nothing calls

### DIFF
--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -9,7 +9,6 @@ import threading
 from typing import Iterable, Mapping, Self
 
 import msgspec
-import polars as pl
 
 from msgspec.structs import force_setattr, replace
 
@@ -235,32 +234,6 @@ def _is_nan(x: object) -> bool:
 # =============================
 
 
-def validate_scheme_missing(s: CategoryScheme, *, strict: bool = True) -> None:
-    """Retained as a no-op seam.
-
-    Everything it used to check is now unrepresentable. A missing code outside
-    the scheme, a kind for a code that is not missing, a NaN code, a duplicate —
-    each was a way for four parallel collections to disagree, and there is one
-    collection now. NaN and duplicate codes are rejected in ``__post_init__``,
-    where they cannot be skipped by a caller who forgets to validate.
-    """
-    return None
-
-
-def normalize_scheme_missing(s: CategoryScheme) -> CategoryScheme:
-    """Retained as a no-op seam.
-
-    There is nothing left to derive: ``missing`` used to be recoverable from
-    ``missing_kinds``, and both are now one field on the entry.
-    """
-    return s
-
-
-def missing_codes_by_kind(s: CategoryScheme, kinds: set[MissingKind]) -> set[Category]:
-    """Collect codes matching any of the requested kinds."""
-    return set(s.codes_of_kind(*kinds))
-
-
 # =============================
 # Scheme factory
 # =============================
@@ -376,8 +349,6 @@ class LabellingCatalog:
                     where="labels.LabellingCatalog.register",
                     scheme_id=scheme.id,
                 )
-            # Validate again here (defensive) when bringing external schemes
-            validate_scheme_missing(scheme, strict=True)
             if scheme.id is not None:
                 self._schemes[scheme.id] = scheme
         return self
@@ -570,153 +541,11 @@ class LabellingCatalog:
 # =============================
 
 
-class SchemeCatalogView:
-    def __init__(self, catalog: LabellingCatalog):
-        self._c = catalog
-
-    @property
-    def locale(self):
-        return self._c.locale
-
-    def set_locale(self, locale: str | None):
-        self._c.set_locale(locale)
-
-    def list(self, **kw):
-        return self._c.list(**kw)
-
-    def search(self, q: str):
-        return self._c.search(q)
-
-    def get(self, scheme_id: str):
-        return self._c.get(scheme_id)
-
-    def pick(self, concept: str, *, locale: str | None = None):
-        return self._c.pick(concept, locale=locale)
-
-    def to_label(self, var_label: str, scheme_id: str, **kw):
-        return self._c.to_label(var_label, scheme_id, **kw)
-
-    def to_label_by_concept(self, var_label: str, concept: str, **kw):
-        return self._c.to_label_by_concept(var_label, concept, **kw)
-
-
 # =============================
 # Missing policies & simple transforms
 # =============================
 
 
-def is_missing_value(
-    value: Category | None,
-    *,
-    scheme: CategoryScheme | None,
-    kinds: set[MissingKind] | None = None,
-    treat_null: bool = True,
-    treat_nan: bool = True,
-) -> bool:
-    """Test missingness with an optional policy by kind."""
-    if value is None and treat_null:
-        return True
-    if _is_nan(value) and treat_nan:
-        return True
-    if not scheme:
-        return False
-
-    if kinds is None:
-        return value in scheme.missing_codes
-
-    if not scheme.missing_codes:
-        return False
-    if value is None:
-        return False
-    k = scheme.kind_of(value)
-    return (k in kinds) if k is not None else False
-
-
-def recode_for_analysis(
-    seq: Iterable[Category | None],
-    *,
-    scheme: CategoryScheme | None,
-    kinds: set[MissingKind] | None = None,
-    treat_null: bool = True,
-    treat_nan: bool = True,
-) -> list[Category | None]:
-    """Return a new list where selected missing codes are turned into None."""
-    out: list[Category | None] = []
-    for v in seq:
-        out.append(
-            None
-            if is_missing_value(
-                v, scheme=scheme, kinds=kinds, treat_null=treat_null, treat_nan=treat_nan
-            )
-            else v
-        )
-    return out
-
-
-def display_text(
-    value: Category | None,
-    *,
-    scheme: CategoryScheme | None,
-    null_text: str = "",
-) -> str:
-    """Return display label (or empty/null_text for NA)."""
-    if value is None or _is_nan(value):
-        return null_text
-    if scheme is not None:
-        entry = scheme.entry(value)
-        if entry is not None:
-            return entry.label
-    return str(value)
-
-
 # =============================
 # Optional adapters (Polars/Pandas)
 # =============================
-
-
-def polars_mask(col, scheme: CategoryScheme | None, kinds: set[MissingKind] | None = None):
-    """
-    Returns a Polars expression masking values that are missing by policy.
-    Safe on non-float columns (guards is_nan via cast).
-    Usage:
-      df.with_columns(pl.when(polars_mask("q1", s)).then(None).otherwise(pl.col("q1")))
-    """
-    import polars as pl
-
-    expr = pl.col(col) if isinstance(col, str) else col
-    mask = expr.is_null()
-    # Guarded NaN check via permissive cast
-    mask = mask | expr.cast(pl.Float64, strict=False).is_nan()
-    if scheme:
-        if kinds is None and scheme.missing_codes:
-            mask = mask | expr.is_in(list(scheme.missing_codes))
-        elif kinds and scheme.missing_codes:
-            codes = list(scheme.codes_of_kind(*kinds))
-            if codes:
-                mask = mask | expr.is_in(codes)
-    # Null-safe: under Kleene logic `False | null = null`, and a null mask
-    # entry behaves differently depending on the consumer (when() takes the
-    # otherwise-branch; filter() drops the row). A null in any sub-check can
-    # only arise from a null input, which IS missing-by-policy, so pin the
-    # mask to True there explicitly.
-    return mask.fill_null(True)
-
-
-def polars_to_analysis(
-    col,
-    scheme: CategoryScheme | None,
-    kinds: set[MissingKind] | None = None,
-    alias: str | None = None,
-):
-    expr = pl.col(col) if isinstance(col, str) else col
-    alias = alias or (col if isinstance(col, str) else None)
-    return pl.when(polars_mask(expr, scheme, kinds)).then(None).otherwise(expr).alias(alias)
-
-
-def polars_to_display(col, scheme: CategoryScheme | None, alias: str | None = None):
-    import polars as pl
-
-    expr = pl.col(col) if isinstance(col, str) else col
-    alias = alias or (f"{col}_label" if isinstance(col, str) else "label")
-    mapping = scheme.labels if scheme else {}
-    return expr.replace(mapping).cast(pl.Utf8).alias(alias)

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -969,8 +969,14 @@ class MetadataStore:
             try:
                 scheme = meta.scheme_ref.resolve(self._catalog)
                 value_labels = scheme.labels
-                # Also get missing from scheme if not defined on meta
-                if meta.missing is None and scheme.missing:
+                # Also get missing from scheme if not defined on meta.
+                # `scheme.missing_codes`, not `scheme.missing`: a scheme holds
+                # one SchemeEntry per code carrying its own missing kind, and
+                # has had no `missing` collection since that change. The broad
+                # `except` below turned the AttributeError into a logged warning
+                # and an empty result, so a catalog-labelled variable silently
+                # lost its missing codes.
+                if meta.missing is None and scheme.missing_codes:
                     missing_codes = scheme.missing_codes
             except Exception as e:
                 log.warning(

--- a/packages/svy/tests/svy/metadata/test_labels.py
+++ b/packages/svy/tests/svy/metadata/test_labels.py
@@ -219,3 +219,32 @@ def test_a_missing_code_outside_the_scheme_is_unrepresentable():
     """
     scheme = _scheme()
     assert scheme.missing_codes <= set(scheme.codes)
+
+
+def test_a_catalog_labelled_variable_keeps_its_missing_codes():
+    """resolve_labels read `scheme.missing`, which stopped existing when a
+    scheme became one SchemeEntry per code. The broad `except Exception` around
+    it logged a warning and returned an empty set, so the codes vanished with
+    no error — the failure mode a bare except is supposed to prevent and here
+    caused."""
+    from svy.core.enumerations import MissingKind
+    from svy.metadata import CategoryScheme, LabellingCatalog, MetadataStore, VariableMeta
+    from svy.metadata.labels import SchemeEntry
+    from svy.metadata.variable_meta import SchemeRef
+
+    scheme = CategoryScheme(
+        concept="yesno",
+        entries=[
+            SchemeEntry(1, "Yes"),
+            SchemeEntry(0, "No"),
+            SchemeEntry(9, "Refused", missing=MissingKind.REFUSED),
+        ],
+    )
+    catalog = LabellingCatalog()
+    catalog.register(scheme)
+    store = MetadataStore(catalog=catalog)
+    store.set("q", VariableMeta(name="q", scheme_ref=SchemeRef(concept="yesno")))
+
+    resolved = store.resolve_labels("q")
+    assert resolved.missing_codes == frozenset({9})
+    assert resolved.labels == {1: "Yes", 0: "No", 9: "Refused"}


### PR DESCRIPTION
Two commits from auditing which parts of the labelling module anything actually calls.

## 1. A catalog-labelled variable silently lost its missing codes

`resolve_labels` read `scheme.missing`, which stopped existing when `CategoryScheme` became one `SchemeEntry` per code (#102). The broad `except Exception` caught the `AttributeError`, logged a warning, and returned an empty frozenset.

```python
store.resolve_labels("q").missing_codes
# before: frozenset()      after: frozenset({9})
```

No test covered it because **nothing in svy ever sets a `scheme_ref`** — the field appears nowhere outside `metadata/`, so the branch is reached only from svy-spec's bridge. There is a test now.

The bare `except` is why a refactor error became a wrong answer rather than a traceback. Narrowing it is a separate change.

## 2. 171 dead lines

Nothing in the monorepo, in svy-spec, or in any test references these:

- `is_missing_value`, `recode_for_analysis`, `display_text`, `polars_mask`, `polars_to_analysis`, `polars_to_display` — also not exported
- `SchemeCatalogView`
- `validate_scheme_missing`, `normalize_scheme_missing`, `missing_codes_by_kind` — no-op seams left over from #102

`labels.py` 722 → 552 lines, and it no longer imports polars.

**One judgement call to check:** `polars_mask` has a CHANGELOG entry from 0.20.x. It has no callers, no tests, and is not exported — reachable only as `svy.metadata.labels.polars_mask`. Happy to keep it if you would rather.

2815 passed, ruff clean.