### PR TITLE
perf(estimation): drop O(B^2) column lookups in replication prep

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,21 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Fixed
+
+- **Replication variance no longer costs O(B²) in the replicate count B.** The replicate kernels themselves were never at fault — they already do a single O(n·B) pass — but two sites in the Python prep layer tested column membership once per replicate weight column: `prepare_data` with `[c for c in rep_weight_cols if c in df.columns]`, and `Estimation._ensure_float64` with `c in data.columns and data[c].dtype != ...`. `df.columns` is a property that rebuilds the entire column-name list across the FFI boundary on every access, so B lookups cost O(B²) Python-string constructions; `_ensure_float64` also materialised a Series per column. A cProfile run at n=25,000 / B=800 put `PyDataFrame.columns` at 57% of total runtime, called ~2·B times per estimate.
+
+  With total work n·B held constant at 20M cells — an identical 160 MB replicate weight matrix in every case — the sweep spanned 36× across cases doing identical arithmetic. Column names are now snapshotted into a set once, and dtypes read from a single `data.schema` snapshot that answers both existence and dtype:
+
+  | n | B | before | after | speedup |
+  | ---: | ---: | ---: | ---: | ---: |
+  | 200,000 | 100 | 0.0067 s | 0.0059 s | 1.1× |
+  | 50,000 | 400 | 0.0219 s | 0.0077 s | 2.8× |
+  | 25,000 | 800 | 0.0704 s | 0.0116 s | 6.1× |
+  | 12,500 | 1600 | 0.2442 s | 0.0201 s | 12.1× |
+
+  Sweep spread drops from 36.2× to 3.4×. This matters most for bootstrap designs at B=1000+; it is negligible for BRR (32–64) and SDR/ACS (80). **Results are numerically inert** — mean, total, ratio, prop and mean-by-domain are bit-for-bit identical to the previous build.
+
 ## [0.22.0] — 2026-08-02
 
 **svy labels values so results print nicely. That is the whole job.** Everything that made

--- a/packages/svy/src/svy/core/data_prep.py
+++ b/packages/svy/src/svy/core/data_prep.py
@@ -580,7 +580,11 @@ def prepare_data(
     weight_col = design.wgt if design.wgt else "__svy_ones__"
 
     # Rep weight columns that actually exist in df after select/singleton.
-    rep_weight_cols_in_df = [c for c in rep_weight_cols if c in df.columns]
+    # `df.columns` rebuilds the whole name list on every access, so testing it
+    # once per replicate is O(B^2) in Python-string construction — the dominant
+    # cost at bootstrap replicate counts. Snapshot it once into a set instead.
+    _df_col_set = set(df.columns)
+    rep_weight_cols_in_df = [c for c in rep_weight_cols if c in _df_col_set]
 
     # ── Where clause → domain column + zero weights (main + replicate) ───
     # Must happen BEFORE the categorical/by/strata type casting below so

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -297,10 +297,15 @@ class Estimation:
     # ----------------------------------------------------------------
 
     def _ensure_float64(self, data: pl.DataFrame, cols: list[str]) -> pl.DataFrame:
+        # One `data.schema` lookup answers both "does the column exist" and
+        # "what is its dtype". The previous `c in data.columns and data[c].dtype`
+        # rebuilt the full column-name list *and* materialised a Series per
+        # column, making this O(B^2) when `cols` is a set of replicate weights.
+        schema = data.schema
         casts = [
             pl.col(c).cast(pl.Float64)
             for c in cols
-            if c in data.columns and data[c].dtype != pl.Float64
+            if (dtype := schema.get(c)) is not None and dtype != pl.Float64
         ]
         return data.with_columns(casts) if casts else data
 

--- a/packages/svy/tests/svy/estimation/test_replication_scaling.py
+++ b/packages/svy/tests/svy/estimation/test_replication_scaling.py
@@ -1,0 +1,123 @@
+# tests/svy/estimation/test_replication_scaling.py
+"""Guard against O(B^2) cost in replication estimation, B = replicate count.
+
+The replicate kernels are O(n*B), but the Python prep layer used to test
+membership against ``df.columns`` once per replicate weight column. Each access
+rebuilds the entire column-name list across the FFI boundary, so B lookups cost
+O(B^2) Python-string constructions. At bootstrap replicate counts this
+dominated: with n*B held constant at 2e7 cells, B=800 ran ~10x slower than
+B=100 despite doing identical arithmetic on an identically sized matrix.
+
+These tests assert the *structural* property that produced the blowup --
+per-call accesses to column metadata must not grow with B -- rather than
+wall-clock time, which is too noisy to assert on in CI.
+"""
+
+import numpy as np
+import polars as pl
+import pytest
+
+import svy
+
+
+N_ROWS = 2_000
+SMALL_REPS = 16
+LARGE_REPS = 256
+
+
+def _make_sample(n_reps: int, n_rows: int = N_ROWS) -> svy.Sample:
+    """A tiny replication design with ``n_reps`` bootstrap replicate weights."""
+    rng = np.random.default_rng(20260804)
+    data = {
+        "psu": np.repeat(np.arange(40, dtype=np.int64), n_rows // 40),
+        "wgt": rng.uniform(5.0, 20.0, size=n_rows),
+        "y": rng.normal(10.0, 3.0, size=n_rows),
+        "x": rng.normal(20.0, 4.0, size=n_rows),
+    }
+    for r in range(n_reps):
+        data[f"bsrw{r + 1}"] = data["wgt"] * rng.integers(0, 3, size=n_rows)
+    df = pl.DataFrame(data)
+
+    design = svy.Design(
+        wgt="wgt",
+        rep_wgts=svy.RepWeights(method="bootstrap", prefix="bsrw", n_reps=n_reps),
+    )
+    return svy.Sample(data=df, design=design)
+
+
+@pytest.fixture
+def count_columns_access(monkeypatch):
+    """Count ``pl.DataFrame.columns`` property accesses inside a with-block."""
+    counter = {"n": 0}
+    original = pl.DataFrame.columns
+
+    def counting_fget(self):
+        counter["n"] += 1
+        return original.fget(self)
+
+    monkeypatch.setattr(pl.DataFrame, "columns", property(counting_fget))
+    return counter
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda s: s.estimation.mean("y", method="replication"), id="mean"),
+        pytest.param(lambda s: s.estimation.total("y", method="replication"), id="total"),
+        pytest.param(lambda s: s.estimation.ratio("y", "x", method="replication"), id="ratio"),
+    ],
+)
+def test_column_metadata_access_does_not_scale_with_replicates(count_columns_access, call):
+    """A 16x larger replicate count must not mean 16x more `.columns` accesses.
+
+    Pre-fix this grew as ~2*B (two call sites each looping over every replicate
+    column), which is what made total cost quadratic.
+    """
+    small = _make_sample(SMALL_REPS)
+    large = _make_sample(LARGE_REPS)
+
+    # Warm any per-sample caches so we measure steady-state estimation cost,
+    # not one-off design resolution.
+    call(small)
+    call(large)
+
+    count_columns_access["n"] = 0
+    call(small)
+    small_accesses = count_columns_access["n"]
+
+    count_columns_access["n"] = 0
+    call(large)
+    large_accesses = count_columns_access["n"]
+
+    # Allow a small constant slack for incidental per-call metadata lookups,
+    # but nothing proportional to the 240 extra replicate columns.
+    assert large_accesses <= small_accesses + 10, (
+        f"`.columns` accesses grew with replicate count "
+        f"({small_accesses} at B={SMALL_REPS} -> {large_accesses} at B={LARGE_REPS}); "
+        f"an O(B) access pattern makes replication estimation O(B^2)."
+    )
+
+
+def test_replicate_estimates_are_unchanged_by_column_lookup_shape():
+    """The optimisation must be numerically inert.
+
+    `_ensure_float64` now reads dtypes from a single schema snapshot rather than
+    per-column `data[c].dtype`; non-Float64 replicate weights must still be cast.
+    """
+    sample = _make_sample(SMALL_REPS)
+    ref = sample.estimation.mean("y", method="replication").estimates[0]
+
+    # Same data, but replicate weights stored as Float32 so the cast path runs.
+    df = sample._data
+    if isinstance(df, pl.LazyFrame):
+        df = df.collect()
+    cast_df = df.with_columns([pl.col(f"bsrw{r + 1}").cast(pl.Float32) for r in range(SMALL_REPS)])
+    design = svy.Design(
+        wgt="wgt",
+        rep_wgts=svy.RepWeights(method="bootstrap", prefix="bsrw", n_reps=SMALL_REPS),
+    )
+    recast = svy.Sample(data=cast_df, design=design)
+    got = recast.estimation.mean("y", method="replication").estimates[0]
+
+    assert got.est == pytest.approx(ref.est, rel=1e-6)
+    assert got.se == pytest.approx(ref.se, rel=1e-6)


### PR DESCRIPTION
Replication variance cost grew quadratically in the replicate count `B`. With total work `n*B` held constant at 20M cells — an identical 160 MB replicate weight matrix in every case — `mean()` ran 0.0067 s at B=100 but 0.2442 s at B=1600: a **36× spread over cases doing identical arithmetic**.

## Where it was

Not in the kernels. The replicate kernels in `svy-rs` already do a single O(n·B) pass accumulating per-replicate sums, and measured ~13% of runtime at B=800.

The quadratic term was in the Python prep layer, where two sites tested column membership once per replicate weight column:

- `data_prep.prepare_data` — `[c for c in rep_weight_cols if c in df.columns]`
- `Estimation._ensure_float64` — `c in data.columns and data[c].dtype != ...`

`df.columns` is a property that rebuilds the entire column-name list across the FFI boundary on **every** access, so B lookups cost O(B²) Python-string constructions; the `in list` scan is O(B) on top, and `_ensure_float64` also materialised a Series per column via `data[c]`. A cProfile run at n=25,000 / B=800 put `PyDataFrame.columns` at **57% of total runtime**, called ~2·B times per estimate.

## The fix

Snapshot the column names into a set once, and read dtypes from a single `data.schema` snapshot that answers both existence and dtype. Cost is now O(n·B) plus a small fixed per-replicate overhead that is linear in B.

| n | B | before | after | speedup |
| ---: | ---: | ---: | ---: | ---: |
| 200,000 | 100 | 0.0067 s | 0.0059 s | 1.1× |
| 50,000 | 400 | 0.0219 s | 0.0077 s | 2.8× |
| 25,000 | 800 | 0.0704 s | 0.0116 s | 6.1× |
| 12,500 | 1600 | 0.2442 s | 0.0201 s | 12.1× |

Sweep spread: **36.2× → 3.4×**. Matters most for bootstrap designs at B=1000+; negligible for BRR (32–64) and SDR/ACS (80).

## Correctness

Results are numerically inert: mean, total, ratio, prop and mean-by-domain snapshots are **bit-for-bit identical** to the pre-change build.

## Testing

The regression test asserts the *structural* property that caused the blowup — per-call column-metadata accesses must not grow with B — rather than wall-clock time, which is too noisy for CI. It fails on the previous code (39 accesses at B=16 → 519 at B=256).

## Release

Python-only; no `svy-rs` change. Ships in the **svy 0.22.1** release PR alongside #114.