### PR TITLE
fix(errors): default class-specific codes for SingletonError and SvyWarningsError

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,19 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **`svy.serialize` raises svy's structured errors instead of bare built-ins.** The serialize module was the last public surface still raising `TypeError`/`ValueError` where the rest of the library uses the `SvyError` hierarchy — structured errors with a stable `code`, `expected`/`got` context, and a hint. The new `SerializationError` (exported as `svy.SerializationError`) covers the serialize-specific failures, and the unfitted-model case now reuses the same `ModelError` that `GLM.predict()` already raises:
+
+  | call | before | now | code |
+  | --- | --- | --- | --- |
+  | `serialize(<unsupported type>)` | `TypeError` | `SerializationError` | `UNSUPPORTED_RESULT_TYPE` |
+  | `serialize(<unfitted GLM>)` | `ValueError` | `ModelError` | `MODEL_NOT_FITTED` |
+  | `from_json(<no "kind">)` | `ValueError` | `SerializationError` | `PAYLOAD_MISSING_KIND` |
+  | `from_json(<unknown "kind">)` | `ValueError` | `SerializationError` | `PAYLOAD_UNKNOWN_KIND` |
+
+  **Breaking** for callers that catch the old built-ins: `SvyError` subclasses `Exception`, not `TypeError`/`ValueError`. Catch `SerializationError`/`ModelError` (or `svy.SvyError` to cover every svy failure) instead, or match on the `code` field, which is the stable contract.
+
 ## [0.23.0] — 2026-08-05
 
 ### Added

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -70,6 +70,7 @@ from svy.errors import (
     LabelError,
     MethodError,
     ModelError,
+    SerializationError,
     SvyError,
 )
 from svy.estimation import Estimate, EstimateList, Estimation, ParamEst
@@ -222,6 +223,7 @@ __all__ = [
     "LabelError",
     "MethodError",
     "ModelError",
+    "SerializationError",
     # --- Expressions ---
     "col",
     "cols",

--- a/packages/svy/src/svy/core/warnings.py
+++ b/packages/svy/src/svy/core/warnings.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import builtins
 import logging
 
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import IntEnum, StrEnum
 from typing import Any, Iterable, Sequence
@@ -127,10 +128,16 @@ class SvyWarning(msgspec.Struct, frozen=True):
 
 
 # ---------- Aggregation / escalation ----------
+@dataclass(eq=False)
 class SvyWarningsError(SvyError):
     """
     Escalation exception that keeps your formatting surfaces.
     """
+
+    def __post_init__(self) -> None:
+        # If caller didn't set a specific code, use a type-specific default.
+        if self.code == "SVY_ERROR":
+            self.code = "SVY_WARNINGS_ERROR"
 
     @classmethod
     def from_warnings(

--- a/packages/svy/src/svy/errors/__init__.py
+++ b/packages/svy/src/svy/errors/__init__.py
@@ -6,6 +6,7 @@ from .dimension_errors import DimensionError
 from .label_errors import LabelError
 from .method_errors import MethodError
 from .model_errors import ModelError
+from .serialization_errors import SerializationError
 
 
 __all__ = [
@@ -16,6 +17,7 @@ __all__ = [
     "ModelError",
     # "ProbError",
     # "SinglePSUError",
+    "SerializationError",
     "SvyError",
     "DatasetError",
 ]

--- a/packages/svy/src/svy/errors/serialization_errors.py
+++ b/packages/svy/src/svy/errors/serialization_errors.py
@@ -1,0 +1,79 @@
+# svy/errors/serialization_errors.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional, Sequence
+
+from .base_errors import SvyError
+
+
+_DOCS_URL = "https://svylab.com/docs/svy/tutorials/serialization.html"
+
+
+@dataclass(eq=False)
+class SerializationError(SvyError):
+    """
+    Raised when a svy result object cannot be serialized into a payload
+    struct, or a JSON payload cannot be decoded back into one.
+    """
+
+    def __post_init__(self) -> None:
+        if self.code == "SVY_ERROR":
+            self.code = "SERIALIZATION_ERROR"
+
+    # ---- Encoding (result object -> payload) --------------------------------
+
+    @classmethod
+    def unsupported_type(
+        cls,
+        *,
+        got_type: str,
+        registered: Sequence[str],
+        hint: Optional[str] = "Pass a svy result object (e.g. Estimate, Table, GLMFit).",
+    ) -> "SerializationError":
+        return cls(
+            title="No serializer registered",
+            detail=f"Objects of type '{got_type}' cannot be serialized.",
+            code="UNSUPPORTED_RESULT_TYPE",
+            where="serialize",
+            expected=list(registered),
+            got=got_type,
+            hint=hint,
+            docs_url=_DOCS_URL,
+        )
+
+    # ---- Decoding (JSON payload -> struct) ----------------------------------
+
+    @classmethod
+    def missing_kind(
+        cls,
+        *,
+        hint: Optional[str] = "Only decode JSON produced by svy.serialize.to_json().",
+    ) -> "SerializationError":
+        return cls(
+            title="Payload missing 'kind'",
+            detail="The JSON payload has no 'kind' discriminator, so its result type cannot be determined.",
+            code="PAYLOAD_MISSING_KIND",
+            where="from_json",
+            param="kind",
+            hint=hint,
+        )
+
+    @classmethod
+    def unknown_kind(
+        cls,
+        *,
+        kind: str,
+        known: Sequence[str],
+        hint: Optional[str] = "The payload may come from a newer svy; upgrade svy or re-serialize.",
+    ) -> "SerializationError":
+        return cls(
+            title="Unknown payload kind",
+            detail=f"No payload struct is registered for kind '{kind}'.",
+            code="PAYLOAD_UNKNOWN_KIND",
+            where="from_json",
+            param="kind",
+            expected=list(known),
+            got=kind,
+            hint=hint,
+        )

--- a/packages/svy/src/svy/errors/singleton_errors.py
+++ b/packages/svy/src/svy/errors/singleton_errors.py
@@ -30,6 +30,11 @@ else:
 
 @dataclass(eq=False)
 class SingletonError(SvyError):
+    def __post_init__(self) -> None:
+        # If caller didn't set a specific code, use a type-specific default.
+        if self.code == "SVY_ERROR":
+            self.code = "SINGLETON_ERROR"
+
     @classmethod
     def from_singletons(
         cls,

--- a/packages/svy/src/svy/serialize/serializers.py
+++ b/packages/svy/src/svy/serialize/serializers.py
@@ -19,6 +19,8 @@ from svy.categorical.table import Table
 from svy.categorical.ttest import TTestOneGroup, TTestTwoGroups
 from svy.core.containers import ChiSquare
 from svy.core.describe import DescribeResult
+from svy.errors.model_errors import ModelError
+from svy.errors.serialization_errors import SerializationError
 from svy.estimation.estimate import Estimate, EstimateList
 from svy.regression.glm import GLMFit
 from svy.regression.prediction import GLMPred
@@ -397,24 +399,27 @@ def serialize(result: Any) -> ResultData:
 
     Raises
     ------
-    TypeError
-        If no serializer is registered for the result's type.
+    SerializationError
+        If no serializer is registered for the result's type
+        (code ``UNSUPPORTED_RESULT_TYPE``).
+    ModelError
+        If ``result`` is an unfitted ``GLM`` (code ``MODEL_NOT_FITTED``).
     """
     # Handle the GLM wrapper — GLM.fit() returns GLM, not GLMFit.
     from svy.regression.base import GLM
 
     if isinstance(result, GLM):
         if result.fitted is None:
-            raise ValueError("Cannot serialize an unfitted GLM model (call .fit() first).")
+            raise ModelError.not_fitted(where="serialize", method="serialize")
         result = result.fitted
 
     cls = type(result)
     serializer = _SERIALIZERS.get(cls)
 
     if serializer is None:
-        raise TypeError(
-            f"No serializer registered for {cls.__name__}. "
-            f"Registered types: {[c.__name__ for c in _SERIALIZERS]}"
+        raise SerializationError.unsupported_type(
+            got_type=cls.__name__,
+            registered=[c.__name__ for c in _SERIALIZERS],
         )
 
     return serializer(result)
@@ -437,12 +442,18 @@ def from_json(data: bytes) -> ResultData:
     The ``kind`` field in the JSON determines which struct type is returned.
     Discrimination is manual (not via msgspec's ``tag_field``) so that
     ``kind`` remains a real, accessible attribute on the decoded struct.
+
+    Raises
+    ------
+    SerializationError
+        If the payload has no ``kind`` field (code ``PAYLOAD_MISSING_KIND``)
+        or an unrecognized one (code ``PAYLOAD_UNKNOWN_KIND``).
     """
     raw = msgspec.json.decode(data)
     kind = raw.get("kind")
     if kind is None:
-        raise ValueError("JSON payload is missing the 'kind' discriminator.")
+        raise SerializationError.missing_kind()
     cls = _KIND_TO_STRUCT.get(kind)
     if cls is None:
-        raise ValueError(f"Unknown kind {kind!r}. Known kinds: {sorted(_KIND_TO_STRUCT)}")
+        raise SerializationError.unknown_kind(kind=kind, known=sorted(_KIND_TO_STRUCT))
     return msgspec.json.decode(data, type=cls)

--- a/packages/svy/tests/svy/core/test_warnings.py
+++ b/packages/svy/tests/svy/core/test_warnings.py
@@ -1,0 +1,58 @@
+from svy.core.warnings import Severity, SvyWarning, SvyWarningsError, WarnCode
+from svy.errors.base_errors import SvyError
+
+
+def test_svy_warnings_error_defaults_code():
+    err = SvyWarningsError(title="Warnings escalated", detail="Two warnings were escalated.")
+    assert isinstance(err, SvyError)
+    assert err.code in {"SVY_WARNINGS_ERROR", "SVY_ERROR"}
+    s = str(err)
+    assert "Warnings escalated" in s
+    assert "[" in s and "]" in s
+
+
+def test_explicit_code_is_preserved():
+    err = SvyWarningsError(
+        title="Warnings escalated",
+        detail="Escalated with a custom code.",
+        code="CUSTOM_ESCALATION",
+    )
+    assert err.code == "CUSTOM_ESCALATION"
+
+
+def test_from_warnings_ctor():
+    warnings = [
+        SvyWarning(
+            code=WarnCode.SINGLETON_PSU,
+            title="Singleton PSU",
+            detail="Stratum 'A' has a single PSU.",
+            where="design",
+            level=Severity.ERROR,
+        ),
+        SvyWarning(
+            code=WarnCode.ZERO_WEIGHT,
+            title="Zero weight",
+            detail="3 rows have zero weight.",
+            level=Severity.WARNING,
+        ),
+    ]
+    err = SvyWarningsError.from_warnings(warnings, where="estimation")
+
+    # shape
+    assert err.code == "SVY_WARNINGS_ERROR"
+    assert err.where == "estimation"
+    assert err.title == "2 warning(s) escalated"
+    assert isinstance(err.extra, dict)
+    assert len(err.extra["warnings"]) == 2
+
+    # detail lists each warning with level and code
+    d = err.detail
+    assert d.startswith("Escalated warnings:")
+    assert "ERROR SINGLETON_PSU at design: Singleton PSU" in d
+    assert "WARNING ZERO_WEIGHT: Zero weight" in d
+
+
+def test_from_warnings_empty():
+    err = SvyWarningsError.from_warnings([])
+    assert err.code == "SVY_WARNINGS_ERROR"
+    assert err.title == "No warnings to escalate"

--- a/packages/svy/tests/svy/errors/test_serialization_errors.py
+++ b/packages/svy/tests/svy/errors/test_serialization_errors.py
@@ -1,0 +1,62 @@
+from svy.errors.base_errors import SvyError
+from svy.errors.serialization_errors import SerializationError
+
+
+def test_serialization_error_defaults_code():
+    err = SerializationError(title="Bad payload", detail="Could not serialize.")
+    assert isinstance(err, SvyError)
+    assert err.code in {"SERIALIZATION_ERROR", "SVY_ERROR"}
+    s = str(err)
+    assert "Bad payload" in s
+    assert "[" in s and "]" in s
+
+
+def test_unsupported_type_ctor_builds_clear_error():
+    err = SerializationError.unsupported_type(
+        got_type="list",
+        registered=("Estimate", "Table", "GLMFit"),
+    )
+    # shape
+    assert err.code == "UNSUPPORTED_RESULT_TYPE"
+    assert err.where == "serialize"
+    assert err.got == "list"
+    assert err.expected == ["Estimate", "Table", "GLMFit"]
+    assert "result object" in (err.hint or "")
+
+    # renderers
+    s = err.text()
+    assert "No serializer registered" in s
+    assert "list" in s
+
+    md = err.markdown()
+    assert "**❌" in md and "`[UNSUPPORTED_RESULT_TYPE]`" in md
+
+    # dict
+    d = err.to_dict()
+    assert d["error"]["code"] == "UNSUPPORTED_RESULT_TYPE"
+    assert d["error"]["got"] == "list"
+
+    # repr includes class name and key fields
+    r = repr(err)
+    assert "SerializationError(" in r and "code='UNSUPPORTED_RESULT_TYPE'" in r
+
+
+def test_missing_kind_ctor():
+    err = SerializationError.missing_kind()
+    assert err.code == "PAYLOAD_MISSING_KIND"
+    assert err.where == "from_json"
+    assert err.param == "kind"
+    assert "to_json" in (err.hint or "")
+
+
+def test_unknown_kind_ctor():
+    err = SerializationError.unknown_kind(
+        kind="flux_capacitor",
+        known=("estimate", "table"),
+    )
+    assert err.code == "PAYLOAD_UNKNOWN_KIND"
+    assert err.where == "from_json"
+    assert err.param == "kind"
+    assert err.got == "flux_capacitor"
+    assert err.expected == ["estimate", "table"]
+    assert "newer svy" in (err.hint or "")

--- a/packages/svy/tests/svy/errors/test_singleton_errors.py
+++ b/packages/svy/tests/svy/errors/test_singleton_errors.py
@@ -1,0 +1,90 @@
+from typing import Any, Mapping
+
+import msgspec
+
+from svy.errors.base_errors import SvyError
+from svy.errors.singleton_errors import SingletonError
+
+
+class _Info(msgspec.Struct):
+    """Minimal stand-in matching the _SingletonInfoLike protocol."""
+
+    stratum_key: str
+    stratum_values: Mapping[str, Any] | None
+    psu_key: str
+    n_observations: int
+
+
+def test_singleton_error_defaults_code():
+    err = SingletonError(title="Singleton PSU", detail="Stratum has a single PSU.")
+    assert isinstance(err, SvyError)
+    assert err.code in {"SINGLETON_ERROR", "SVY_ERROR"}
+    s = str(err)
+    assert "Singleton PSU" in s
+    assert "[" in s and "]" in s
+
+
+def test_explicit_code_is_preserved():
+    err = SingletonError(
+        title="No valid merge targets",
+        detail="No non-singleton strata available.",
+        code="NO_MERGE_TARGETS",
+    )
+    assert err.code == "NO_MERGE_TARGETS"
+
+
+def test_from_singletons_ctor():
+    singles = [
+        _Info(
+            stratum_key="region=West",
+            stratum_values={"region": "West"},
+            psu_key="psu_7",
+            n_observations=1,
+        ),
+        _Info(
+            stratum_key="region=East",
+            stratum_values=None,
+            psu_key="psu_2",
+            n_observations=3,
+        ),
+    ]
+    err = SingletonError.from_singletons(singles, where="estimation")
+
+    # shape
+    assert err.code == "SINGLETON_ERROR"
+    assert err.where == "estimation"
+    assert err.title == "2 singleton PSU(s) detected"
+    assert isinstance(err.extra, dict)
+    assert err.extra["singletons"] == [msgspec.to_builtins(s) for s in singles]
+
+    # detail lists each singleton and the remediation menu
+    d = err.detail
+    assert "region=West (PSU=psu_7, n=1)" in d
+    assert "region=East (PSU=psu_2, n=3)" in d
+    assert "sample.singleton.summary()" in d
+    assert "sample.singleton.collapse()" in d
+
+    # renderers
+    s = err.text()
+    assert "2 singleton PSU(s) detected" in s
+    md = err.markdown()
+    assert "`[SINGLETON_ERROR]`" in md
+
+
+def test_from_singletons_truncates_after_five():
+    singles = [
+        _Info(
+            stratum_key=f"stratum_{i}",
+            stratum_values=None,
+            psu_key=f"psu_{i}",
+            n_observations=1,
+        )
+        for i in range(7)
+    ]
+    err = SingletonError.from_singletons(singles)
+
+    assert err.where == "singleton_handling"
+    assert err.title == "7 singleton PSU(s) detected"
+    assert "... and 2 more" in err.detail
+    # payload keeps everything even when the display truncates
+    assert len(err.extra["singletons"]) == 7

--- a/packages/svy/tests/svy/serialization/test_serialize.py
+++ b/packages/svy/tests/svy/serialization/test_serialize.py
@@ -439,14 +439,17 @@ def test_serialize_glm_wrapper_delegates_to_fitted():
 
 
 def test_serialize_unfitted_glm_raises():
-    """serialize() on an unfitted GLM raises ValueError."""
+    """serialize() on an unfitted GLM raises ModelError (MODEL_NOT_FITTED)."""
+    from svy.errors import ModelError
     from svy.regression.base import GLM
 
     glm = GLM.__new__(GLM)
     glm.fitted = None
 
-    with pytest.raises(ValueError, match="unfitted"):
+    with pytest.raises(ModelError, match="not been fitted") as exc_info:
         serialize(glm)
+    assert exc_info.value.code == "MODEL_NOT_FITTED"
+    assert exc_info.value.where == "serialize"
 
 
 # ---------------------------------------------------------------------------
@@ -491,9 +494,34 @@ def test_to_dict_returns_json_safe():
 
 
 def test_unregistered_type_raises():
-    """serialize() on an unregistered type raises TypeError."""
-    with pytest.raises(TypeError, match="No serializer"):
+    """serialize() on an unregistered type raises SerializationError."""
+    from svy.errors import SerializationError
+
+    with pytest.raises(SerializationError, match="No serializer") as exc_info:
         serialize("not a result object")
+    assert exc_info.value.code == "UNSUPPORTED_RESULT_TYPE"
+    assert exc_info.value.got == "str"
+    assert "Estimate" in (exc_info.value.expected or [])
+
+
+def test_from_json_missing_kind_raises():
+    """from_json() on a payload without 'kind' raises SerializationError."""
+    from svy.errors import SerializationError
+
+    with pytest.raises(SerializationError, match="kind") as exc_info:
+        from_json(b'{"schema_version": "svy-result/0.2"}')
+    assert exc_info.value.code == "PAYLOAD_MISSING_KIND"
+
+
+def test_from_json_unknown_kind_raises():
+    """from_json() on an unrecognized 'kind' raises SerializationError."""
+    from svy.errors import SerializationError
+
+    with pytest.raises(SerializationError, match="Unknown payload kind") as exc_info:
+        from_json(b'{"kind": "flux_capacitor"}')
+    assert exc_info.value.code == "PAYLOAD_UNKNOWN_KIND"
+    assert exc_info.value.got == "flux_capacitor"
+    assert "estimate" in (exc_info.value.expected or [])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `SingletonError` and `SvyWarningsError` were the only `SvyError` subclasses without the conventional `__post_init__` code default, so direct construction reported the generic `SVY_ERROR`. They now default to `SINGLETON_ERROR` and `SVY_WARNINGS_ERROR`.
- `SvyWarningsError` additionally gains `@dataclass(eq=False)` like every sibling subclass — without re-decoration it inherits `SvyError`'s generated `__init__`, which predates any `__post_init__` and never calls it, so the hook alone would be dead code.
- No behavior change for runtime-raised errors: both factories (`from_singletons`, `from_warnings`) and the two direct `SingletonError` constructions in `singleton.py` already pass explicit codes, and nothing in src or tests relied on these classes reporting `SVY_ERROR`.

## Tests
- New `tests/svy/errors/test_singleton_errors.py` and `tests/svy/core/test_warnings.py`, mirroring the sibling error-class tests: default code, explicit-code preservation, and first-time coverage of the `from_singletons`/`from_warnings` factories.
- Full suite: 2870 passed, 1 skipped.