### PR TITLE
perf(estimation): stop indexing the Taylor design twice per estimate

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **A Taylor estimate indexes its design once instead of twice.** `degrees_of_freedom` re-derived the stratum codes and nested (stratum, PSU) codes that `build_taylor_design` had just built, from the same columns via the same calls — two full densification passes over the design columns per estimate. At 1M rows over 2000 PSUs that was 11.3 ms on top of the design build's 11.0 ms, i.e. **63% of a 35 ms kernel spent indexing the same two columns twice.** A new `degrees_of_freedom_from_design` takes the df off the design's own code vectors; because those codes come from identical calls on identical inputs, the df is bit-identical by construction rather than merely equivalent. Applied to the ungrouped and batched mean, total, ratio and proportion kernels. The median kernels still double-index — their design is built inside the Woodruff variance and is not available to reuse — but they are sort-bound, so the share is smaller.
+
+- **The ungrouped kernels overlap their two independent halves.** Indexing the design reads none of the response columns, and the point estimate, scores and SRS variance read none of the design columns; likewise the variance and the df both read the finished design but neither feeds the other. Both pairs now run under `rayon::join`, and the ungrouped entry points release the GIL (`Python::detach`) so the second half can actually be picked up — previously only the by-group and batched paths did, and `taylor_mean`'s ungrouped branch held the interpreter lock through the whole call. Each half is internally unchanged and still accumulates in row order.
+
+- **`scores_mean_arr` skips a score-vector round-trip.** `taylor_variance` immediately converted the `Float64Chunked` from `scores_mean` back into a `Vec<f64>`, so the chunked array was two 8 MB copies at 1M rows that existed only to be undone. Callers that need the array take it directly; null positions still map to `0.0` exactly as before.
+
+**Results are numerically inert.** Estimates, standard errors, variances and degrees of freedom are bit-for-bit identical to 0.12.0 across stratified/clustered, stratified-only, PSU-only and unstratified designs, with and without `where=` zero weights, and identical at 1, 2 and 10 rayon threads — the thread-count invariance the parallelism policy in `estimation/mod.rs` requires.
+
 ## [0.12.0] — 2026-07-24
 
 ### Fixed

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -477,6 +477,35 @@ pub fn scores_mean(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult
     Ok(Float64Chunked::from_slice_options("scores".into(), &scores))
 }
 
+/// `scores_mean` returning the raw score array the variance actually consumes.
+///
+/// `taylor_variance` immediately turns the `Float64Chunked` from `scores_mean`
+/// back into a `Vec<f64>` (`unwrap_or(0.0)` per element), so the Chunked is a
+/// pure round-trip: one copy into an arrow buffer and one copy back out, 2 x 8 MB
+/// at 1M rows. Callers that only need the array skip both. Null positions map to
+/// 0.0 exactly as `taylor_variance` does, so the variance is bit-identical.
+pub fn scores_mean_arr(y: &Float64Chunked, weights: &Float64Chunked) -> PolarsResult<Vec<f64>> {
+    if let Some((ys, ws)) = cont_pair(y, weights) {
+        let mut sum_wy = 0.0f64;
+        let mut sum_w = 0.0f64;
+        for i in 0..ys.len() {
+            sum_wy += ys[i] * ws[i];
+            sum_w += ws[i];
+        }
+        if sum_w == 0.0 {
+            return Err(PolarsError::ComputeError("Sum of weights is zero".into()));
+        }
+        let est = sum_wy / sum_w;
+        return Ok((0..ys.len()).map(|i| (ws[i] / sum_w) * (ys[i] - est)).collect());
+    }
+    // Nulls or chunking: defer to the reference implementation and flatten,
+    // which is exactly what `taylor_variance` did with its result.
+    Ok(scores_mean(y, weights)?
+        .iter()
+        .map(|s| s.unwrap_or(0.0))
+        .collect())
+}
+
 pub fn scores_mean_domain(
     y: &Float64Chunked,
     weights: &Float64Chunked,
@@ -1432,7 +1461,59 @@ pub fn degrees_of_freedom_in_domain(
     // This ensures domain estimation (where non-domain obs have w=0, or are
     // excluded by `domain`) gives the correct df, matching R's degf() on
     // subsetted designs.
-    let active: Vec<bool> = match domain {
+    let active = active_mask(weights, domain);
+
+    // Design columns are resolved to dense first-appearance integer codes,
+    // dispatching on dtype (String hashed, integer densified). The unique
+    // counts below are order-independent, so this is identical to the previous
+    // string-only implementation and to the integer-code fast path.
+    let str_idx = strata.map(design_col_codes).transpose()?;
+    let psu_idx = match (strata, psu) {
+        // PSUs are nested within stratum when stratified (so labels reused
+        // across strata are distinct); plain codes otherwise.
+        (Some(s), Some(p)) => Some(design_pair_codes(s, p)?.0),
+        (None, Some(p)) => Some(design_col_codes(p)?.0),
+        _ => None,
+    };
+
+    Ok(df_from_codes(
+        &active,
+        str_idx.as_ref().map(|(v, n)| (v.as_slice(), *n)),
+        psu_idx.as_deref(),
+    ))
+}
+
+/// Design df from a [`TaylorDesign`]'s already-resolved codes.
+///
+/// `degrees_of_freedom_in_domain` re-derives the strata and (stratum, psu) code
+/// vectors that `build_taylor_design` has just built from the very same columns
+/// — at 1M rows that duplicate densification was ~6.5 ms, a third of the whole
+/// ungrouped kernel. The codes are produced by identical calls
+/// (`design_col_codes` / `design_pair_codes`) on identical inputs, so reusing
+/// them is bit-identical by construction, not merely equivalent.
+pub fn degrees_of_freedom_from_design(
+    weights: &Float64Chunked,
+    design: &TaylorDesign,
+    domain: Option<&BooleanChunked>,
+) -> u32 {
+    if weights.is_empty() {
+        return 0;
+    }
+    let active = active_mask(weights, domain);
+    df_from_codes(
+        &active,
+        design
+            .strata_indices
+            .as_ref()
+            .map(|v| (v.as_slice(), design.n_strata)),
+        design.psu_indices.as_deref(),
+    )
+}
+
+/// Mask of active (positive weight, in-domain) observations. Shared so the
+/// column-driven and design-driven df entry points cannot drift apart.
+fn active_mask(weights: &Float64Chunked, domain: Option<&BooleanChunked>) -> Vec<bool> {
+    match domain {
         None => weights
             .iter()
             .map(|w| w.map_or(false, |v| v > 0.0))
@@ -1442,46 +1523,45 @@ pub fn degrees_of_freedom_in_domain(
             .zip(mask.iter())
             .map(|(w, d)| w.map_or(false, |v| v > 0.0) && d.unwrap_or(false))
             .collect(),
-    };
+    }
+}
 
-    // Design columns are resolved to dense first-appearance integer codes,
-    // dispatching on dtype (String hashed, integer densified). The unique
-    // counts below are order-independent, so this is identical to the previous
-    // string-only implementation and to the integer-code fast path.
+/// The df arithmetic itself, over resolved design codes.
+fn df_from_codes(
+    active: &[bool],
+    strata: Option<(&[u32], u32)>,
+    psu: Option<&[u32]>,
+) -> u32 {
     match (strata, psu) {
         (None, None) => {
             // No strata, no PSU: each obs is its own PSU, df = n_active - 1
             let n_active = active.iter().filter(|&&a| a).count();
-            Ok(n_active.saturating_sub(1) as u32)
+            n_active.saturating_sub(1) as u32
         }
-        (None, Some(psu_col)) => {
+        (None, Some(psu_idx)) => {
             // No strata, with PSU: df = n_unique_active_psus - 1
-            let (psu_idx, _) = design_col_codes(psu_col)?;
             let mut seen: FxHashSet<u32> = FxHashSet::default();
             for (&p, &act) in psu_idx.iter().zip(active.iter()) {
                 if act && p != u32::MAX {
                     seen.insert(p);
                 }
             }
-            Ok(seen.len().saturating_sub(1) as u32)
+            seen.len().saturating_sub(1) as u32
         }
-        (Some(strata_col), None) => {
+        (Some((str_idx, n_strata)), None) => {
             // Stratified, no PSU: df = sum_h(n_active_h - 1)
-            let (str_idx, n_strata) = design_col_codes(strata_col)?;
             let mut counts = vec![0u32; n_strata as usize];
             for (&s, &act) in str_idx.iter().zip(active.iter()) {
                 if act && s != u32::MAX {
                     counts[s as usize] += 1;
                 }
             }
-            Ok(counts.iter().map(|&c| c.saturating_sub(1)).sum())
+            counts.iter().map(|&c| c.saturating_sub(1)).sum()
         }
-        (Some(strata_col), Some(psu_col)) => {
+        (Some((str_idx, n_strata)), Some(psu_idx)) => {
             // Stratified + clustered: df = sum_h(n_active_psus_h - 1), where
             // PSUs are nested within stratum (so labels reused across strata are
             // distinct). psu codes are pair-nested; strata codes give the stratum.
-            let (str_idx, n_strata) = design_col_codes(strata_col)?;
-            let (psu_idx, _) = design_pair_codes(strata_col, psu_col)?;
             let mut stratum_psus: Vec<FxHashSet<u32>> =
                 vec![FxHashSet::default(); n_strata as usize];
             for ((&s, &p), &act) in str_idx.iter().zip(psu_idx.iter()).zip(active.iter()) {
@@ -1489,10 +1569,10 @@ pub fn degrees_of_freedom_in_domain(
                     stratum_psus[s as usize].insert(p);
                 }
             }
-            Ok(stratum_psus
+            stratum_psus
                 .iter()
                 .map(|psus| psus.len().saturating_sub(1) as u32)
-                .sum())
+                .sum()
         }
     }
 }
@@ -2359,5 +2439,71 @@ mod tests {
             SvyQuantileMethod::from_str("unknown"),
             SvyQuantileMethod::Higher
         ); // default
+    }
+
+    /// `degrees_of_freedom_from_design` exists so the ungrouped kernels stop
+    /// densifying the strata/PSU columns a second time just to count df. It has
+    /// to agree with the column-driven entry point on every design shape,
+    /// including the zero-weight rows a `where=` filter produces.
+    #[test]
+    fn test_df_from_design_matches_column_path() {
+        let strata_i = icol("s".into(), &[10, 10, 10, 10, 99, 99, 99, 99]);
+        let psu_i = icol("p".into(), &[7, 7, 3, 3, 7, 7, 3, 3]);
+        let strata_s = scol("s".into(), &["A", "A", "A", "A", "B", "B", "B", "B"]);
+        let psu_s = scol("p".into(), &["1", "1", "2", "2", "1", "1", "2", "2"]);
+
+        let w_all = Float64Chunked::from_slice("w".into(), &[1.0; 8]);
+        // Zero weights: two PSUs drop out, and stratum B loses one entirely.
+        let w_some =
+            Float64Chunked::from_slice("w".into(), &[1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]);
+
+        for (label, strata, psu) in [
+            ("integer codes", Some(&strata_i), Some(&psu_i)),
+            ("string labels", Some(&strata_s), Some(&psu_s)),
+            ("stratified, no psu", Some(&strata_i), None),
+            ("psu, no strata", None, Some(&psu_i)),
+            ("no design", None, None),
+        ] {
+            for (wlabel, w) in [("all positive", &w_all), ("some zero", &w_some)] {
+                let design =
+                    build_taylor_design(strata, psu, None, None, None, None).unwrap();
+                let from_design = degrees_of_freedom_from_design(w, &design, None);
+                let from_cols = degrees_of_freedom(w, strata, psu).unwrap();
+                assert_eq!(
+                    from_design, from_cols,
+                    "df mismatch for {label} / {wlabel}: design path {from_design} \
+                     vs column path {from_cols}"
+                );
+            }
+        }
+    }
+
+    /// `scores_mean_arr` skips the `Float64Chunked` round-trip that
+    /// `taylor_variance` used to undo immediately. It must produce exactly the
+    /// bits that round-trip produced, on both the contiguous fast path and the
+    /// null-bearing fallback.
+    #[test]
+    fn test_scores_mean_arr_matches_chunked_roundtrip() {
+        let w = Float64Chunked::from_slice("w".into(), &[1.0, 2.5, 0.5, 3.0, 1.25]);
+
+        let dense = Float64Chunked::from_slice("y".into(), &[1.0, 2.0, 3.0, 4.0, 5.0]);
+        let with_nulls = Float64Chunked::from_slice_options(
+            "y".into(),
+            &[Some(1.0), None, Some(3.0), Some(4.0), None],
+        );
+
+        for (label, y) in [("contiguous", &dense), ("with nulls", &with_nulls)] {
+            let roundtrip: Vec<f64> = scores_mean(y, &w)
+                .unwrap()
+                .iter()
+                .map(|s| s.unwrap_or(0.0))
+                .collect();
+            let direct = scores_mean_arr(y, &w).unwrap();
+            assert_eq!(
+                roundtrip.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                direct.iter().map(|v| v.to_bits()).collect::<Vec<_>>(),
+                "scores_mean_arr diverged from the chunked round-trip ({label})"
+            );
+        }
     }
 }

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -13,19 +13,20 @@ use crate::estimation::taylor::{
     SvyQuantileMethod,
     build_taylor_design,
     degrees_of_freedom,
+    degrees_of_freedom_from_design,
     degrees_of_freedom_in_domain,
     median_variance_woodruff,
     median_variance_woodruff_domain,
     point_estimate_mean, point_estimate_mean_domain,
     point_estimate_ratio, point_estimate_ratio_domain,
     point_estimate_total, point_estimate_total_domain,
-    scores_mean, scores_mean_domain,
+    scores_mean, scores_mean_arr, scores_mean_domain,
     scores_ratio, scores_ratio_domain,
     scores_total, scores_total_domain,
     srs_variance_mean, srs_variance_mean_domain,
     srs_variance_ratio, srs_variance_ratio_domain,
     srs_variance_total, srs_variance_total_domain,
-    taylor_variance, taylor_variance_apply,
+    taylor_variance_apply,
     weighted_median, weighted_median_domain,
 };
 
@@ -65,12 +66,19 @@ pub fn taylor_mean(
     let df = into_contiguous(data);
 
     if by_col.is_none() {
-        let result = compute_mean_ungrouped(
-            &df, &value_col, &weight_col,
-            strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
-            fpc_col.as_deref(), fpc_ssu_col.as_deref(), singleton_method.as_deref(),
-        )
-        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+        // Detach for the ungrouped path too: `compute_mean_ungrouped` overlaps
+        // the design build with the score pass via `rayon::join`, and holding
+        // the GIL would keep the rayon worker from ever picking up the second
+        // half (see the policy note in estimation/mod.rs).
+        let result = _py
+            .detach(|| {
+                compute_mean_ungrouped(
+                    &df, &value_col, &weight_col,
+                    strata_col.as_deref(), psu_col.as_deref(), ssu_col.as_deref(),
+                    fpc_col.as_deref(), fpc_ssu_col.as_deref(), singleton_method.as_deref(),
+                )
+            })
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
         return Ok(PyDataFrame(result));
     }
 
@@ -117,6 +125,54 @@ pub fn taylor_mean_multi(
     Ok(PyDataFrame(result))
 }
 
+/// Shared skeleton for the ungrouped single-estimate Taylor kernels.
+///
+/// Two overlaps, both free of any effect on the numbers:
+///
+/// 1. Indexing the design (densify strata, nest PSU codes, per-stratum maps)
+///    reads none of the response columns, and the point estimate / scores / SRS
+///    variance read none of the design columns. They run concurrently.
+/// 2. The variance and the df both read the finished design but neither feeds
+///    the other, so they run concurrently too — and taking df from the design's
+///    codes drops the second densification pass over the same columns, which at
+///    1M rows was on its own about a third of the kernel.
+///
+/// Every half is internally unchanged and still accumulates in row order, so the
+/// output is bit-identical and independent of `RAYON_NUM_THREADS`, as
+/// `estimation/mod.rs` requires.
+///
+/// `value_work` returns the score vector plus whatever else the caller needs out
+/// of the response columns.
+fn ungrouped_estimate<T: Send>(
+    weights: &Float64Chunked,
+    strata: Option<&Column>,
+    psu: Option<&Column>,
+    ssu: Option<&Column>,
+    fpc: Option<&Float64Chunked>,
+    fpc_ssu: Option<&Float64Chunked>,
+    singleton_method: Option<&str>,
+    value_work: impl FnOnce() -> PolarsResult<(Vec<f64>, T)> + Send,
+) -> PolarsResult<(f64, u32, T)> {
+    let (design_res, value_res) = rayon::join(
+        || build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method),
+        value_work,
+    );
+    let design = design_res?;
+    let (scores, extra) = value_res?;
+
+    let (variance, df_val) = rayon::join(
+        || taylor_variance_apply(&scores, &design),
+        || degrees_of_freedom_from_design(weights, &design, None),
+    );
+    Ok((variance, df_val, extra))
+}
+
+/// Flatten a score `Float64Chunked` to the array the variance consumes, mapping
+/// nulls to 0.0 exactly as `taylor_variance` did.
+fn scores_to_arr(scores: &Float64Chunked) -> Vec<f64> {
+    scores.iter().map(|s| s.unwrap_or(0.0)).collect()
+}
+
 fn compute_mean_ungrouped(
     df: &DataFrame,
     value_col: &str, weight_col: &str,
@@ -132,14 +188,19 @@ fn compute_mean_ungrouped(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let estimate = point_estimate_mean(y, weights)?;
-    let scores   = scores_mean(y, weights)?;
-    let variance = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
-    let se       = variance.max(0.0).sqrt();
-    let df_val   = degrees_of_freedom(weights, strata, psu)?;
-    let n        = y.len() as u32;
-    let srs_var  = srs_variance_mean(y, weights)?;
-    let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+    let (variance, df_val, (estimate, srs_var)) = ungrouped_estimate(
+        weights, strata, psu, ssu, fpc, fpc_ssu, singleton_method,
+        || {
+            let estimate = point_estimate_mean(y, weights)?;
+            let scores   = scores_mean_arr(y, weights)?;
+            let srs_var  = srs_variance_mean(y, weights)?;
+            Ok((scores, (estimate, srs_var)))
+        },
+    )?;
+
+    let se   = variance.max(0.0).sqrt();
+    let n    = y.len() as u32;
+    let deff = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
 
     df!["y" => vec![value_col], "est" => vec![estimate], "se" => vec![se],
         "var" => vec![variance], "df" => vec![df_val], "n" => vec![n], "deff" => vec![deff]]
@@ -166,8 +227,13 @@ fn compute_mean_multi(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let df_val = degrees_of_freedom(weights, strata, psu)?;
+    // Serial head, previously ~22 ms of a ~35 ms kernel at 1M rows and the whole
+    // reason the batched path stalled well under its available width: the design
+    // was indexed once here and *again* inside `degrees_of_freedom`. Building it
+    // once and deriving df from the same codes roughly halves the head, which is
+    // the term Amdahl's law was multiplying.
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+    let df_val = degrees_of_freedom_from_design(weights, &design, None);
 
     // Resolve every response column to its typed slice BEFORE fanning out.
     // `df.column()` mutates the frame's internal schema cache, so calling it
@@ -183,8 +249,7 @@ fn compute_mean_multi(
         .map(|i| -> PolarsResult<(String, f64, f64, f64, u32, f64)> {
             let y        = y_cols[i];
             let estimate = point_estimate_mean(y, weights)?;
-            let scores   = scores_mean(y, weights)?;
-            let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+            let scores_arr = scores_mean_arr(y, weights)?;
             let variance = taylor_variance_apply(&scores_arr, &design);
             let se       = variance.max(0.0).sqrt();
             let n        = y.len() as u32;
@@ -367,14 +432,19 @@ fn compute_total_ungrouped(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let estimate = point_estimate_total(y, weights)?;
-    let scores   = scores_total(y, weights)?;
-    let variance = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
-    let se       = variance.max(0.0).sqrt();
-    let df_val   = degrees_of_freedom(weights, strata, psu)?;
-    let n        = y.len() as u32;
-    let srs_var  = srs_variance_total(y, weights)?;
-    let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+    let (variance, df_val, (estimate, srs_var)) = ungrouped_estimate(
+        weights, strata, psu, ssu, fpc, fpc_ssu, singleton_method,
+        || {
+            let estimate = point_estimate_total(y, weights)?;
+            let scores   = scores_to_arr(&scores_total(y, weights)?);
+            let srs_var  = srs_variance_total(y, weights)?;
+            Ok((scores, (estimate, srs_var)))
+        },
+    )?;
+
+    let se   = variance.max(0.0).sqrt();
+    let n    = y.len() as u32;
+    let deff = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
 
     df!["y" => vec![value_col], "est" => vec![estimate], "se" => vec![se],
         "var" => vec![variance], "df" => vec![df_val], "n" => vec![n], "deff" => vec![deff]]
@@ -396,8 +466,10 @@ fn compute_total_multi(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let df_val = degrees_of_freedom(weights, strata, psu)?;
+    // Design indexed once; df taken off its codes rather than densifying the
+    // same strata/PSU columns a second time (see `compute_mean_multi`).
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+    let df_val = degrees_of_freedom_from_design(weights, &design, None);
 
     // Hoist column resolution out of the parallel region (see compute_mean_multi).
     let y_cols: Vec<&Float64Chunked> = value_cols
@@ -594,14 +666,19 @@ fn compute_ratio_ungrouped(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let estimate = point_estimate_ratio(y, x, weights)?;
-    let scores   = scores_ratio(y, x, weights)?;
-    let variance = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
-    let se       = variance.max(0.0).sqrt();
-    let df_val   = degrees_of_freedom(weights, strata, psu)?;
-    let n        = y.len() as u32;
-    let srs_var  = srs_variance_ratio(y, x, weights)?;
-    let deff     = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+    let (variance, df_val, (estimate, srs_var)) = ungrouped_estimate(
+        weights, strata, psu, ssu, fpc, fpc_ssu, singleton_method,
+        || {
+            let estimate = point_estimate_ratio(y, x, weights)?;
+            let scores   = scores_to_arr(&scores_ratio(y, x, weights)?);
+            let srs_var  = srs_variance_ratio(y, x, weights)?;
+            Ok((scores, (estimate, srs_var)))
+        },
+    )?;
+
+    let se   = variance.max(0.0).sqrt();
+    let n    = y.len() as u32;
+    let deff = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
 
     df!["y" => vec![numerator_col], "x" => vec![denominator_col], "est" => vec![estimate],
         "se" => vec![se], "var" => vec![variance], "df" => vec![df_val], "n" => vec![n], "deff" => vec![deff]]
@@ -623,8 +700,10 @@ fn compute_ratio_multi(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let df_val = degrees_of_freedom(weights, strata, psu)?;
+    // Design indexed once; df taken off its codes rather than densifying the
+    // same strata/PSU columns a second time (see `compute_mean_multi`).
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+    let df_val = degrees_of_freedom_from_design(weights, &design, None);
 
     // Hoist column resolution out of the parallel region (see compute_mean_multi).
     let y_cols: Vec<&Float64Chunked> = numerator_cols
@@ -843,10 +922,11 @@ fn compute_prop_ungrouped(
     let mut dfs_vec: Vec<u32> = Vec::new();
     let mut ns: Vec<u32> = Vec::new();
     let mut deffs: Vec<f64> = Vec::new();
-    let df_val = degrees_of_freedom(weights, strata, psu)?;
     let n = weights.len() as u32;
-    // Design is identical across levels; index it once.
+    // Design is identical across levels; index it once — and take the df off its
+    // codes rather than densifying the same columns a second time.
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+    let df_val = degrees_of_freedom_from_design(weights, &design, None);
 
     for lvl in &levels {
         let indicator: Vec<Option<f64>> = value_str.iter()
@@ -896,9 +976,10 @@ fn compute_prop_multi(
     let fpc    = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
     let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
 
-    let df_val = degrees_of_freedom(weights, strata, psu)?;
     let n = weights.len() as u32;
+    // Design indexed once; df taken off its codes (see `compute_mean_multi`).
     let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+    let df_val = degrees_of_freedom_from_design(weights, &design, None);
 
     // Hoist String-cast + level enumeration out of the parallel region: keep the
     // owned casted columns alive, borrow their StringChunked, and precompute each

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,29 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **Taylor estimation uses the cores it is given.** On a 10-core machine at 1M rows a single-variable mean used 1.15 cores and an 8-variable batched mean reached 1.8 of a possible 8. None of it was a rayon width problem — three pieces of redundant *serial* work sat around the fan-out, and removing them is what freed the parallelism:
+
+  - `sample.estimation` returned a **new `Estimation` on every attribute access**, so the `_data_version`-keyed caches it carries — the factorized design arrays and prepared design info — were discarded before they could ever be reused, and every `sample.estimation.mean(...)` re-derived the whole design. The accessor is now retained per `Sample`. Derived samples are handled by an identity check: `_replace_data` forks with `copy.copy`, which carries the cached accessor over verbatim, and without the check a fork would answer with an `Estimation` still bound to its parent's data.
+  - The reporting metadata on each `Estimate` (unique stratum labels, PSU count) was computed with `np.unique` over the **full-length** design arrays *per estimate*. A batched call produces one `Estimate` per variable, so an 8-variable mean did 16 full-length passes — **63% of that call's wall time** at 1M rows, all serial. These are properties of the design, not of the variable, so they are memoised on the design cache and invalidate with it.
+  - The Rust kernels stopped indexing the design twice per estimate and now overlap their independent halves — see [`svy-rs`](../svy-rs/CHANGELOG.md).
+
+  Measured on a 10-core M1 Max at 1M rows, 50 strata, 2000 PSUs:
+
+  | case | before | after | speedup | cores used |
+  | --- | ---: | ---: | ---: | --- |
+  | mean, 1 variable | 70.9 ms | 22.4 ms | 3.2× | 1.15 → 1.60 |
+  | total, 1 variable | 83.8 ms | 27.4 ms | 3.1× | 1.12 → 1.86 |
+  | mean, 8 batched | 163.2 ms | 38.6 ms | 4.2× | 1.78 → 3.47 |
+  | mean by group | 144.4 ms | 131.9 ms | 1.1× | 3.45 → 3.46 |
+
+  Thread scaling from 1 to 10 threads went from 1.11× to 1.54× for a single variable and 1.58× to 3.03× for the batched call. A single estimate overlaps two halves rather than fanning out, so its ceiling is ~2× by construction.
+
+  **Estimates, standard errors and degrees of freedom are unchanged** — bit-for-bit, and identical at 1, 2 and 10 threads.
+
+  One trade-off worth knowing: retaining the accessor means its cached design arrays (~31 B/row) stay alive as long as the `Sample` rather than being freed between calls. **Peak memory is unchanged** — those arrays were rebuilt on every call before, so the high-water mark was always there (2433.8 MB before vs 2434.5 MB after, over six calls at 10M rows). What is new is that a long-lived process holding many large `Sample` objects idle now holds their design caches too.
+
 ## [0.22.0] — 2026-08-02
 
 **svy labels values so results print nicely. That is the whole job.** Everything that made

--- a/packages/svy/benchmarks/bench_taylor_scaling.py
+++ b/packages/svy/benchmarks/bench_taylor_scaling.py
@@ -1,0 +1,227 @@
+# benchmarks/bench_taylor_scaling.py
+"""Check that Taylor estimation actually uses the cores it is given.
+
+Taylor kernels have plenty of independent work — by-group cells, batched
+variables, and (within one estimate) a design build that shares nothing with the
+score pass. What limited them was not rayon width but redundant *serial* work
+around the fan-out: the design was indexed twice per call, the factorized design
+was rebuilt on every ``sample.estimation`` access, and per-estimate reporting
+metadata ran ``np.unique`` over full-length design arrays once per variable.
+
+Two things are measured here, because either alone is misleading:
+
+* **cores used** — process CPU time (which sums rayon's threads) over wall time.
+  Useful, but it *falls* when redundant parallel work is deleted, so it can only
+  be read next to wall time.
+* **thread scaling** — wall time at 1 thread over wall time at N. This is the
+  property that actually breaks when a kernel silently goes serial (a missing
+  ``Python::detach``, a reduction moved back onto one thread), and it is what
+  this benchmark asserts on.
+
+Scaling is measured in subprocesses with ``RAYON_NUM_THREADS`` and
+``POLARS_MAX_THREADS`` pinned, since both pools are fixed at first use.
+
+Usage:
+    python benchmarks/bench_taylor_scaling.py
+    python benchmarks/bench_taylor_scaling.py --rows 1000000
+    python benchmarks/bench_taylor_scaling.py --skip-scaling   # utilisation only
+
+Exits non-zero if any case scales worse than ``--min-speedup``, so it can be
+wired into CI as a coarse guard.
+"""
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+import time
+
+import numpy as np
+import polars as pl
+
+import svy
+
+
+SEED = 20260804
+N_STRATA = 50
+PSU_PER_STRATUM = 40
+N_Y_VARS = 8
+Y_VARS = [f"y{j}" for j in range(N_Y_VARS)]
+ROWS = 1_000_000
+TIMING_REPS = 7
+WARMUP = 2
+
+# Floors, not targets. Measured on a 10-core M1 Max after the fan-out fixes:
+# single-variable 1.48x, batched 2.93x, by-group 3.56x. The floors sit well
+# under those so ordinary machine noise cannot trip them, while a kernel that
+# regresses to serial (1.0x) fails loudly.
+MIN_SPEEDUP = {
+    # A single estimate overlaps two halves (design build vs score pass), so its
+    # ceiling is ~2x by construction — not a sign of a missing fan-out.
+    "mean_1": 1.20,
+    "mean_8": 2.00,
+    "mean_by": 2.50,
+}
+
+
+def make_sample(n_rows: int) -> svy.Sample:
+    """A stratified two-stage sample, unequal weights, cluster random effect."""
+    rng = np.random.default_rng(SEED)
+    n_psu = N_STRATA * PSU_PER_STRATUM
+    # Contiguous PSU blocks that always cover exactly n_rows.
+    psu = (np.arange(n_rows, dtype=np.int64) * n_psu) // n_rows
+    stratum = psu // PSU_PER_STRATUM
+    psu_effect = rng.normal(0.0, 1.0, size=n_psu)[psu]
+
+    x = rng.normal(10.0, 3.0, size=n_rows)
+    data = {
+        "stratum": stratum,
+        "psu": psu,
+        "wgt": np.exp(rng.normal(0.0, 0.4, size=n_rows)) * (10.0 + stratum % 7),
+        "x": x,
+        "grp": rng.integers(0, 12, size=n_rows),
+    }
+    for j in range(N_Y_VARS):
+        data[f"y{j}"] = 2.0 * x + 5.0 * psu_effect + rng.normal(0.0, 4.0, size=n_rows) + j
+
+    df = pl.DataFrame(data)
+    return svy.Sample(df, svy.Design(stratum="stratum", psu="psu", wgt="wgt"))
+
+
+def cases(sample: svy.Sample) -> dict:
+    return {
+        "mean_1": ("Taylor mean, 1 variable", lambda: sample.estimation.mean("y0")),
+        "total_1": ("Taylor total, 1 variable", lambda: sample.estimation.total("y0")),
+        "mean_8": ("Taylor mean, 8 batched", lambda: sample.estimation.mean(Y_VARS)),
+        "mean_by": ("Taylor mean by group", lambda: sample.estimation.mean("y0", by="grp")),
+    }
+
+
+def measure(fn, reps: int = TIMING_REPS) -> tuple[float, float]:
+    """Median wall and CPU seconds. CPU sums every in-process thread, rayon's included."""
+    for _ in range(WARMUP):
+        fn()
+    walls, cpus = [], []
+    for _ in range(reps):
+        w0, c0 = time.perf_counter(), time.process_time()
+        fn()
+        walls.append(time.perf_counter() - w0)
+        cpus.append(time.process_time() - c0)
+    return statistics.median(walls), statistics.median(cpus)
+
+
+# ── child process: one case, one pinned thread count ─────────────────────────
+
+
+def _run_pinned() -> None:
+    """Entry point for the scaling subprocesses. Prints a single wall time."""
+    n_rows = int(os.environ["BENCH_ROWS"])
+    case = os.environ["BENCH_CASE"]
+    sample = make_sample(n_rows)
+    _, fn = cases(sample)[case]
+    wall, _ = measure(fn)
+    print(json.dumps({"wall_s": wall}))
+
+
+def thread_scaling(n_rows: int, case: str, threads: list[int]) -> list[float]:
+    """Wall time for ``case`` at each pinned thread count, via subprocesses."""
+    walls = []
+    for t in threads:
+        env = dict(
+            os.environ,
+            BENCH_ROWS=str(n_rows),
+            BENCH_CASE=case,
+            BENCH_CHILD="1",
+            RAYON_NUM_THREADS=str(t),
+            POLARS_MAX_THREADS=str(t),
+        )
+        out = subprocess.run(
+            [sys.executable, os.path.abspath(__file__)],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        if out.returncode != 0:
+            raise RuntimeError(
+                f"scaling child failed for {case} at {t} threads:\n{out.stderr[-2000:]}"
+            )
+        walls.append(json.loads(out.stdout.strip().splitlines()[-1])["wall_s"])
+    return walls
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--rows", type=int, default=ROWS)
+    ap.add_argument(
+        "--min-speedup",
+        type=float,
+        default=None,
+        help="override the per-case scaling floor (default: built-in per case)",
+    )
+    ap.add_argument("--skip-scaling", action="store_true")
+    args = ap.parse_args()
+
+    n_cores = os.cpu_count() or 1
+    sample = make_sample(args.rows)
+
+    print(
+        f"n = {args.rows:,} rows, {N_STRATA} strata, "
+        f"{N_STRATA * PSU_PER_STRATUM} PSUs, {n_cores} cores\n"
+    )
+
+    print("utilisation (cores = CPU time / wall time; read next to wall):")
+    print(f"  {'case':<26} {'wall':>10} {'cpu':>10} {'cores':>7}")
+    for key, (label, fn) in cases(sample).items():
+        wall, cpu = measure(fn)
+        print(f"  {label:<26} {wall * 1e3:9.1f}m {cpu * 1e3:9.1f}m {cpu / wall:7.2f}")
+
+    if args.skip_scaling:
+        return 0
+
+    if n_cores < 4:
+        print(f"\nskipping scaling: needs >= 4 cores, this machine has {n_cores}")
+        return 0
+
+    top = min(n_cores, 10)
+    threads = [1, top]
+    print(f"\nthread scaling (1 thread vs {top}):")
+    print(f"  {'case':<26} {'1 thr':>10} {f'{top} thr':>10} {'speedup':>9} {'floor':>7}")
+
+    failures = []
+    for key in ("mean_1", "mean_8", "mean_by"):
+        label = cases(sample)[key][0]
+        walls = thread_scaling(args.rows, key, threads)
+        speedup = walls[0] / walls[-1]
+        floor = args.min_speedup if args.min_speedup is not None else MIN_SPEEDUP[key]
+        ok = speedup >= floor
+        print(
+            f"  {label:<26} {walls[0] * 1e3:9.1f}m {walls[-1] * 1e3:9.1f}m "
+            f"{speedup:8.2f}x {floor:6.2f}x {'' if ok else '  <-- REGRESSION'}"
+        )
+        if not ok:
+            failures.append((label, speedup, floor))
+
+    if failures:
+        print("\nFAILED — these cases are not using the cores they were given:")
+        for label, speedup, floor in failures:
+            print(f"  {label}: {speedup:.2f}x vs floor {floor:.2f}x")
+        print(
+            "\nA case that drops to ~1.0x has gone serial. The usual causes are a "
+            "PyO3 entry point that stopped releasing the GIL (`Python::detach`), or "
+            "serial work added ahead of the fan-out — indexing the design twice, "
+            "rebuilding the factorized design per call, or per-estimate work that "
+            "scales with the variable count."
+        )
+        return 1
+
+    print("\nOK — every case scales above its floor.")
+    return 0
+
+
+if __name__ == "__main__":
+    if os.environ.get("BENCH_CHILD"):
+        _run_pinned()
+    else:
+        sys.exit(main())

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -807,7 +807,24 @@ class Sample:
     def estimation(self) -> Estimation:
         from svy.estimation import Estimation
 
-        return Estimation(self)
+        # Retain the instance. `Estimation` carries caches of the factorized
+        # design (stratum/PSU code arrays, unique-label metadata, prepared design
+        # info) that are already guarded on `_data_version`, but handing out a
+        # fresh object per attribute access threw them away before they could
+        # ever be reused — so every `sample.estimation.mean(...)` re-derived the
+        # whole design. Those caches invalidate themselves whenever
+        # `__setattr__` bumps `_data_version` on a data/design rebind, so a
+        # retained instance can never serve stale arrays.
+        #
+        # The identity check is what makes this safe across forks: `_replace_data`
+        # builds a derived Sample with `copy.copy`, which carries this `__dict__`
+        # entry over verbatim. Without the check the fork would answer with an
+        # `Estimation` still bound to its parent, and estimate the parent's data.
+        est = self.__dict__.get("_estimation_api")
+        if est is None or est._sample is not self:
+            est = Estimation(self)
+            self.__dict__["_estimation_api"] = est
+        return est
 
     @property
     def categorical(self) -> Categorical:

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -985,25 +985,53 @@ class Estimation:
         else:
             estimate.estimates = est_list
         d_cache = self._get_factorized_design()
-        if d_cache["stratum"] is not None:
+        strata_labels = self._design_strata_labels(d_cache)
+        if strata_labels is not None:
+            # Copy: the memo is shared by every Estimate built off this design,
+            # and the attribute is a plain mutable list on a user-facing object.
+            estimate.strata = list(strata_labels)
+            estimate.n_strata = len(strata_labels)
+        n_psus = self._design_n_psus(d_cache)
+        if n_psus is not None:
+            estimate.n_psus = n_psus
+        return estimate
+
+    # The two helpers below exist only to populate reporting metadata, but they
+    # run per *estimate*. Batched calls produce one Estimate per variable, so an
+    # 8-variable mean() was doing 16 `np.unique` passes over the full-length
+    # design arrays — 63% of that call's wall time at 1M rows, and entirely
+    # serial, which is what held the batched path near 1.8 cores. The unique
+    # strata and PSU count are properties of the design, not of the variable, so
+    # they are memoised on the design cache (already keyed on `_data_version`,
+    # so they invalidate exactly when the design arrays do).
+
+    @staticmethod
+    def _design_strata_labels(d_cache: dict[str, Any]) -> list[Any] | None:
+        """Sorted unique stratum labels, or None when the design is unstratified."""
+        if d_cache["stratum"] is None:
+            return None
+        if "_strata_labels" not in d_cache:
             strata_info = d_cache["stratum"]
             if isinstance(strata_info, tuple) and strata_info[1] is not None:
-                estimate.strata = strata_info[1]
-                estimate.n_strata = len(strata_info[1])
+                d_cache["_strata_labels"] = strata_info[1]
             else:
                 arr = strata_info[0] if isinstance(strata_info, tuple) else strata_info
-                estimate.strata = np.unique(arr).tolist()
-                estimate.n_strata = len(estimate.strata)
-        if d_cache["psu"] is not None:
+                d_cache["_strata_labels"] = np.unique(arr).tolist()
+        return d_cache["_strata_labels"]
+
+    @staticmethod
+    def _design_n_psus(d_cache: dict[str, Any]) -> int | None:
+        """Number of distinct PSUs, falling back to the row count when no PSU is set."""
+        if d_cache["psu"] is None:
+            return len(d_cache["wgt"]) if d_cache["wgt"] is not None else None
+        if "_n_psus" not in d_cache:
             psu_info = d_cache["psu"]
             if isinstance(psu_info, tuple) and psu_info[1] is not None:
-                estimate.n_psus = len(psu_info[1])
+                d_cache["_n_psus"] = len(psu_info[1])
             else:
                 arr = psu_info[0] if isinstance(psu_info, tuple) else psu_info
-                estimate.n_psus = len(np.unique(arr))
-        elif d_cache["wgt"] is not None:
-            estimate.n_psus = len(d_cache["wgt"])
-        return estimate
+                d_cache["_n_psus"] = len(np.unique(arr))
+        return d_cache["_n_psus"]
 
     @staticmethod
     def _normalize_method(method: str | None) -> Literal["taylor", "replication"] | None:

--- a/packages/svy/tests/svy/estimation/test_taylor_parallelism.py
+++ b/packages/svy/tests/svy/estimation/test_taylor_parallelism.py
@@ -1,0 +1,199 @@
+# tests/svy/estimation/test_taylor_parallelism.py
+"""Guard the work-elimination that lets the Taylor kernels use more than one core.
+
+Single-variable Taylor estimation used ~1.15 cores of 10 at 1M rows, and the
+8-variable batched call reached only ~1.8 of a possible 8. Neither was a rayon
+width problem. Three pieces of redundant *serial* work dominated, and each one
+is a structural property that can be asserted without timing anything:
+
+1. The design was indexed twice per call — once in ``build_taylor_design`` and
+   again inside ``degrees_of_freedom``, which re-densified the same stratum and
+   PSU columns. That is Rust-side and is covered by ``svy-rs``'s own tests; what
+   is observable here is the consequence, below.
+
+2. ``sample.estimation`` returned a *new* ``Estimation`` on every attribute
+   access, so its ``_data_version``-keyed design cache was discarded before it
+   could ever be reused and every call re-derived the factorized design.
+
+3. The reporting metadata on each ``Estimate`` (unique strata, PSU count) was
+   computed with ``np.unique`` over the full-length design arrays *per
+   estimate*. A batched call produces one ``Estimate`` per variable, so an
+   8-variable mean did 16 full-length ``np.unique`` passes — 63% of that call's
+   wall time at 1M rows, all of it serial.
+
+These tests assert the structural invariants (work must not repeat per call, and
+must not grow with the number of variables) rather than wall-clock time, which is
+too noisy for CI. Timing lives in ``benchmarks/bench_taylor_scaling.py``.
+"""
+
+import numpy as np
+import polars as pl
+import pytest
+
+import svy
+
+
+N_ROWS = 20_000
+N_STRATA = 10
+PSU_PER_STRATUM = 20
+Y_VARS = [f"y{j}" for j in range(8)]
+
+
+def _make_sample(n_rows: int = N_ROWS) -> svy.Sample:
+    """A stratified two-stage sample with integer design columns."""
+    rng = np.random.default_rng(20260804)
+    n_psu = N_STRATA * PSU_PER_STRATUM
+    psu = (np.arange(n_rows, dtype=np.int64) * n_psu) // n_rows
+    data = {
+        "stratum": psu // PSU_PER_STRATUM,
+        "psu": psu,
+        "wgt": rng.uniform(5.0, 20.0, size=n_rows),
+        "x": rng.normal(20.0, 4.0, size=n_rows),
+        "grp": rng.integers(0, 4, size=n_rows),
+    }
+    for j in range(len(Y_VARS)):
+        data[f"y{j}"] = rng.normal(10.0 + j, 3.0, size=n_rows)
+    df = pl.DataFrame(data)
+    return svy.Sample(df, svy.Design(stratum="stratum", psu="psu", wgt="wgt"))
+
+
+@pytest.fixture
+def count_unique(monkeypatch):
+    """Count ``np.unique`` calls made on full-length arrays."""
+    counter = {"n": 0}
+    original = np.unique
+
+    def counting_unique(arr, *args, **kwargs):
+        if getattr(arr, "size", 0) >= N_ROWS:
+            counter["n"] += 1
+        return original(arr, *args, **kwargs)
+
+    monkeypatch.setattr("svy.estimation.base.np.unique", counting_unique, raising=True)
+    return counter
+
+
+# ── 2. The estimation accessor must not throw away its design cache ──────────
+
+
+def test_estimation_accessor_is_retained():
+    """Repeated access returns the same object, so its caches survive."""
+    sample = _make_sample()
+    assert sample.estimation is sample.estimation
+
+
+def test_design_is_factorized_once_across_calls(monkeypatch):
+    """The factorized design is derived once per sample, not once per call."""
+    sample = _make_sample()
+    est = sample.estimation
+
+    calls = {"n": 0}
+    original = type(est)._get_factorized_design
+
+    def counting(self):
+        # Count only the cache *misses* — the rebuilds are the cost.
+        if self._design_cache is None or (
+            self._design_cache["_data_version"] != self._sample._data_version
+        ):
+            calls["n"] += 1
+        return original(self)
+
+    monkeypatch.setattr(type(est), "_get_factorized_design", counting)
+
+    for _ in range(5):
+        sample.estimation.mean("y0")
+
+    assert calls["n"] == 1, (
+        f"factorized design rebuilt {calls['n']}x over 5 calls; it is keyed on "
+        "_data_version and the data never changed, so it must be built once"
+    )
+
+
+def test_derived_sample_does_not_inherit_parent_estimation():
+    """A fork must not answer with an Estimation still bound to its parent.
+
+    ``_replace_data`` builds derived samples with ``copy.copy``, which carries
+    the cached accessor across verbatim. Without an identity check the fork
+    would estimate the parent's data.
+    """
+    sample = _make_sample()
+    parent_est = sample.estimation
+    assert parent_est._sample is sample
+
+    derived = sample._replace_data(sample._data.head(N_ROWS // 2))
+    assert derived.estimation is not parent_est
+    assert derived.estimation._sample is derived
+
+    # And it must actually see the smaller frame: half the rows is half the PSUs,
+    # which is exactly the memoised metadata that would go stale if it did not.
+    n_psu = N_STRATA * PSU_PER_STRATUM
+    assert sample.estimation.mean("y0").n_psus == n_psu
+    assert derived.estimation.mean("y0").n_psus == n_psu // 2
+
+
+# ── 3. Per-estimate metadata must not scale with the variable count ──────────
+
+
+def test_metadata_unique_does_not_grow_with_variable_count(count_unique):
+    """Unique strata/PSU labels are design properties, not per-variable ones."""
+    sample = _make_sample()
+
+    sample.estimation.mean("y0")
+    one_var = count_unique["n"]
+
+    # Fresh sample so the memo starts cold again for the batched call.
+    sample2 = _make_sample()
+    count_unique["n"] = 0
+    sample2.estimation.mean(Y_VARS)
+    eight_vars = count_unique["n"]
+
+    assert eight_vars == one_var, (
+        f"{eight_vars} full-length np.unique passes for 8 variables vs "
+        f"{one_var} for 1; the design's unique strata and PSU count do not "
+        "depend on the variable being estimated"
+    )
+    assert one_var <= 2, (
+        f"{one_var} full-length np.unique passes for a single estimate; expected "
+        "at most one for strata and one for PSUs"
+    )
+
+
+def test_metadata_is_not_recomputed_across_calls(count_unique):
+    """The memo survives between calls on the same sample."""
+    sample = _make_sample()
+    sample.estimation.mean("y0")
+    after_first = count_unique["n"]
+
+    for _ in range(4):
+        sample.estimation.mean("y0")
+
+    assert count_unique["n"] == after_first, (
+        f"{count_unique['n'] - after_first} extra np.unique passes over 4 repeat "
+        "calls; the design did not change, so the metadata must be memoised"
+    )
+
+
+def test_metadata_invalidates_when_data_changes():
+    """A memo must never outlive the design arrays it was derived from."""
+    sample = _make_sample()
+    first = sample.estimation.mean("y0")
+    assert first.n_strata == N_STRATA
+
+    # Keep only the first two strata; the memo must not report the old count.
+    smaller = sample._replace_data(sample._data.filter(pl.col("stratum") < 2))
+    second = smaller.estimation.mean("y0")
+    assert second.n_strata == 2
+    assert sorted(second.strata) == [0, 1]
+
+
+def test_estimate_strata_lists_are_independent():
+    """Each Estimate owns its strata list; the shared memo must not be aliased."""
+    sample = _make_sample()
+    estimates = sample.estimation.mean(Y_VARS)
+
+    first, second = estimates[0], estimates[1]
+    assert first.strata == second.strata
+    assert first.strata is not second.strata
+
+    first.strata.append("mutated")
+    assert "mutated" not in second.strata
+    assert "mutated" not in sample.estimation.mean("y0").strata


### PR DESCRIPTION
Taylor estimation used a fraction of the cores available to it. On a 10-core M1 Max at 1M rows a single-variable mean ran at **1.15 cores** and an 8-variable batched mean reached **1.8 of a possible 8**, while the by-group path — already parallelised with the GIL released — reached 3.4.

None of it was a rayon width problem. Three pieces of redundant **serial** work sat around the fan-out.

## Where the time went

Profiling a single-variable mean at 1M rows over 2000 PSUs: 75% of wall time in the Rust kernel, which broke down as

| stage | ms | |
| --- | ---: | --- |
| `build_taylor_design` | 11.0 | densify strata + nested PSU codes |
| `degrees_of_freedom` | 11.3 | **re-densifies the same two columns** |
| `taylor_variance_apply` | 4.9 | the actual accumulation |
| `srs_variance_mean` | 3.4 | |
| scores → `Vec<f64>` copy | 2.2 | a round-trip that only gets undone |
| `scores_mean` + point estimate | 2.6 | |

**63% of the kernel was design indexing done twice.** `degrees_of_freedom` re-derived the stratum codes and nested (stratum, PSU) codes that `build_taylor_design` had just built, from the same columns via the same calls.

The batched path was capped by something else again: per-estimate reporting metadata ran `np.unique` over the **full-length** design arrays once per `Estimate`, so an 8-variable call did 16 full-length passes — **63% of that call's wall time**, entirely serial.

## What changed

- **`degrees_of_freedom_from_design`** takes the df off the design's own code vectors. The codes come from identical calls on identical inputs, so the df is bit-identical *by construction*, not merely equivalent. Applied to the ungrouped and batched mean, total, ratio and prop kernels.
- **The ungrouped kernels overlap their independent halves** under `rayon::join` — the design build shares nothing with the point estimate/scores/SRS pass, and the variance and df both read the finished design without feeding each other. The ungrouped entry points now release the GIL, which `taylor_mean`'s ungrouped branch never did.
- **`scores_mean_arr`** skips a score-vector round-trip that existed only to be undone (2 × 8 MB at 1M rows).
- **`sample.estimation` is retained per `Sample`.** It returned a *new* `Estimation` on every attribute access, so its `_data_version`-keyed design caches were discarded before they could ever be reused — the version check was effectively dead code. Guarded by an identity check, because `_replace_data` forks with `copy.copy` and would otherwise hand a fork an `Estimation` still bound to its parent's data.
- **Per-estimate metadata is memoised** on the design cache, and invalidates with it.

## Results

| case | before | after | speedup | cores used |
| --- | ---: | ---: | ---: | --- |
| mean, 1 variable | 70.9 ms | 22.4 ms | **3.2×** | 1.15 → 1.60 |
| total, 1 variable | 83.8 ms | 27.4 ms | **3.1×** | 1.12 → 1.86 |
| mean, 8 batched | 163.2 ms | 38.6 ms | **4.2×** | 1.78 → 3.47 |
| mean by group | 144.4 ms | 131.9 ms | 1.1× | 3.45 → 3.46 |

Thread scaling 1→10: 1.11× → 1.54× single-variable, 1.58× → 3.03× batched. A single estimate overlaps two halves rather than fanning out, so ~2× is its ceiling by construction.

## Correctness

**Numerically inert.** Estimates, SEs, variances and df are bit-for-bit identical to the pre-change build across stratified/clustered, stratified-only, PSU-only and unstratified designs, with and without `where=` zero weights — and identical at 1, 2 and 10 rayon threads, the thread-count invariance the policy note in `estimation/mod.rs` requires.

2808 Python tests and 80 Rust tests pass.

## What was deliberately left alone

The per-stratum/per-PSU accumulation was measured as a parallelisation candidate and rejected for now:

- The per-stratum reduction over 50 strata is **0.001 ms** — fanning out over strata buys nothing.
- The 1M-row scatter-add into per-PSU totals is 3.5 ms, but splitting it over arbitrary row chunks reorders the additions inside any PSU straddling a chunk edge, and was **confirmed to produce different bits**. Splitting on PSU boundaries is bit-exact and 2.7× including the one-pass grouping check it needs — worth ~2.3 ms of what is now a ~20 ms kernel. A follow-up, not this PR.

The median kernels still double-index; their design is built inside the Woodruff variance and is not available to reuse. They are sort-bound, so the share is smaller.

## Trade-off

Retaining the accessor keeps its cached design arrays (~31 B/row) alive between calls rather than freeing them after each. **Peak memory is unchanged** — those arrays were rebuilt on every call before, so the high-water mark was always there (2433.8 MB before vs 2434.5 MB after, over six calls at 10M rows). What is new is that a long-lived process holding many large idle `Sample` objects now holds their design caches too.

## Testing

Two parts:

- `test_taylor_parallelism.py` asserts the **structural** invariants — work must not repeat per call, and must not grow with the variable count — rather than wall-clock, which is too noisy for CI. **4 of its 7 tests fail on the previous code.**
- `benchmarks/bench_taylor_scaling.py` reports core utilisation and asserts thread scaling against per-case floors, exiting non-zero on regression. **Fails on the previous code** (1.11× against a 1.20× floor, 1.58× against 2.00×).

It asserts on *scaling* rather than cores-used deliberately: cores-used **falls** when redundant parallel work is deleted, so it is misleading read alone.

## Release

Needs **svy-rs 0.12.1** (Rust kernels changed). A patch is the right level precisely because the change is bit-identical — `svy` pins `svy-rs>=0.12.0,<0.13.0`, so 0.12.1 reaches existing installs as a pure speedup. Ships in the **svy 0.22.1** release PR alongside #113.