### PR TITLE
docs(changelog): add missing 0.23.0 and svy-rs 0.13.0 release links

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -105,7 +105,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 Baseline for this changelog. For earlier history, see the [Git tags](https://github.com/samplics-org/svy/tags).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.12.1...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-rs-v0.13.0...HEAD
+[0.13.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.13.0
 [0.12.1]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.12.1
 [0.12.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.12.0
 [0.11.0]: https://github.com/samplics-org/svy/releases/tag/svy-rs-v0.11.0

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -338,7 +338,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.22.1...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.23.0...HEAD
+[0.23.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.23.0
 [0.22.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.22.1
 [0.22.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.22.0
 [0.21.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.21.0


### PR DESCRIPTION
The 0.23.0 release added the section headings but not the footer link definitions, so [0.23.0] and [0.13.0] render as plain text on the published release-notes page. Adds the two release-tag links and points both [Unreleased] compare ranges at the new tags.