### PR TITLE
release: svy 0.23.0, svy-rs 0.13.0

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.13.0] — 2026-08-05
+
 ### Fixed
 
 - **The Woodruff score is centered on its own weighted mean.** The linearization used `(w_i / sum_w) * (I(y_i > q) - (1 - p))`, centering the residual on the *nominal* target rather than on the mean it actually realizes. `u_bar` is zero only when `F(q)` lands exactly on `p`, which discreteness prevents — on a 5000-record fixture it sits near -4e-5, and omitting it moved the probability-scale SE by ~2e-4 relative. R reaches the centered form by computing the variance as `svymean(U, design)`. The `Higher`/`Lower` rules were unaffected in their output, because the CDF inversion snaps to an order statistic and absorbs the wobble, so medians and default-`q_method` quantiles do not move; `Linear`, `Middle` and `Nearest` interpolate continuously and did drift — up to 4e-4 relative on the confidence limits. All rules now agree with R to floating-point noise.

--- a/packages/svy-rs/Cargo.lock
+++ b/packages/svy-rs/Cargo.lock
@@ -3783,7 +3783,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "svy_rs"
-version = "0.12.1"
+version = "0.13.0"
 dependencies = [
  "ahash",
  "approx",

--- a/packages/svy-rs/Cargo.toml
+++ b/packages/svy-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svy_rs"
-version = "0.12.1"
+version = "0.13.0"
 edition = "2024"
 # polars calls i64::strict_abs (strict_overflow_ops, stable since 1.91) and
 # declares no rust-version of its own, so without this the failure on an older

--- a/packages/svy-rs/pyproject.toml
+++ b/packages/svy-rs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy_rs"
-version = "0.12.1"
+version = "0.13.0"
 description = "Internal Rust extension for the svy package. Do not depend on this directly."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/packages/svy-rs/svy_rs/__init__.py
+++ b/packages/svy-rs/svy_rs/__init__.py
@@ -52,4 +52,4 @@ from svy_rs._internal import (
     ttest_rs,
 )
 
-__version__ = "0.9.0"
+__version__ = "0.13.0"

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.23.0] — 2026-08-05
+
 ### Added
 
 - **`sample.estimation.quantile()` — design-based quantiles with standard errors** ([#112](https://github.com/samplics-org/svy/issues/112)). Previously only the median carried a standard error; every other quantile was available as a point estimate through `describe(percentiles=)`, with no variance. `quantile()` estimates any set of probabilities under Taylor linearization or replicate weights, with `by=` domains and `where=` filters:

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.22.1"
+version = "0.23.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -26,7 +26,7 @@ dependencies = [
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
   "svy-io>=0.2.0,<0.3.0",
-  "svy-rs>=0.12.1,<0.13.0",
+  "svy-rs>=0.13.0,<0.14.0",
 ]
 
 [project.urls]

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -128,7 +128,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.22.1"
+__version__ = "0.23.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.22.1"
+version = "0.23.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },
@@ -2431,7 +2431,7 @@ dev = [
 
 [[package]]
 name = "svy-rs"
-version = "0.12.1"
+version = "0.13.0"
 source = { editable = "packages/svy-rs" }
 dependencies = [
     { name = "polars", extra = ["pyarrow"] },


### PR DESCRIPTION
Both take a **minor**, and the pin is what forces it.

| package | from | to |
|---|---|---|
| svy | 0.22.1 | **0.23.0** |
| svy-rs | 0.12.1 | **0.13.0** |

svy 0.23.0's Python calls `rs.taylor_quantile` and `rs.weighted_quantile_at`, neither of which exists in svy-rs 0.12.1. The current range `svy-rs>=0.12.1,<0.13.0` would be satisfied by a stale 0.12.1 extension and the new svy would die with `AttributeError` at call time. The floor moves to `>=0.13.0,<0.14.0`.

Minor on svy-rs does real work beyond bookkeeping: a patch (0.12.2) would satisfy 0.22.1's existing `<0.13.0` range and reach every current install on the next sync — a brand-new polars 0.55 / pyo3 0.29 extension landing silently under old svy code. 0.13.0 makes that impossible.

## ⚠️ Numbers move, for the first time in three releases

`median()` standard errors and confidence limits change. **Point estimates do not.**

Two defects, both understating the SE — so the old values were too small and intervals widen:

- interval endpoints were inverted linearly regardless of `q_method`, while R hands one `method`/`f` pair to both its point `approxfun` and its endpoint `approx`
- the linearization centered on the nominal target rather than on the mean it realizes

Anyone who has published estimates from `median()` should re-run them. This belongs in the release notes, not just the CHANGELOG.

Estimates, SEs and both limits now agree with R's `oldsvyquantile` to floating-point noise — 4e-15 worst over 44 comparisons per tie rule, p = 0.001 to 0.999 — the residual being scipy's `t.ppf` against R's `qt`.

## Seven version strings, not six

`b356d59` tracked six. The seventh is `__version__` in `svy_rs/__init__.py`, **stale at 0.9.0** since `6f97387` — Cargo.toml and pyproject.toml moved through 0.10, 0.11 and 0.12 without it. Nothing reads it, so nothing broke; corrected to 0.13.0 here rather than left to drift.

Full set: svy-rs `Cargo.toml` / `pyproject.toml` / `__init__.py`; svy `pyproject.toml` / `__init__.py` / svy-rs floor; `Cargo.lock` and `uv.lock`. Both locks edited to the member lines rather than regenerated, for the reason `b356d59` gives — a local `uv lock` also rewrites unrelated `python_full_version` markers on ipython's dependencies.

## Build requirement

svy-rs now declares `rust-version = "1.91"` (polars calls `i64::strict_abs`, stable since 1.91, and declares no `rust-version` itself). Source builds only — wheel users unaffected, and all five wheel platforms build on CI's floating stable.

## Verified on this commit

`svy_rs` installs as 0.13.0; `svy.__version__` and `svy_rs.__version__` report 0.23.0 and 0.13.0; 80 Rust and 2856 Python tests pass.