### PR TITLE
release: svy 0.22.1, svy-rs 0.12.1

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.12.1] — 2026-08-04
+
 ### Changed
 
 - **A Taylor estimate indexes its design once instead of twice.** `degrees_of_freedom` re-derived the stratum codes and nested (stratum, PSU) codes that `build_taylor_design` had just built, from the same columns via the same calls — two full densification passes over the design columns per estimate. At 1M rows over 2000 PSUs that was 11.3 ms on top of the design build's 11.0 ms, i.e. **63% of a 35 ms kernel spent indexing the same two columns twice.** A new `degrees_of_freedom_from_design` takes the df off the design's own code vectors; because those codes come from identical calls on identical inputs, the df is bit-identical by construction rather than merely equivalent. Applied to the ungrouped and batched mean, total, ratio and proportion kernels. The median kernels still double-index — their design is built inside the Woodruff variance and is not available to reuse — but they are sort-bound, so the share is smaller.
@@ -73,7 +75,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 Baseline for this changelog. For earlier history, see the [Git tags](https://github.com/samplics-org/svy/tags).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.12.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.12.1...HEAD
+[0.12.1]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.12.1
 [0.12.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.12.0
 [0.11.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.11.0
 [0.10.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.10.0

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -3562,7 +3562,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svy_rs"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "ahash",
  "approx",

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svy_rs"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2024"
 repository = "https://gitlab.com/samplics/svy"
 homepage = "https://gitlab.com/samplics/svy"

--- a/packages/svy-rs/pyproject.toml
+++ b/packages/svy-rs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy_rs"
-version = "0.12.0"
+version = "0.12.1"
 description = "Internal Rust extension for the svy package. Do not depend on this directly."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.22.1] — 2026-08-04
+
 ### Changed
 
 - **Taylor estimation uses the cores it is given.** On a 10-core machine at 1M rows a single-variable mean used 1.15 cores and an 8-variable batched mean reached 1.8 of a possible 8. None of it was a rayon width problem — three pieces of redundant *serial* work sat around the fan-out, and removing them is what freed the parallelism:
@@ -308,7 +310,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.22.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.22.1...HEAD
+[0.22.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.22.1
 [0.22.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.22.0
 [0.21.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.21.0
 [0.20.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.20.1

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.22.0"
+version = "0.22.1"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -26,7 +26,7 @@ dependencies = [
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
   "svy-io>=0.2.0,<0.3.0",
-  "svy-rs>=0.12.0,<0.13.0",
+  "svy-rs>=0.12.1,<0.13.0",
 ]
 
 [project.urls]

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -128,7 +128,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.22.0"
+__version__ = "0.22.1"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.22.0"
+version = "0.22.1"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },
@@ -2431,7 +2431,7 @@ dev = [
 
 [[package]]
 name = "svy-rs"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "packages/svy-rs" }
 dependencies = [
     { name = "polars", extra = ["pyarrow"] },


### PR DESCRIPTION
Promotes both `[Unreleased]` sections and bumps versions. Two perf changes ship, neither of which moves a number:

- **#114** — `svy-rs` stops indexing the Taylor design twice per estimate and overlaps the design build with the score pass
- **#113** — the Python prep layer stops paying O(B²) column lookups in the replicate count `B`

## Why both are patches

Neither adds, removes or changes public API, and neither changes a result. Estimates, standard errors, variances and degrees of freedom are **bit-for-bit identical to 0.22.0** across stratified/clustered, stratified-only, PSU-only and unstratified designs, with and without `where=` zero weights — and identical at 1, 2 and 10 rayon threads, the invariance the policy note in `estimation/mod.rs` requires.

A patch on `svy-rs` is safe here for the exact reason 0.11.1 was not. svy 0.22.0 pins `svy-rs>=0.12.0,<0.13.0`, so a 0.12.1 reaches every existing install on its next sync — which is precisely why b356d59 refused a patch back when the change moved domain df, `by=` confidence intervals and deff. This change moves nothing, so reaching those installs delivers a pure speedup.

## On the pin

`svy`'s floor moves to `svy-rs>=0.12.1,<0.13.0`, so a 0.22.1 install cannot resolve an extension older than the one it was built and verified against.

Worth being explicit, since it is easy to read the opposite intent into it: **this does not gate the extension change behind an svy upgrade, and is not meant to.** svy 0.22.0's published range already admits 0.12.1, and nothing in 0.22.1's metadata can retract that. Gating would have required `svy-rs` 0.13.0, outside 0.22.0's `<0.13.0` bound.

## Version strings

Six move, not four:

| file | from | to |
| --- | --- | --- |
| `packages/svy-rs/Cargo.toml` | 0.12.0 | 0.12.1 |
| `packages/svy-rs/pyproject.toml` | 0.12.0 | 0.12.1 |
| `packages/svy/pyproject.toml` | 0.22.0 | 0.22.1 |
| `packages/svy/src/svy/__init__.py` | 0.22.0 | 0.22.1 |
| `packages/svy-rs/Cargo.lock` | 0.12.0 | 0.12.1 |
| `uv.lock` (both members) | — | — |

Both `svy-rs` strings move together: `Cargo.toml` for the crate and `pyproject.toml` for the Python distribution. maturin reads the latter, so bumping only `Cargo.toml` would leave the version the pin resolves against untouched.

`__version__` in `svy/__init__.py` is the second svy version string and `uv build` does not touch it — it is the one that still said `0.21.1` after the 0.22.0 pyproject bump.

`uv.lock` was edited to those two member versions by hand rather than regenerated: a local `uv lock` also rewrote unrelated `python_full_version` markers on ipython's dependencies, which does not belong in a release. `uv lock --check` and `uv sync --frozen` both pass on the result.

## Verification

Run locally against this branch:

- `svy-rs` builds clean; wheel is `svy_rs-0.12.1`
- **2812** Python tests and **80** Rust tests pass
- After `uv sync`, all metadata agrees: `svy.__version__` 0.22.1, `svy` dist 0.22.1, `svy-rs` dist 0.12.1, requirement `svy-rs>=0.12.1,<0.13.0`
- `uv lock --check` and `uv sync --frozen` pass without rewriting the lock
- Estimation output **bit-for-bit identical** to pre-perf `main` (b84c9f0)

Utilisation on a 10-core M1 Max at 1M rows, for the record:

| case | wall | cores |
| --- | ---: | ---: |
| mean, 1 variable | 22.5 ms | 1.59 |
| total, 1 variable | 27.2 ms | 1.86 |
| mean, 8 batched | 37.2 ms | 3.62 |
| mean by group | 119.8 ms | 3.91 |

## Tagging

The changelog link refs assume tags `svy-v0.22.1` and `svy-rs-v0.12.1`, matching the existing scheme. "Publish to PyPI" is gated on a release tag, so it will show `skipping` on this PR.