### PR TITLE
chore(deps): polars 0.52 → 0.55.1 and its version-locked chain (#109)

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,7 +6,23 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **polars 0.52 → 0.55.1, and the three crates version-locked to it** ([#109](https://github.com/samplics-org/svy/issues/109)). `pyo3-polars` pins polars, and `pyo3` pins `pyo3-polars`, and `numpy` pins `pyo3`, so the polars bump is really a four-crate move: `pyo3-polars` 0.25 → 0.28, `pyo3` 0.26 → 0.29.1, `numpy` 0.26 → 0.29. `criterion` 0.5 → 0.8.2 rides along as a dev-dependency.
+
+  Three API changes carried the migration. `IntoIterator for &ChunkedArray<T>` is gone, so 50 call sites move from `.into_iter()` to `.iter()` — both yield `Option<T>`, so the iteration is unchanged. `DataFrame::as_single_chunk_par` is renamed `rechunk_mut_par` (same parallel rechunk, same doc contract). `DataFrame::with_column` takes a `Column` rather than a `Series`.
+
+  **Results are numerically inert.** Estimates, standard errors and confidence limits are bit-for-bit identical to the polars 0.52 build, and the quantile path still agrees bit-for-bit with R's `oldsvyquantile` across p = 0.01 to 0.99. 80 Rust and 2844 Python tests pass, including the suite's R and Stata reference comparisons.
+
+- **`ndarray` stays at 0.16 and is no longer safe to bump on its own.** `numpy` requires `>= 0.15, <=0.17`, which cargo reads as ≤ 0.17.0, so bumping to 0.17 resolves 0.17.x for this crate while numpy keeps its own 0.16 — two `ArrayBase` types in one graph, and every ndarray-typed call stops typechecking. It moves only when numpy's range moves.
+
+### Security
+
+- **`pyo3` 0.26 → 0.29.1** closes the bump deferred on 2026-07-22, when it was blocked on `pyo3-polars` not yet supporting a current pyo3. `svy-io` moved to 0.29 at the time ([#66](https://github.com/samplics-org/svy/pull/66)); both native crates are now on the same major.
+
 ### Added
+
+- **`rust-version = "1.91"`.** polars calls `i64::strict_abs` (`strict_overflow_ops`, stable since 1.91) and declares no `rust-version` itself, so on an older toolchain the build failed with a raw `E0658` inside `polars-core` instead of an MSRV error. CI is unaffected — it floats on stable.
 
 - **The Woodruff kernels take a probability instead of assuming 0.5.** `scores_median` hardcoded `let _p = 0.5` and its indicator `I(y > q) - 0.5`; the generalized `scores_quantile` uses `I(y > q) - (1 - p)`, which reduces to the old expression at `p = 0.5`. `weighted_quantile_domain`, `scores_quantile_domain` and the replication kernels (`weighted_quantiles_vec`, `matrix_quantile_estimates`, `matrix_quantile_by_domain`) are generalized the same way. The median entry points remain, delegating with `probs = [0.5]` and dropping the probability column, so their result schema is unchanged.
 

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloca"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +90,7 @@ version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f13d10a41ac8d2ec79ee34178d61e6f47a29c2edfe7ef1721c7383b0359e65"
 dependencies = [
+ "half",
  "num-traits",
 ]
 
@@ -149,11 +159,12 @@ dependencies = [
 
 [[package]]
 name = "atoi_simd"
-version = "0.16.1"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a49e05797ca52e312a0c658938b7d00693ef037799ef7187678f212d7684cf"
+checksum = "f3cdb3708a128e559a30fb830e8a77a5022ee6902806925c216658652b452a44"
 dependencies = [
  "debug_unsafe",
+ "rustversion",
 ]
 
 [[package]]
@@ -234,6 +245,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -432,6 +452,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,25 +508,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.5.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
 dependencies = [
+ "alloca",
  "anes",
  "cast",
  "ciborium",
  "clap",
  "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "num-traits",
- "once_cell",
  "oorandom",
+ "page_size",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_derive",
  "serde_json",
  "tinytemplate",
  "walkdir",
@@ -508,12 +533,12 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.5.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools 0.10.5",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -589,6 +614,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "debug_unsafe"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,8 +640,28 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "const-oid",
+ "crypto-common 0.2.2",
+]
+
+[[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -782,7 +836,7 @@ dependencies = [
  "private-gemm-x86",
  "pulp",
  "rand 0.9.5",
- "rand_distr",
+ "rand_distr 0.5.1",
  "rayon",
  "reborrow",
  "spindle",
@@ -816,6 +870,12 @@ name = "fast-float2"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8eb564c5c7423d25c886fb561d1e4ee69f72354d16918afa32c08811f6b6a55"
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
@@ -862,12 +922,12 @@ dependencies = [
 
 [[package]]
 name = "fs4"
-version = "0.13.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
 dependencies = [
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1129,11 +1189,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1185,6 +1243,7 @@ dependencies = [
  "cfg-if",
  "crunchy",
  "num-traits",
+ "serde",
  "zerocopy",
 ]
 
@@ -1204,6 +1263,12 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1224,6 +1289,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -1278,6 +1349,15 @@ name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -1481,15 +1561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "interpol"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1517,17 +1588,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "iter-read"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,9 +1595,9 @@ checksum = "071ed4cc1afd86650602c7b11aa2e1ce30762a1c27193201cb5cee9c6ebb1294"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -1695,15 +1755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ntapi"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3b335231dfd352ffb0f8017f3b6027a4917f7df785ea2143d8af2adc66980ae"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1858,6 +1918,17 @@ dependencies = [
  "bytemuck",
  "num-traits",
  "rand 0.8.7",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1891,10 +1962,11 @@ dependencies = [
 
 [[package]]
 name = "numpy"
-version = "0.26.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dba356160b54f5371b550575b78130a54718b4c6e46b3f33a6da74a27e78b"
+checksum = "6a5b15d63a5ff39e378daed0e1340d3a5964703ea9712eb09a0dc66fade996f4"
 dependencies = [
+ "half",
  "libc",
  "ndarray",
  "num-complex",
@@ -1903,6 +1975,25 @@ dependencies = [
  "pyo3",
  "pyo3-build-config",
  "rustc-hash",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1916,16 +2007,18 @@ dependencies = [
 
 [[package]]
 name = "object_store"
-version = "0.12.4"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c1be0c6c22ec0817cdc77d3842f721a17fd30ab6965001415b5402a74e6b740"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http",
  "http-body-util",
  "humantime",
@@ -1934,7 +2027,7 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.5",
+ "rand 0.10.2",
  "reqwest",
  "ring",
  "serde",
@@ -1966,6 +2059,16 @@ name = "openssl-probe"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f50d9b3dabb09ecd771ad0aa242ca6894994c130308ca3d7684634df8037391"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"
@@ -2048,7 +2151,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "602113b5b5e8621770cfd490cfd90b9f84ab29bd2b0e49ad83eb6d186cef2365"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2127,42 +2230,47 @@ dependencies = [
 
 [[package]]
 name = "polars"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bc9ea901050c1bb8747ee411bc7fbb390f3b399931e7484719512965132a248"
+checksum = "f73cc1d5bdd9293c4531e2ced5bbe8a2f5d4e55eb6122f11d4d73ccd0fc41e18"
 dependencies = [
  "getrandom 0.2.16",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
  "polars-error",
  "polars-io",
  "polars-lazy",
  "polars-ops",
+ "polars-plan",
  "polars-utils",
  "version_check",
 ]
 
 [[package]]
 name = "polars-arrow"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d3fe43f8702cf7899ff3d516c2e5f7dc84ee6f6a3007e1a831a0ff87940704"
+checksum = "966ca4b2b80071710c2526e1d0c52a7c07157a74ac6a459709515cc6dda832c9"
 dependencies = [
  "bitflags",
  "bytemuck",
+ "bytes",
  "chrono",
  "chrono-tz",
  "dyn-clone",
  "either",
  "ethnum",
  "getrandom 0.2.16",
- "getrandom 0.3.4",
- "hashbrown 0.16.1",
+ "getrandom 0.4.3",
+ "half",
+ "hashbrown 0.17.1",
  "lz4",
  "num-traits",
  "polars-arrow-format",
+ "polars-buffer",
  "polars-error",
  "polars-schema",
  "polars-utils",
@@ -2185,59 +2293,108 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-compute"
-version = "0.52.0"
+name = "polars-async"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29cc7497378dee3a002f117e0b4e16b7cbe6c8ed3da16a0229c89294af7c3bf"
+checksum = "9af82e2b7b4a4c036eadd4dc19bf98f8e4520cd3e7e3f04c9bfcf1019ea0a67a"
+dependencies = [
+ "atomic-waker",
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "parking_lot",
+ "pin-project-lite",
+ "polars-config",
+ "polars-error",
+ "polars-utils",
+ "rand 0.10.2",
+ "slotmap",
+ "tokio",
+]
+
+[[package]]
+name = "polars-buffer"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "762edafe40af51ba27003cee55a59672d1f209a8611e9824cfd73fd1dadda077"
+dependencies = [
+ "bytemuck",
+ "either",
+ "polars-utils",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "polars-compute"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb28d9574178db0acc244c05cc6155c4235a92d90b05c3ebbd9a26d7324954ba"
 dependencies = [
  "atoi_simd",
  "bytemuck",
  "chrono",
  "either",
  "fast-float2",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-error",
  "polars-utils",
- "rand 0.9.5",
- "ryu",
+ "rand 0.10.2",
  "serde",
  "strength_reduce",
  "strum_macros",
  "version_check",
+ "zmij",
+]
+
+[[package]]
+name = "polars-config"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1f18d908862cf377987596c8aca289b7ab31d44eb33eead0324c4b127da1cac"
+dependencies = [
+ "polars-error",
+ "serde",
 ]
 
 [[package]]
 name = "polars-core"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48409b7440cb1a4aa84953fe3a4189dfbfb300a3298266a92a37363476641e40"
+checksum = "3eaf2490f858c7b1097e7169db2b48362cca8b6342455470d475210dd655cd35"
 dependencies = [
  "bitflags",
  "boxcar",
  "bytemuck",
  "chrono",
  "either",
- "hashbrown 0.16.1",
+ "getrandom 0.4.3",
+ "hashbrown 0.17.1",
  "indexmap",
  "itoa",
  "num-traits",
  "polars-arrow",
+ "polars-async",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-dtype",
  "polars-error",
  "polars-row",
  "polars-schema",
  "polars-utils",
- "rand 0.9.5",
- "rand_distr",
+ "rand 0.10.2",
+ "rand_distr 0.6.0",
  "rayon",
  "regex",
  "serde",
  "serde_json",
  "strum_macros",
+ "tokio",
  "uuid",
  "version_check",
  "xxhash-rust",
@@ -2245,12 +2402,12 @@ dependencies = [
 
 [[package]]
 name = "polars-dtype"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7007e9e8b7b657cbd339b65246af7e87f5756ee9a860119b9424ddffd2aaf133"
+checksum = "fdb936fa87de737124aacc778b22254d3281a542d0ed8b175a78020a4f064107"
 dependencies = [
  "boxcar",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "polars-arrow",
  "polars-error",
  "polars-utils",
@@ -2260,9 +2417,9 @@ dependencies = [
 
 [[package]]
 name = "polars-error"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a6be22566c89f6405f553bfdb7c8a6cb20ec51b35f3172de9a25fa3e252d85"
+checksum = "9db40f052ac576cfb1ea2eef531665cca2da7f6d432677e766cd94ed163e0472"
 dependencies = [
  "object_store",
  "parking_lot",
@@ -2275,14 +2432,15 @@ dependencies = [
 
 [[package]]
 name = "polars-expr"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6199a50d3e1afd0674fb009e340cbfb0010682b2387187a36328c00f3f2ca87b"
+checksum = "218f48069444b2356ac221d93ceadaf4cf140469e3d18890eeede5af074ec76b"
 dependencies = [
  "bitflags",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
  "polars-io",
@@ -2290,7 +2448,7 @@ dependencies = [
  "polars-plan",
  "polars-row",
  "polars-utils",
- "rand 0.9.5",
+ "rand 0.10.2",
  "rayon",
  "recursive",
  "version_check",
@@ -2298,9 +2456,9 @@ dependencies = [
 
 [[package]]
 name = "polars-ffi"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e57ae94d00719556ce242d265f77720287d0c02b78e204aaeee8885db59c7a58"
+checksum = "4a90911d9ea247b381c6ccad02ea9d3a41678056b288389b21db95ac01190e64"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2308,55 +2466,64 @@ dependencies = [
 
 [[package]]
 name = "polars-io"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be3714acdff87170141880a07f5d9233490d3bd5531c41898f6969d440feee11"
+checksum = "5885a77a4838e5c789c783f893634d30e335e1e9823667eb7f7d04c2e1460c49"
 dependencies = [
  "async-trait",
  "atoi_simd",
  "blake3",
  "bytes",
+ "chrono",
+ "crossbeam-queue",
  "fast-float2",
+ "fastrand",
  "fs4",
  "futures",
  "glob",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "home",
  "itoa",
  "memchr",
  "memmap2",
  "num-traits",
  "object_store",
+ "parking_lot",
  "percent-encoding",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-parquet",
  "polars-schema",
  "polars-utils",
+ "rand 0.10.2",
  "rayon",
  "regex",
  "reqwest",
- "ryu",
  "serde",
  "serde_json",
  "simdutf8",
  "tokio",
+ "zmij",
 ]
 
 [[package]]
 name = "polars-lazy"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea136c360d03aafe56e0233495e30044ce43639b8b0360a4a38e840233f048a1"
+checksum = "2135f14b47e77d7578c5d5fcebc612213e1c2de7e0c03f10da00374d5ed12ffc"
 dependencies = [
  "bitflags",
  "chrono",
  "either",
  "memchr",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-expr",
  "polars-io",
@@ -2371,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "polars-mem-engine"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6e455ceb6e5aee7ed7d5c8944104e66992173e03a9c42f9670226318672249"
+checksum = "dbaaf077b03a0315e0ff5610c6bf0a5d5cd2743139863fe4805c518ea0789038"
 dependencies = [
  "memmap2",
  "polars-arrow",
@@ -2389,20 +2556,43 @@ dependencies = [
 ]
 
 [[package]]
-name = "polars-ops"
-version = "0.52.0"
+name = "polars-ooc"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b59c80a019ef0e6f09b4416d2647076a52839305c9eb11919e8298ec667f853"
+checksum = "bc2972642f961dfbebed9af434c27cb1c51c67fe4464bfd63b5727a0f3ec4e71"
+dependencies = [
+ "async-trait",
+ "boxcar",
+ "libc",
+ "polars-async",
+ "polars-config",
+ "polars-core",
+ "polars-error",
+ "polars-io",
+ "polars-utils",
+ "rand 0.10.2",
+ "rand_distr 0.6.0",
+ "thread_local",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "polars-ops"
+version = "0.55.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3001103c2bf0e31f450cfd8cc75a7e72a88ce0ac3ebf112f60b718c1db9e625b"
 dependencies = [
  "argminmax",
  "bytemuck",
  "either",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "indexmap",
  "libm",
  "memchr",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-core",
  "polars-error",
@@ -2418,22 +2608,25 @@ dependencies = [
 
 [[package]]
 name = "polars-parquet"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c2439d127c59e6bfc9d698419bdb45210068a6f501d44e6096429ad72c2eaa"
+checksum = "983f78669a62bb201cc4947d53a6ca221013de81950da401a74a583c15292285"
 dependencies = [
  "async-stream",
  "base64",
  "bytemuck",
  "ethnum",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "num-traits",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-error",
  "polars-parquet-format",
  "polars-utils",
+ "regex",
  "serde",
  "simdutf8",
  "streaming-decompression",
@@ -2451,20 +2644,27 @@ dependencies = [
 
 [[package]]
 name = "polars-plan"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4619f5c7e9b91f18611c9ed82ebeee4b10052160825c1316ecf4dbd4d97e6"
+checksum = "3ad5e622bb7dfc549d96509e774d2e461224267704deba0b6da40c669691ef82"
 dependencies = [
  "bitflags",
+ "blake3",
  "bytemuck",
  "bytes",
+ "digest-io",
  "either",
- "hashbrown 0.16.1",
+ "futures",
+ "hashbrown 0.17.1",
+ "hex",
+ "indexmap",
  "memmap2",
  "num-traits",
  "percent-encoding",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-ffi",
@@ -2476,21 +2676,23 @@ dependencies = [
  "rayon",
  "recursive",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "slotmap",
  "strum_macros",
+ "tokio",
  "version_check",
 ]
 
 [[package]]
 name = "polars-row"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a18d232f25b83032e280a279a1f40beb8a6f8fc43907b13dc07b1c56f3b11eea"
+checksum = "968cd19c3381e29621accae5b15a32bce87d5bbbee943aa02079432e144325a4"
 dependencies = [
  "bitflags",
  "bytemuck",
  "polars-arrow",
+ "polars-buffer",
  "polars-compute",
  "polars-dtype",
  "polars-error",
@@ -2499,9 +2701,9 @@ dependencies = [
 
 [[package]]
 name = "polars-schema"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73e21d429ae1c23f442b0220ccfe773a9734a44e997b5062a741842909d9441"
+checksum = "dc94280316abcf09547758ce3c3e04120b1f6153eddd66cb36392e70dc02337b"
 dependencies = [
  "indexmap",
  "polars-error",
@@ -2512,49 +2714,52 @@ dependencies = [
 
 [[package]]
 name = "polars-stream"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff19612074640a9d65e5928b7223db76ffee63e55b276f1e466d06719eb7362"
+checksum = "21e0bef74290a7f2a443f70984d03c41ce7934e82f61847ed87df5f1110fa581"
 dependencies = [
  "async-channel",
  "async-trait",
- "atomic-waker",
  "bitflags",
+ "bytes",
+ "chrono",
  "chrono-tz",
  "crossbeam-channel",
- "crossbeam-deque",
  "crossbeam-queue",
- "crossbeam-utils",
  "futures",
- "memmap2",
+ "memchr",
+ "num-traits",
  "parking_lot",
  "percent-encoding",
- "pin-project-lite",
  "polars-arrow",
+ "polars-async",
+ "polars-buffer",
  "polars-compute",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-expr",
  "polars-io",
  "polars-mem-engine",
+ "polars-ooc",
  "polars-ops",
  "polars-parquet",
  "polars-plan",
  "polars-time",
  "polars-utils",
- "rand 0.9.5",
  "rayon",
  "recursive",
  "slotmap",
  "tokio",
+ "uuid",
  "version_check",
 ]
 
 [[package]]
 name = "polars-time"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddce7a9f81d5f47d981bcee4a8db004f9596bb51f0f4d9d93667a1a00d88166c"
+checksum = "51e8686349610e819b66265e8f98ec73949b490066b7d9b9b66d32535e1b01ca"
 dependencies = [
  "atoi_simd",
  "bytemuck",
@@ -2575,10 +2780,11 @@ dependencies = [
 
 [[package]]
 name = "polars-utils"
-version = "0.52.0"
+version = "0.55.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "667c1bc2d2313f934d711f6e3b58d8d9f80351d14ea60af936a26b7dfb06e309"
+checksum = "bb4e0ee58aac33a6e5dd34975f141a098edeaa5948dfbc0a4228bfc9621b6df9"
 dependencies = [
+ "argminmax",
  "bincode",
  "bytemuck",
  "bytes",
@@ -2586,14 +2792,19 @@ dependencies = [
  "either",
  "flate2",
  "foldhash 0.2.0",
- "hashbrown 0.16.1",
+ "futures",
+ "half",
+ "hashbrown 0.17.1",
  "indexmap",
  "libc",
  "memmap2",
+ "num-derive",
  "num-traits",
+ "numpy",
+ "polars-config",
  "polars-error",
  "pyo3",
- "rand 0.9.5",
+ "rand 0.10.2",
  "raw-cpuid",
  "rayon",
  "regex",
@@ -2603,6 +2814,8 @@ dependencies = [
  "serde_stacker",
  "slotmap",
  "stacker",
+ "sysinfo",
+ "tokio",
  "uuid",
  "version_check",
 ]
@@ -2713,36 +2926,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "fc153f5fd745cc038b5eed86622125969f8a39834a57bc96beaaf2512b1da729"
 dependencies = [
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "bb77d9aa6d647507b55c69ee714d266d84c526c78ff0bc6dd8757f58591e64d1"
 dependencies = [
- "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "3160087aa5733bce7d9a729f8c55f85a2a53b74742a09613178eeebff0722253"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2750,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "91f9d455db760a9a0b0ddeaac25f1390b8a36ba73dfbda9f127cac6fc340d4d5"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2762,27 +2971,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "e343bcec300ff262f5806a33a4e51b6d097a8a46435f512fcb83e95592581625"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.114",
 ]
 
 [[package]]
 name = "pyo3-polars"
-version = "0.25.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a1e9d697dd76f39b269a5c2f2904469092c0ef6452f47caaf20879891a6a62"
+checksum = "edbd5831456c88d2ba153608fd9cca4baf3dbc6364ed4628d1e12ca6122b7ddb"
 dependencies = [
  "libc",
  "once_cell",
  "polars",
  "polars-arrow",
+ "polars-config",
  "polars-core",
  "polars-error",
  "polars-ffi",
@@ -2791,14 +3000,14 @@ dependencies = [
  "pyo3-polars-derive",
  "serde",
  "serde-pickle",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
 ]
 
 [[package]]
 name = "pyo3-polars-derive"
-version = "0.19.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f5ac697f68e98220c506a933d83398a2687d279de42713b1a0b8e0b4b88cead"
+checksum = "8ec01b2f29641899a0286ac3b48aafe8ee3375510b1bfbe322c88d30f71d1bc7"
 dependencies = [
  "polars-arrow",
  "polars-core",
@@ -2807,15 +3016,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.114",
-]
-
-[[package]]
-name = "python3-dll-a"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d381ef313ae70b4da5f95f8a4de773c6aa5cd28f73adec4b4a31df70b66780d8"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2832,9 +3032,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
  "serde",
@@ -2986,6 +3186,16 @@ checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
 dependencies = [
  "num-traits",
  "rand 0.9.5",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
+dependencies = [
+ "num-traits",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -3395,7 +3605,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3415,9 +3636,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -3544,9 +3765,9 @@ checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
 
 [[package]]
 name = "strum_macros"
-version = "0.27.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3643,6 +3864,20 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.39.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
+dependencies = [
+ "libc",
+ "memchr",
+ "ntapi",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows",
 ]
 
 [[package]]
@@ -3898,9 +4133,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ucd-trie"
@@ -3913,12 +4148,6 @@ name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -4106,12 +4335,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core",
 ]
 
 [[package]]
@@ -4125,6 +4397,17 @@ dependencies = [
  "windows-link",
  "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -4154,6 +4437,16 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core",
+ "windows-link",
+]
 
 [[package]]
 name = "windows-result"
@@ -4255,6 +4548,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -2,6 +2,10 @@
 name = "svy_rs"
 version = "0.12.1"
 edition = "2024"
+# polars calls i64::strict_abs (strict_overflow_ops, stable since 1.91) and
+# declares no rust-version of its own, so without this the failure on an older
+# toolchain is a raw E0658 inside polars-core rather than an MSRV error.
+rust-version = "1.91"
 repository = "https://gitlab.com/samplics/svy"
 homepage = "https://gitlab.com/samplics/svy"
 
@@ -20,12 +24,16 @@ crate-type = ["cdylib", "rlib"]
 # dependency lets host builds drop it with `--no-default-features`, so
 # `cargo test`/`cargo bench` link a normal binary instead of failing on
 # undefined libpython symbols. See the [features] section below.
-pyo3 = { version = "0.26", features = ["abi3-py311", "generate-import-lib"] }
-pyo3-polars = { version = "0.25", features = ["derive"] }
-polars = { version = "0.52", default-features = false, features = ["dtype-categorical"] }
+pyo3 = { version = "0.29", features = ["abi3-py311", "generate-import-lib"] }
+pyo3-polars = { version = "0.28", features = ["derive"] }
+polars = { version = "0.55", default-features = false, features = ["dtype-categorical"] }
 faer = "0.24"
 ahash = "0.8"
-numpy = "0.26"
+numpy = "0.29"
+# Pinned to whatever numpy accepts, NOT bumped independently: numpy requires
+# `>= 0.15, <=0.17`, which cargo reads as <= 0.17.0, so a 0.17 bump resolves to
+# 0.17.x here while numpy keeps its own 0.16 — two ArrayBase types in one graph
+# and every ndarray-typed call fails to typecheck. Move this only with numpy.
 ndarray = { version = "0.16", features = ["rayon"] }
 rayon = "1.12"
 rustc-hash = "2.1"
@@ -37,7 +45,7 @@ extension-module = ["pyo3/extension-module"]
 default = ["extension-module"]
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.8", features = ["html_reports"] }
 
 # Criterion micro-benchmarks for the estimation kernel. Run WITHOUT the
 # extension-module feature so the bench binary links as a normal executable:

--- a/packages/svy-rs/benches/kernel_bench.rs
+++ b/packages/svy-rs/benches/kernel_bench.rs
@@ -135,8 +135,10 @@ fn bench_taylor_variance(c: &mut Criterion) {
         let w = make_w(n);
         let scores = scores_mean(&y, &w).unwrap();
         for &long in &[false, true] {
-            let strata = make_strata(n, long);
-            let psu = make_psu(n, long);
+            // taylor_variance takes design columns; build them outside the
+            // timed closure so the conversion is not measured.
+            let strata = Column::from(make_strata(n, long).into_series());
+            let psu = Column::from(make_psu(n, long).into_series());
             let id = format!("{n}/{}", if long { "long" } else { "short" });
             g.throughput(Throughput::Elements(n as u64));
             g.bench_function(BenchmarkId::from_parameter(id), |b| {

--- a/packages/svy-rs/src/categorical/api.rs
+++ b/packages/svy-rs/src/categorical/api.rs
@@ -195,7 +195,7 @@ where
 
         let mut single = run_single(&temp_df, Some("__svy_by_domain__"), Some("true"))?;
         let with_by    = single
-            .with_column(Series::new(by_col.into(), vec![level.as_str()]))?
+            .with_column(Column::new(by_col.into(), vec![level.as_str()]))?
             .clone();
 
         result_dfs.push(with_by);

--- a/packages/svy-rs/src/estimation/replication.rs
+++ b/packages/svy-rs/src/estimation/replication.rs
@@ -182,7 +182,7 @@ pub fn extract_rep_weights_matrix(
         None => {
             // Fallback for chunked/nullable columns — identical semantics.
             for (r, col) in f64_cols.iter().enumerate() {
-                for (i, v) in col.into_iter().enumerate() {
+                for (i, v) in col.iter().enumerate() {
                     matrix[i * n_reps + r] = v.unwrap_or(0.0);
                 }
             }
@@ -462,7 +462,7 @@ pub fn index_domains(by: &StringChunked) -> (Vec<u32>, Vec<String>, usize) {
     let mut next_idx = 0u32;
 
     let indices: Vec<u32> = by
-        .into_iter()
+        .iter()
         .map(|opt| match opt {
             Some(s) => *map.entry(s).or_insert_with(|| {
                 let idx = next_idx;

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -58,7 +58,7 @@ fn get_domain_mask(df: &DataFrame, mask_col: Option<&str>) -> PolarsResult<Optio
         None => Ok(None),
         Some(name) => {
             let ca = df.column(name)?.f64()?;
-            Ok(Some(ca.into_iter().map(|o| o.unwrap_or(0.0)).collect()))
+            Ok(Some(ca.iter().map(|o| o.unwrap_or(0.0)).collect()))
         }
     }
 }
@@ -139,8 +139,8 @@ fn compute_replicate_mean_ungrouped(
     let weights = df.column(weight_col)?.f64()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
     let domain_mask = get_domain_mask(df, domain_mask_col)?;
     let mask = domain_mask.as_deref();
 
@@ -174,8 +174,8 @@ fn compute_replicate_mean_grouped(
     let by_str = df.column(by_col)?.str()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
@@ -268,8 +268,8 @@ fn compute_replicate_total_ungrouped(
     let weights = df.column(weight_col)?.f64()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
     let domain_mask = get_domain_mask(df, domain_mask_col)?;
     let mask = domain_mask.as_deref();
 
@@ -301,8 +301,8 @@ fn compute_replicate_total_grouped(
     let by_str = df.column(by_col)?.str()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
@@ -400,9 +400,9 @@ fn compute_replicate_ratio_ungrouped(
     let weights = df.column(weight_col)?.f64()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let x_arr: Vec<f64> = x.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let x_arr: Vec<f64> = x.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
     let domain_mask = get_domain_mask(df, domain_mask_col)?;
     let mask = domain_mask.as_deref();
 
@@ -436,9 +436,9 @@ fn compute_replicate_ratio_grouped(
     let by_str = df.column(by_col)?.str()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let x_arr: Vec<f64> = x.into_iter().map(|v| v.unwrap_or(0.0)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let x_arr: Vec<f64> = x.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (theta_full_vec, theta_reps_vec, counts) = match get_cont_rep_cols(df, rep_weight_cols)? {
@@ -531,7 +531,7 @@ fn compute_replicate_prop_ungrouped(
     let weights  = df.column(weight_col)?.f64()?;
     let n = y_series.len();
     let n_reps = rep_weight_cols.len();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
     let cont_cols = get_cont_rep_cols(df, rep_weight_cols)?;
     let domain_mask = get_domain_mask(df, domain_mask_col)?;
     let mask = domain_mask.as_deref();
@@ -544,7 +544,7 @@ fn compute_replicate_prop_ungrouped(
 
     let (n_levels, level_strs, estimates, variances) = if is_string {
         let y_cast = y_series.cast(&DataType::String)?;
-        let y_arr: Vec<String> = y_cast.str()?.into_iter()
+        let y_arr: Vec<String> = y_cast.str()?.iter()
             .map(|v| v.unwrap_or("").to_string())
             .collect();
         let (levels, theta_full, theta_reps) = match &cont_cols {
@@ -562,9 +562,9 @@ fn compute_replicate_prop_ungrouped(
     } else {
         // Integer or boolean: convert to i64 category codes.
         let y_arr: Vec<i64> = if y_series.dtype().is_integer() {
-            y_series.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect()
+            y_series.i64()?.iter().map(|v| v.unwrap_or(0)).collect()
         } else if y_series.dtype() == &DataType::Boolean {
-            y_series.bool()?.into_iter()
+            y_series.bool()?.iter()
                 .map(|v| if v.unwrap_or(false) { 1 } else { 0 })
                 .collect()
         } else {
@@ -610,7 +610,7 @@ fn compute_replicate_prop_grouped(
     let by_str   = df.column(by_col)?.str()?;
     let n = y_series.len();
     let n_reps = rep_weight_cols.len();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
@@ -621,7 +621,7 @@ fn compute_replicate_prop_grouped(
 
     let (levels_str, theta_full_mat, theta_reps_mat, counts) = if is_string {
         let y_cast = y_series.cast(&DataType::String)?;
-        let y_arr: Vec<String> = y_cast.str()?.into_iter()
+        let y_arr: Vec<String> = y_cast.str()?.iter()
             .map(|v| v.unwrap_or("").to_string())
             .collect();
         let (levels, tf, tr, counts) =
@@ -629,9 +629,9 @@ fn compute_replicate_prop_grouped(
         (levels, tf, tr, counts)
     } else {
         let y_arr: Vec<i64> = if y_series.dtype().is_integer() {
-            y_series.i64()?.into_iter().map(|v| v.unwrap_or(0)).collect()
+            y_series.i64()?.iter().map(|v| v.unwrap_or(0)).collect()
         } else if y_series.dtype() == &DataType::Boolean {
-            y_series.bool()?.into_iter()
+            y_series.bool()?.iter()
                 .map(|v| if v.unwrap_or(false) { 1 } else { 0 })
                 .collect()
         } else {
@@ -771,8 +771,8 @@ fn compute_replicate_quantile_ungrouped(
     let weights = df.column(weight_col)?.f64()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(f64::NAN)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(f64::NAN)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;
     let (theta_full, theta_reps) =
@@ -802,8 +802,8 @@ fn compute_replicate_quantile_grouped(
     let by_str  = df.column(by_col)?.str()?;
     let n = y.len();
     let n_reps = rep_weight_cols.len();
-    let y_arr: Vec<f64> = y.into_iter().map(|v| v.unwrap_or(f64::NAN)).collect();
-    let w_arr: Vec<f64> = weights.into_iter().map(|v| v.unwrap_or(0.0)).collect();
+    let y_arr: Vec<f64> = y.iter().map(|v| v.unwrap_or(f64::NAN)).collect();
+    let w_arr: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
 
     let (domain_ids, domain_names, n_domains) = index_domains(by_str);
     let (rep_w_matrix, _, _) = extract_rep_weights_matrix(df, rep_weight_cols)?;

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -1800,7 +1800,7 @@ pub fn srs_variance_mean(y: &Float64Chunked, weights: &Float64Chunked) -> Polars
     // Fallback: only observations where y and w are non-null and w > 0.
     let mut yv = Vec::new();
     let mut wv = Vec::new();
-    for (yi, wi) in y.into_iter().zip(weights.into_iter()) {
+    for (yi, wi) in y.iter().zip(weights.iter()) {
         if let (Some(y_val), Some(w_val)) = (yi, wi) {
             if w_val > 0.0 {
                 yv.push(y_val);
@@ -1834,9 +1834,9 @@ pub fn srs_variance_mean_domain(
         let mut yv = Vec::new();
         let mut wv = Vec::new();
         for ((yi, wi), mi) in y
-            .into_iter()
-            .zip(weights.into_iter())
-            .zip(domain_mask.into_iter())
+            .iter()
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
         {
             if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
                 if w_val > 0.0 {
@@ -1864,7 +1864,7 @@ pub fn srs_variance_total(y: &Float64Chunked, weights: &Float64Chunked) -> Polar
     // Zero-weight rows are excluded from n (see srs_variance_mean).
     let mut yv: Vec<f64> = Vec::new();
     let mut wv: Vec<f64> = Vec::new();
-    for (yi, wi) in y.into_iter().zip(weights.into_iter()) {
+    for (yi, wi) in y.iter().zip(weights.iter()) {
         let w_val = wi.unwrap_or(0.0);
         if w_val > 0.0 {
             yv.push(yi.unwrap_or(0.0));
@@ -1906,9 +1906,9 @@ pub fn srs_variance_total_domain(
         let mut yv = Vec::new();
         let mut wv = Vec::new();
         for ((yi, wi), mi) in y
-            .into_iter()
-            .zip(weights.into_iter())
-            .zip(domain_mask.into_iter())
+            .iter()
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
         {
             if let (Some(y_val), Some(w_val), Some(true)) = (yi, wi, mi) {
                 if w_val > 0.0 {
@@ -1941,7 +1941,7 @@ pub fn srs_variance_ratio(
     let mut yv: Vec<f64> = Vec::new();
     let mut xv: Vec<f64> = Vec::new();
     let mut wv: Vec<f64> = Vec::new();
-    for ((yi, xi), wi) in y.into_iter().zip(x.into_iter()).zip(weights.into_iter()) {
+    for ((yi, xi), wi) in y.iter().zip(x.iter()).zip(weights.iter()) {
         let w_val = wi.unwrap_or(0.0);
         if w_val > 0.0 {
             yv.push(yi.unwrap_or(0.0));
@@ -2001,10 +2001,10 @@ pub fn srs_variance_ratio_domain(
         let mut xv = Vec::new();
         let mut wv = Vec::new();
         for (((yi, xi), wi), mi) in y
-            .into_iter()
-            .zip(x.into_iter())
-            .zip(weights.into_iter())
-            .zip(domain_mask.into_iter())
+            .iter()
+            .zip(x.iter())
+            .zip(weights.iter())
+            .zip(domain_mask.iter())
         {
             if let (Some(y_val), Some(x_val), Some(w_val), Some(true)) = (yi, xi, wi, mi) {
                 if w_val > 0.0 {

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -40,7 +40,7 @@ use crate::estimation::taylor::{
 fn into_contiguous(data: PyDataFrame) -> DataFrame {
     let mut df: DataFrame = data.into();
     if df.first_col_n_chunks() > 1 {
-        df.as_single_chunk_par();
+        df.rechunk_mut_par();
     }
     df
 }

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -223,7 +223,7 @@ fn index_groups(series: &Series) -> PolarsResult<(Vec<usize>, usize)> {
     match series.dtype() {
         DataType::String => {
             let ca = series.str()?;
-            for opt_s in ca.into_iter() {
+            for opt_s in ca.iter() {
                 let s = opt_s.unwrap_or("__NULL__");
                 let idx = *map.entry(s.to_string()).or_insert_with(|| {
                     let i = next_idx;
@@ -238,7 +238,7 @@ fn index_groups(series: &Series) -> PolarsResult<(Vec<usize>, usize)> {
             let ca = physical.u32()?;
             let mut phys_map: HashMap<u32, usize> = HashMap::new();
 
-            for opt_v in ca.into_iter() {
+            for opt_v in ca.iter() {
                 let v = opt_v.unwrap_or(u32::MAX);
                 let idx = *phys_map.entry(v).or_insert_with(|| {
                     let i = next_idx;
@@ -786,8 +786,8 @@ fn fit_glm_domain(
             let p_str = p.cast(&DataType::String)?;
             let s_ca = s_str.str()?;
             let p_ca = p_str.str()?;
-            let s_vals: Vec<&str> = s_ca.into_iter().map(|v| v.unwrap_or("__NULL__")).collect();
-            let p_vals: Vec<&str> = p_ca.into_iter().map(|v| v.unwrap_or("__NULL__")).collect();
+            let s_vals: Vec<&str> = s_ca.iter().map(|v| v.unwrap_or("__NULL__")).collect();
+            let p_vals: Vec<&str> = p_ca.iter().map(|v| v.unwrap_or("__NULL__")).collect();
 
             let mut map: HashMap<(&str, &str), usize> = HashMap::new();
             let mut idx = Vec::with_capacity(n);


### PR DESCRIPTION
Closes #109.

polars cannot move on its own. `pyo3-polars` pins polars, `pyo3` pins `pyo3-polars`, and `numpy` pins `pyo3`, so the bump #109 asked for is a four-crate move:

| crate | from | to |
|---|---|---|
| `polars` | 0.52 | **0.55.1** |
| `pyo3-polars` | 0.25 | **0.28.0** |
| `pyo3` | 0.26 | **0.29.1** |
| `numpy` | 0.26 | **0.29.0** |
| `criterion` | 0.5 | 0.8.2 (dev-dep) |

## One step past the 0.54.4 in #109

0.54.4 pairs with pyo3 0.28, which would leave svy-rs behind svy-io. `pyo3-polars` 0.28 pairs with pyo3 **0.29** and compiles just as cleanly, so this closes the pyo3 bump deferred on 2026-07-22 instead of deferring it again. svy-io moved to 0.29 in #66 — both native crates are now on the same major.

Both chains were built and tested; 0.29/0.55.1 is strictly better at equal cost.

## `ndarray` is grouped with these but is not co-upgradable

Dependabot lumps `ndarray` in, but `numpy` requires `>= 0.15, <=0.17`, which cargo reads as **≤ 0.17.0**. Bumping to 0.17 therefore resolves 0.17.x for this crate while numpy holds its own 0.16 — two `ArrayBase` types in one graph, and 31 errors in `weighting/api.rs` reading as *"arguments to this function are incorrect"* with no obvious cause:

```
note: there are multiple different versions of crate `ndarray` in the dependency graph
```

It stays at 0.16, with a comment explaining why, and moves only when numpy's range moves.

## Rust 1.91 is a hard floor

`polars-core` calls `i64::strict_abs` (`strict_overflow_ops`, stable since 1.91) and declares **no `rust-version` of its own**, so on 1.90 the build fails with a raw `E0658` pointing into polars-core:

```
error[E0658]: use of unstable library feature `strict_overflow_ops`
   --> polars-core-0.55.1/src/frame/column/mod.rs:595:61
```

`rust-version = "1.91"` turns that into a proper MSRV error. **CI is unaffected** — it floats on `dtolnay/rust-toolchain # stable`, so CI would have passed while a local 1.90 build did not.

## The migration

Three API changes, all mechanical:

- `IntoIterator for &ChunkedArray<T>` is gone — 50 call sites move from `.into_iter()` to `.iter()`. Both yield `Option<T>`, so iteration is unchanged.
- `DataFrame::as_single_chunk_par` → `rechunk_mut_par` (same parallel rechunk, same doc contract).
- `DataFrame::with_column` takes `Column`, not `Series`.

Plus one bench fix: `taylor_variance` takes `Option<&Column>`, so the design columns are built *before* the timed closure rather than inside it.

Every changed line under `src/` is one of those three — verified by filtering the diff.

## Verification

**Results are numerically inert.** Estimates, standard errors and confidence limits are bit-for-bit identical to the polars 0.52 build, and the quantile path still agrees bit-for-bit with R's `oldsvyquantile` from p = 0.01 to 0.99:

```
bit-identical to polars 0.52 baseline: True
still bit-exact vs R:                  True
```

80 Rust tests, 2844 Python tests, benches build, wheel builds, `lint-svy` and `lint-svy-rs` clean.
