### PR TITLE
feat(estimation): design-based correlation and covariance

### DIFF
--- a/packages/svy-rs/benches/kernel_bench.rs
+++ b/packages/svy-rs/benches/kernel_bench.rs
@@ -17,6 +17,10 @@
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use polars::prelude::*;
 
+use _internal::estimation::association::{
+    AssocKind, PairProducts, bivar_moments, multi_moments, point_estimate_corr,
+    replicate_association,
+};
 use _internal::estimation::taylor::{
     index_categorical, index_categorical_pair, point_estimate_mean, scores_mean, srs_variance_mean,
     taylor_variance,
@@ -162,11 +166,114 @@ fn bench_taylor_variance(c: &mut Criterion) {
     g.finish();
 }
 
+// ── Association: all-pairs sweep vs repeated pairwise kernels ───────────────
+//
+// Pairwise costs k(k+1)/2 two-pass kernels, each re-reading its two columns;
+// the matrix form reads each column twice regardless of k. This measures how
+// much of that O(k^2) → O(k) traffic reduction survives to the clock.
+
+fn make_col(n: usize, seed: usize) -> Float64Chunked {
+    let v: Vec<f64> = (0..n)
+        .map(|i| 100.0 + ((i * (7 + seed) + seed * 13) % 997) as f64 * 0.37)
+        .collect();
+    Float64Chunked::from_slice("c".into(), &v)
+}
+
+fn bench_all_pairs(c: &mut Criterion) {
+    let mut g = c.benchmark_group("association_all_pairs");
+    g.sample_size(20);
+    for &n in &SIZES {
+        for &k in &[5usize, 10] {
+            let owned: Vec<Float64Chunked> = (0..k).map(|s| make_col(n, s)).collect();
+            let cols: Vec<&Float64Chunked> = owned.iter().collect();
+            let w = make_w(n);
+            g.throughput(Throughput::Elements((n * k) as u64));
+
+            g.bench_with_input(BenchmarkId::new("matrix", format!("{n}/k{k}")), &k, |b, _| {
+                b.iter(|| black_box(multi_moments(black_box(&cols), black_box(&w), None).unwrap()))
+            });
+
+            g.bench_with_input(BenchmarkId::new("pairwise", format!("{n}/k{k}")), &k, |b, _| {
+                b.iter(|| {
+                    let mut acc = 0.0f64;
+                    for j in 0..k {
+                        for l in j..k {
+                            let m = bivar_moments(cols[j], cols[l], &w, None).unwrap();
+                            acc += m.m_yx;
+                        }
+                    }
+                    black_box(acc)
+                })
+            });
+        }
+    }
+    g.finish();
+}
+
+// ── Association: replicate recomputation, precomputed vs from scratch ──────
+//
+// y*x, y^2 and x^2 do not depend on the weights. Forming them once turns each
+// replicate into six weighted dot products; recomputing them per replicate
+// repeats R*n multiplications.
+
+fn bench_replicate_association(c: &mut Criterion) {
+    let mut g = c.benchmark_group("association_replicates");
+    g.sample_size(10);
+    const N_REPS: usize = 200;
+
+    for &n in &[100_000usize] {
+        let y = make_col(n, 1);
+        let x = make_col(n, 2);
+        let w = make_w(n);
+
+        // JK1-shaped replicate weights over PSU_PER_STRATUM clusters.
+        let reps: Vec<Vec<f64>> = (0..N_REPS)
+            .map(|r| {
+                (0..n)
+                    .map(|i| {
+                        let psu = i % PSU_PER_STRATUM;
+                        if psu == r % PSU_PER_STRATUM { 0.0 } else { 0.5 + (i % 7) as f64 * 0.25 }
+                    })
+                    .collect()
+            })
+            .collect();
+        let cols: Vec<&[f64]> = reps.iter().map(|v| v.as_slice()).collect();
+        g.throughput(Throughput::Elements((n * N_REPS) as u64));
+
+        g.bench_function(BenchmarkId::new("precomputed", n), |b| {
+            let p = PairProducts::new(&y, &x, &w, None).unwrap();
+            b.iter(|| {
+                black_box(replicate_association(
+                    black_box(&p),
+                    black_box(&cols),
+                    AssocKind::Corr,
+                ))
+            })
+        });
+
+        g.bench_function(BenchmarkId::new("recompute", n), |b| {
+            b.iter(|| {
+                let out: Vec<f64> = cols
+                    .iter()
+                    .map(|col| {
+                        let rw = Float64Chunked::from_slice("rw".into(), col);
+                        point_estimate_corr(&y, &x, &rw).unwrap()
+                    })
+                    .collect();
+                black_box(out)
+            })
+        });
+    }
+    g.finish();
+}
+
 criterion_group!(
     benches,
     bench_index_categorical,
     bench_index_categorical_pair,
     bench_point_estimates,
     bench_taylor_variance,
+    bench_all_pairs,
+    bench_replicate_association,
 );
 criterion_main!(benches);

--- a/packages/svy-rs/src/estimation/association.rs
+++ b/packages/svy-rs/src/estimation/association.rs
@@ -797,11 +797,83 @@ pub fn multi_moments(
 // Replication: precomputed products, one dot product set per replicate
 // ============================================================================
 
-/// Which association a replicate recomputes.
+/// Which association is being estimated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AssocKind {
     Corr,
     Cov,
+}
+
+impl AssocKind {
+    /// Parse the selector the Python layer sends. Aliases are accepted the way
+    /// `_normalize_ci_method` accepts them: case-insensitive, underscores and
+    /// hyphens interchangeable.
+    pub fn from_name(s: &str) -> PolarsResult<Self> {
+        match s.to_lowercase().replace('_', "-").as_str() {
+            "corr" | "correlation" | "pearson" => Ok(AssocKind::Corr),
+            "cov" | "covariance" => Ok(AssocKind::Cov),
+            other => Err(PolarsError::ComputeError(
+                format!("unknown association kind '{other}'; expected 'corr' or 'cov'").into(),
+            )),
+        }
+    }
+
+    /// Label carried into the result frame.
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AssocKind::Corr => "corr",
+            AssocKind::Cov => "cov",
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kind-dispatching entry points
+//
+// The API layer works in terms of (kind, optional domain) rather than four
+// separately-named functions per statistic, so the dispatch lives here once
+// instead of being rebuilt at every call site.
+// ---------------------------------------------------------------------------
+
+pub fn point_estimate_assoc(
+    kind: AssocKind,
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+) -> PolarsResult<f64> {
+    match (kind, domain) {
+        (AssocKind::Corr, None) => point_estimate_corr(y, x, weights),
+        (AssocKind::Corr, Some(d)) => point_estimate_corr_domain(y, x, weights, d),
+        (AssocKind::Cov, None) => point_estimate_cov(y, x, weights),
+        (AssocKind::Cov, Some(d)) => point_estimate_cov_domain(y, x, weights, d),
+    }
+}
+
+pub fn scores_assoc(
+    kind: AssocKind,
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+) -> PolarsResult<Float64Chunked> {
+    match (kind, domain) {
+        (AssocKind::Corr, None) => scores_corr(y, x, weights),
+        (AssocKind::Corr, Some(d)) => scores_corr_domain(y, x, weights, d),
+        (AssocKind::Cov, None) => scores_cov(y, x, weights),
+        (AssocKind::Cov, Some(d)) => scores_cov_domain(y, x, weights, d),
+    }
+}
+
+/// SRS reference variance for either association, over an optional domain.
+pub fn srs_variance_assoc_of(
+    kind: AssocKind,
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+) -> PolarsResult<f64> {
+    srs_variance_assoc(y, x, weights, domain, kind)
 }
 
 /// Full-sample-centered products for one pair, reused across every replicate.
@@ -823,6 +895,10 @@ pub struct PairProducts {
     aa: Vec<f64>,
     bb: Vec<f64>,
     ab: Vec<f64>,
+    /// Domain indicator as a 0/1 float, matching the replication layer's
+    /// convention. Held rather than baked into the products because the
+    /// per-replicate weight sum must also exclude out-of-domain rows.
+    mask: Option<Vec<f64>>,
     /// Full-sample n, held fixed across replicates as R holds it.
     n: usize,
 }
@@ -832,9 +908,20 @@ impl PairProducts {
         y: &Float64Chunked,
         x: &Float64Chunked,
         weights: &Float64Chunked,
-        domain: Option<&BooleanChunked>,
+        domain: Option<&[f64]>,
     ) -> PolarsResult<Self> {
-        let full = bivar_moments(y, x, weights, domain)?;
+        // Fold the domain into the weights for the full-sample moments: a
+        // zeroed weight is exactly how an out-of-domain row drops out, and
+        // `bivar_moments` already keeps zero-weight rows out of `n`.
+        let masked: Option<Float64Chunked> = domain.map(|m| {
+            let v: Vec<f64> = (0..y.len())
+                .map(|i| {
+                    weights.get(i).unwrap_or(0.0) * m.get(i).copied().unwrap_or(0.0)
+                })
+                .collect();
+            Float64Chunked::from_slice("w".into(), &v)
+        });
+        let full = bivar_moments(y, x, masked.as_ref().unwrap_or(weights), None)?;
         let (mean_y, mean_x) = if full.sum_w == 0.0 {
             (0.0, 0.0)
         } else {
@@ -849,12 +936,10 @@ impl PairProducts {
         let mut ab = Vec::with_capacity(len);
 
         for i in 0..len {
-            // A row excluded here contributes zero to every replicate sum,
-            // which is how nulls and out-of-domain rows drop out without
-            // disturbing the design structure.
-            let keep = domain.is_none_or(|d| d.get(i) == Some(true));
-            let (av, bv) = match (y.get(i), x.get(i), keep) {
-                (Some(yv), Some(xv), true) => (yv - mean_y, xv - mean_x),
+            // A null row contributes zero to every replicate sum, which drops
+            // it without disturbing the design structure.
+            let (av, bv) = match (y.get(i), x.get(i)) {
+                (Some(yv), Some(xv)) => (yv - mean_y, xv - mean_x),
                 _ => (0.0, 0.0),
             };
             a.push(av);
@@ -864,7 +949,7 @@ impl PairProducts {
             ab.push(av * bv);
         }
 
-        Ok(PairProducts { a, b, aa, bb, ab, n: full.n })
+        Ok(PairProducts { a, b, aa, bb, ab, mask: domain.map(<[f64]>::to_vec), n: full.n })
     }
 
     /// Recompute the association under one replicate weight column.
@@ -878,14 +963,18 @@ impl PairProducts {
 
         // Pre-slicing all six arrays to a common length lets the bounds checks
         // fall out of the loop body. The traversal is six-way parallel, so an
-        // index walk expresses it more directly than nested zips would.
+        // index walk expresses it more directly than nested zips would. The
+        // domain branch is hoisted out of the loop rather than tested per row.
         let n = self.a.len().min(rep_w.len());
         let (w_s, a_s, b_s) = (&rep_w[..n], &self.a[..n], &self.b[..n]);
         let (aa_s, bb_s, ab_s) = (&self.aa[..n], &self.bb[..n], &self.ab[..n]);
 
         #[allow(clippy::needless_range_loop)]
         for i in 0..n {
-            let w = w_s[i];
+            let w = match &self.mask {
+                Some(m) => w_s[i] * m[i],
+                None => w_s[i],
+            };
             sw += w;
             sa += w * a_s[i];
             sb += w * b_s[i];

--- a/packages/svy-rs/src/estimation/association.rs
+++ b/packages/svy-rs/src/estimation/association.rs
@@ -1,0 +1,1535 @@
+// src/estimation/association.rs
+//
+// Bivariate association estimators: covariance and Pearson correlation.
+//
+// Both are smooth functions of the same six weighted totals, so they share one
+// moment kernel and differ only in the final combination and in the
+// linearization handed to the variance machinery.
+//
+// # Estimands
+//
+// With W = sum(w), ybar = sum(w y)/W, a = y - ybar, b = x - xbar:
+//
+//   m_yx = sum(w a b) / W          (and m_yy, m_xx likewise)
+//   cov  = m_yx * n/(n-1)
+//   corr = m_yx / sqrt(m_yy * m_xx)
+//
+// The n/(n-1) factor on the covariance matches R's `svyvar`, which builds the
+// estimate as `svymean(a*b*n/(n-1))` (survey 4.5, R/survey.R:703-723) with the
+// source comment "Kish uses the n-1 divisor, so it affects design effects".
+// `n` there is the count of rows with NONZERO SAMPLING WEIGHT and no missing
+// value -- not the frame height -- so `where=`/`drop_nulls` rows, which reach
+// this kernel zero-weighted rather than deleted, are excluded exactly as R
+// excludes them. The correlation needs no such choice: any common divisor
+// cancels between numerator and denominator, so corr is divisor-invariant.
+//
+// # Linearization
+//
+// For the covariance, R centers by the ESTIMATED mean and then treats the
+// cross-product as a fixed analysis variable. That looks like it drops the
+// contribution of having estimated ybar and xbar, but those terms cancel
+// identically:
+//
+//   IF = (yx - mu_yx) - xbar(y - ybar) - ybar(x - xbar) = a*b - m_yx
+//
+// so the shortcut is exactly the delta-method influence function, and our
+// covariance SE agrees with `svyvar` rather than merely approximating it.
+//
+// For the correlation the terms do NOT cancel, because the standard deviations
+// in the denominator are themselves estimated. Writing rho as a function of the
+// six totals and applying the chain rule collapses to
+//
+//   IF = yt*xt - (rho/2)(yt^2 + xt^2),   yt = a/s_y,  xt = b/s_x
+//
+// which is the classic Pearson influence function. Feeding the covariance-style
+// score to a correlation would understate its variance.
+//
+// In both cases the score handed to the variance kernel is z_i = (w_i/W) * IF_i,
+// matching the convention already used by `scores_mean` and `scores_ratio`.
+//
+// # Numerical stability
+//
+// Moments are accumulated in two passes (means, then centered sums) rather than
+// from raw sums of squares. The textbook one-pass form
+// `sum(w y^2)/W - ybar^2` cancels catastrophically whenever the mean is large
+// relative to the spread -- for income-like data (mean 5e4, sd 1e4) it discards
+// roughly seven significant digits, and for a covariance that error lands
+// directly in the reported estimate. Two passes cost one extra sweep of memory
+// that the Taylor path pays anyway, since the scores cannot be formed until
+// rho, the means and the standard deviations are known.
+//
+// Accumulation is strictly row-ordered and never parallelized within a single
+// estimate, per the determinism policy in `mod.rs`: output must stay
+// bit-identical across rayon thread counts.
+
+use polars::prelude::*;
+
+/// Weighted bivariate moments shared by the covariance and correlation paths.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BivarMoments {
+    /// Sum of weights over contributing rows.
+    pub sum_w: f64,
+    /// Weighted mean of y.
+    pub mean_y: f64,
+    /// Weighted mean of x.
+    pub mean_x: f64,
+    /// sum(w (y-ybar)^2) / W
+    pub m_yy: f64,
+    /// sum(w (x-xbar)^2) / W
+    pub m_xx: f64,
+    /// sum(w (y-ybar)(x-xbar)) / W
+    pub m_yx: f64,
+    /// Count of rows with nonzero weight and no missing value, matching the
+    /// `n` R's `svyvar` uses for its n/(n-1) factor.
+    pub n: usize,
+}
+
+impl BivarMoments {
+    /// Kish's n/(n-1) inflation, or NaN when fewer than two rows contribute.
+    #[inline]
+    fn kish_factor(&self) -> f64 {
+        if self.n < 2 {
+            f64::NAN
+        } else {
+            self.n as f64 / (self.n as f64 - 1.0)
+        }
+    }
+
+    /// Design-based covariance, on R's `svyvar` scale.
+    #[inline]
+    pub fn cov(&self) -> f64 {
+        self.m_yx * self.kish_factor()
+    }
+
+    /// Design-based Pearson correlation. NaN when either variable is constant,
+    /// which is the same answer `cov2cor` gives a zero-variance diagonal.
+    #[inline]
+    pub fn corr(&self) -> f64 {
+        let denom = (self.m_yy * self.m_xx).sqrt();
+        if denom > 0.0 { self.m_yx / denom } else { f64::NAN }
+    }
+}
+
+/// True when both slices are contiguous and null-free, enabling the fast path.
+fn cont_triple<'a>(
+    y: &'a Float64Chunked,
+    x: &'a Float64Chunked,
+    w: &'a Float64Chunked,
+) -> Option<(&'a [f64], &'a [f64], &'a [f64])> {
+    if y.null_count() == 0
+        && x.null_count() == 0
+        && w.null_count() == 0
+        && let (Ok(sy), Ok(sx), Ok(sw)) = (y.cont_slice(), x.cont_slice(), w.cont_slice())
+    {
+        return Some((sy, sx, sw));
+    }
+    None
+}
+
+/// Accumulate weighted bivariate moments over the rows selected by `domain`
+/// (all rows when `None`).
+///
+/// Rows that are null in y, x or w, and rows outside the domain, contribute
+/// nothing and are not counted in `n`. Zero-weight rows contribute nothing to
+/// the sums and are likewise excluded from `n` -- that is how `where=` and
+/// `drop_nulls` filtering, which arrive here as zeroed weights, stay consistent
+/// with R's definition of `n`.
+pub fn bivar_moments(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+) -> PolarsResult<BivarMoments> {
+    let mut sum_w = 0.0f64;
+    let mut sum_wy = 0.0f64;
+    let mut sum_wx = 0.0f64;
+    let mut n = 0usize;
+
+    // ---- pass 1: weights, means, and R's n -------------------------------
+    match (cont_triple(y, x, weights), domain) {
+        (Some((ys, xs, ws)), None) => {
+            for i in 0..ys.len() {
+                let w = ws[i];
+                sum_w += w;
+                sum_wy += w * ys[i];
+                sum_wx += w * xs[i];
+                if w != 0.0 {
+                    n += 1;
+                }
+            }
+        }
+        _ => {
+            for (((yi, xi), wi), mi) in y
+                .iter()
+                .zip(x.iter())
+                .zip(weights.iter())
+                .zip(mask_iter(domain, y.len()))
+            {
+                if let (Some(yv), Some(xv), Some(wv), true) = (yi, xi, wi, mi) {
+                    sum_w += wv;
+                    sum_wy += wv * yv;
+                    sum_wx += wv * xv;
+                    if wv != 0.0 {
+                        n += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    if sum_w == 0.0 {
+        return Ok(BivarMoments {
+            sum_w: 0.0,
+            mean_y: f64::NAN,
+            mean_x: f64::NAN,
+            m_yy: f64::NAN,
+            m_xx: f64::NAN,
+            m_yx: f64::NAN,
+            n,
+        });
+    }
+
+    let mean_y = sum_wy / sum_w;
+    let mean_x = sum_wx / sum_w;
+
+    // ---- pass 2: centered second moments ---------------------------------
+    let mut s_yy = 0.0f64;
+    let mut s_xx = 0.0f64;
+    let mut s_yx = 0.0f64;
+
+    match (cont_triple(y, x, weights), domain) {
+        (Some((ys, xs, ws)), None) => {
+            for i in 0..ys.len() {
+                let w = ws[i];
+                let a = ys[i] - mean_y;
+                let b = xs[i] - mean_x;
+                s_yy += w * a * a;
+                s_xx += w * b * b;
+                s_yx += w * a * b;
+            }
+        }
+        _ => {
+            for (((yi, xi), wi), mi) in y
+                .iter()
+                .zip(x.iter())
+                .zip(weights.iter())
+                .zip(mask_iter(domain, y.len()))
+            {
+                if let (Some(yv), Some(xv), Some(wv), true) = (yi, xi, wi, mi) {
+                    let a = yv - mean_y;
+                    let b = xv - mean_x;
+                    s_yy += wv * a * a;
+                    s_xx += wv * b * b;
+                    s_yx += wv * a * b;
+                }
+            }
+        }
+    }
+
+    Ok(BivarMoments {
+        sum_w,
+        mean_y,
+        mean_x,
+        m_yy: s_yy / sum_w,
+        m_xx: s_xx / sum_w,
+        m_yx: s_yx / sum_w,
+        n,
+    })
+}
+
+/// Iterate a domain mask, or an all-true mask of length `len` when absent.
+fn mask_iter(domain: Option<&BooleanChunked>, len: usize) -> Box<dyn Iterator<Item = bool> + '_> {
+    match domain {
+        Some(m) => Box::new(m.iter().map(|v| v == Some(true))),
+        None => Box::new(std::iter::repeat_n(true, len)),
+    }
+}
+
+// ============================================================================
+// Point estimates
+// ============================================================================
+
+pub fn point_estimate_cov(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<f64> {
+    let m = bivar_moments(y, x, weights, None)?;
+    if m.sum_w == 0.0 {
+        return Err(PolarsError::ComputeError(
+            "Sum of weights is zero; covariance is undefined".into(),
+        ));
+    }
+    Ok(m.cov())
+}
+
+pub fn point_estimate_cov_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<f64> {
+    // Domains degrade to NaN rather than erroring: one empty by-group must not
+    // fail the whole grouped call, matching `scores_ratio_domain`.
+    let m = bivar_moments(y, x, weights, Some(domain_mask))?;
+    Ok(if m.sum_w == 0.0 { f64::NAN } else { m.cov() })
+}
+
+pub fn point_estimate_corr(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<f64> {
+    let m = bivar_moments(y, x, weights, None)?;
+    if m.sum_w == 0.0 {
+        return Err(PolarsError::ComputeError(
+            "Sum of weights is zero; correlation is undefined".into(),
+        ));
+    }
+    Ok(m.corr())
+}
+
+pub fn point_estimate_corr_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<f64> {
+    let m = bivar_moments(y, x, weights, Some(domain_mask))?;
+    Ok(if m.sum_w == 0.0 { f64::NAN } else { m.corr() })
+}
+
+// ============================================================================
+// Linearization scores
+// ============================================================================
+
+/// Per-unit linearized values for the covariance.
+///
+/// z_i = (w_i/W)(a_i b_i - m_yx) * n/(n-1)
+///
+/// The Kish factor is a constant multiplier, so it scales the score -- and
+/// hence the SE -- exactly as it scales the estimate, keeping the two on the
+/// same footing as R's `svyvar`.
+pub fn scores_cov(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<Float64Chunked> {
+    let m = bivar_moments(y, x, weights, None)?;
+    if m.sum_w == 0.0 {
+        return Err(PolarsError::ComputeError(
+            "Sum of weights is zero; covariance is undefined".into(),
+        ));
+    }
+    Ok(assoc_score_values(y, x, weights, &m, None, AssocKind::Cov))
+}
+
+pub fn scores_cov_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<Float64Chunked> {
+    let m = bivar_moments(y, x, weights, Some(domain_mask))?;
+    if m.sum_w == 0.0 {
+        return Ok(Float64Chunked::from_slice("scores".into(), &vec![0.0; y.len()]));
+    }
+    Ok(assoc_score_values(y, x, weights, &m, Some(domain_mask), AssocKind::Cov))
+}
+
+/// Per-unit linearized values for the Pearson correlation.
+///
+/// z_i = (w_i/W)[ yt_i xt_i - (rho/2)(yt_i^2 + xt_i^2) ]
+///
+/// with yt, xt the weighted-standardized residuals. Verified against a numeric
+/// delta method over the six underlying totals; the scores sum to zero, as they
+/// must for a scale-free statistic.
+pub fn scores_corr(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<Float64Chunked> {
+    let m = bivar_moments(y, x, weights, None)?;
+    if m.sum_w == 0.0 {
+        return Err(PolarsError::ComputeError(
+            "Sum of weights is zero; correlation is undefined".into(),
+        ));
+    }
+    if !(m.m_yy > 0.0 && m.m_xx > 0.0) {
+        return Err(PolarsError::ComputeError(
+            "Zero weighted variance; correlation is undefined for a constant column".into(),
+        ));
+    }
+    Ok(assoc_score_values(y, x, weights, &m, None, AssocKind::Corr))
+}
+
+pub fn scores_corr_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<Float64Chunked> {
+    let m = bivar_moments(y, x, weights, Some(domain_mask))?;
+    if m.sum_w == 0.0 || !(m.m_yy > 0.0 && m.m_xx > 0.0) {
+        return Ok(Float64Chunked::from_slice("scores".into(), &vec![0.0; y.len()]));
+    }
+    Ok(assoc_score_values(y, x, weights, &m, Some(domain_mask), AssocKind::Corr))
+}
+
+/// Shared score writer: applies `f` to each contributing row, 0.0 elsewhere.
+///
+/// Out-of-domain rows emit 0.0 rather than null so the score vector stays
+/// full-length against the shared design build, exactly as the ratio domain
+/// kernels do.
+fn score_values(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+    f: impl Fn(f64, f64, f64) -> f64,
+) -> Float64Chunked {
+    match (cont_triple(y, x, weights), domain) {
+        (Some((ys, xs, ws)), None) => {
+            let vals: Vec<f64> = (0..ys.len()).map(|i| f(ys[i], xs[i], ws[i])).collect();
+            Float64Chunked::from_slice("scores".into(), &vals)
+        }
+        _ => {
+            let vals: Vec<f64> = y
+                .iter()
+                .zip(x.iter())
+                .zip(weights.iter())
+                .zip(mask_iter(domain, y.len()))
+                .map(|(((yi, xi), wi), mi)| match (yi, xi, wi, mi) {
+                    (Some(yv), Some(xv), Some(wv), true) => f(yv, xv, wv),
+                    _ => 0.0,
+                })
+                .collect();
+            Float64Chunked::from_slice("scores".into(), &vals)
+        }
+    }
+}
+
+/// Score kernel for either association: `z_i = (w_i/W) * u_i`, with `u` the
+/// shared influence function so the SE and the deff denominator can never be
+/// built from different linearizations.
+fn assoc_score_values(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    m: &BivarMoments,
+    domain: Option<&BooleanChunked>,
+    kind: AssocKind,
+) -> Float64Chunked {
+    let sum_w = m.sum_w;
+    let inf = Influence::new(kind, m);
+    score_values(y, x, weights, domain, move |yv, xv, wv| {
+        (wv / sum_w) * inf.eval(yv, xv)
+    })
+}
+
+// ============================================================================
+// SRS reference variance (the denominator of deff)
+// ============================================================================
+
+/// Loop-invariant pieces of an influence function, hoisted out of the row loop.
+///
+/// This is the single definition of `u`: the bracket the score kernels weight
+/// by `w/W`, and the variable whose population variance forms the SRS reference
+/// below. Keeping one definition is what stops a deff from being computed
+/// against a different linearization than the SE it is compared with.
+#[derive(Debug, Clone, Copy)]
+struct Influence {
+    kind: AssocKind,
+    mean_y: f64,
+    mean_x: f64,
+    m_yx: f64,
+    /// 1/s_y and 1/s_x, so the row loop multiplies instead of dividing.
+    inv_s_y: f64,
+    inv_s_x: f64,
+    rho: f64,
+    kish: f64,
+}
+
+impl Influence {
+    fn new(kind: AssocKind, m: &BivarMoments) -> Self {
+        Influence {
+            kind,
+            mean_y: m.mean_y,
+            mean_x: m.mean_x,
+            m_yx: m.m_yx,
+            inv_s_y: 1.0 / m.m_yy.sqrt(),
+            inv_s_x: 1.0 / m.m_xx.sqrt(),
+            rho: m.corr(),
+            kish: m.kish_factor(),
+        }
+    }
+
+    #[inline]
+    fn eval(&self, yv: f64, xv: f64) -> f64 {
+        let a = yv - self.mean_y;
+        let b = xv - self.mean_x;
+        match self.kind {
+            AssocKind::Cov => (a * b - self.m_yx) * self.kish,
+            AssocKind::Corr => {
+                let yt = a * self.inv_s_y;
+                let xt = b * self.inv_s_x;
+                yt * xt - 0.5 * self.rho * (yt * yt + xt * xt)
+            }
+        }
+    }
+}
+
+/// SRS reference variance for a design effect.
+///
+/// svy computes deff as `V_design / V_srs`, where `V_srs` is a plug-in: the
+/// estimated population variance of the estimator's influence function, divided
+/// by the nominal `n`, times the finite-population correction `1 - n/N_hat`.
+/// That is the rule `srs_variance_mean` and `srs_variance_ratio` already apply
+/// (taylor.rs), and it is R's rule too -- `svymean` builds its reference as
+/// `svyvar(x, design)/nobs * (psum-nobs)/psum` (R/survey.R:557-562).
+///
+/// Note R offers no deff for `svyvar`, so there is no upstream behaviour to
+/// match for an association; this follows svy's own established pattern rather
+/// than porting anything.
+///
+/// Taking the *empirical* variance of the influence function, rather than the
+/// textbook `(1-rho^2)^2/n`, is deliberate. The two agree asymptotically -- the
+/// textbook form is exactly what this converges to under bivariate normality --
+/// but the empirical version needs no distributional assumption, which is very
+/// likely why R declined to define deff here at all.
+///
+/// For the covariance the Kish factor enters the influence function and the
+/// estimate alike, so it cancels out of deff entirely.
+fn srs_variance_assoc(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+    kind: AssocKind,
+) -> PolarsResult<f64> {
+    let m = bivar_moments(y, x, weights, domain)?;
+    if m.sum_w == 0.0 || (kind == AssocKind::Corr && !(m.m_yy > 0.0 && m.m_xx > 0.0)) {
+        return Ok(f64::NAN);
+    }
+
+    // Only positive-weight rows carry information, matching srs_variance_mean:
+    // zero-weight rows (out-of-domain, or nulls under domain semantics) must
+    // not inflate n and so must not deflate deff.
+    let inf = Influence::new(kind, &m);
+    let mut uv: Vec<f64> = Vec::new();
+    let mut wv: Vec<f64> = Vec::new();
+    for i in 0..y.len() {
+        if domain.is_some_and(|d| d.get(i) != Some(true)) {
+            continue;
+        }
+        if let (Some(yval), Some(xval), Some(wval)) = (y.get(i), x.get(i), weights.get(i))
+            && wval > 0.0
+        {
+            uv.push(inf.eval(yval, xval));
+            wv.push(wval);
+        }
+    }
+
+    let n = uv.len() as f64;
+    if n < 2.0 {
+        return Ok(f64::NAN);
+    }
+    let sum_w: f64 = wv.iter().sum();
+    if sum_w <= 0.0 {
+        return Ok(f64::NAN);
+    }
+    let wn: Vec<f64> = wv.iter().map(|w| w / sum_w).collect();
+    let s2_u = crate::estimation::taylor::weighted_s2(&uv, &wn);
+    Ok((s2_u / n) * (1.0 - (n / sum_w)))
+}
+
+pub fn srs_variance_corr(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<f64> {
+    srs_variance_assoc(y, x, weights, None, AssocKind::Corr)
+}
+
+pub fn srs_variance_corr_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<f64> {
+    srs_variance_assoc(y, x, weights, Some(domain_mask), AssocKind::Corr)
+}
+
+pub fn srs_variance_cov(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+) -> PolarsResult<f64> {
+    srs_variance_assoc(y, x, weights, None, AssocKind::Cov)
+}
+
+pub fn srs_variance_cov_domain(
+    y: &Float64Chunked,
+    x: &Float64Chunked,
+    weights: &Float64Chunked,
+    domain_mask: &BooleanChunked,
+) -> PolarsResult<f64> {
+    srs_variance_assoc(y, x, weights, Some(domain_mask), AssocKind::Cov)
+}
+
+// ============================================================================
+// All-pairs moments: one sweep for every pair
+// ============================================================================
+
+/// Centered second moments for every pair among `k` columns.
+///
+/// Computing `k` columns pairwise runs `k(k+1)/2` independent two-pass kernels,
+/// each re-reading its two columns: `2k(k+1)` column reads in total. Building
+/// the whole matrix in one sweep reads each column twice regardless of `k`, so
+/// traffic falls from O(k^2) to O(k) -- for ten variables, 110 column reads
+/// become 20. The arithmetic is unchanged (the same k^2/2 cross-products), but
+/// the kernel is memory-bound at scale, so the traffic is what shows up on the
+/// clock.
+#[derive(Debug, Clone)]
+pub struct MomentMatrix {
+    pub sum_w: f64,
+    pub n: usize,
+    pub k: usize,
+    pub means: Vec<f64>,
+    /// Row-major `k * k`: `m[j*k + l] = sum(w (yj-mj)(yl-ml)) / W`.
+    pub m: Vec<f64>,
+}
+
+impl MomentMatrix {
+    #[inline]
+    fn kish_factor(&self) -> f64 {
+        if self.n < 2 {
+            f64::NAN
+        } else {
+            self.n as f64 / (self.n as f64 - 1.0)
+        }
+    }
+
+    #[inline]
+    pub fn moment(&self, j: usize, l: usize) -> f64 {
+        self.m[j * self.k + l]
+    }
+
+    /// Covariance of columns `j` and `l`, on R's `svyvar` scale.
+    #[inline]
+    pub fn cov(&self, j: usize, l: usize) -> f64 {
+        self.moment(j, l) * self.kish_factor()
+    }
+
+    /// Pearson correlation of columns `j` and `l`.
+    #[inline]
+    pub fn corr(&self, j: usize, l: usize) -> f64 {
+        let denom = (self.moment(j, j) * self.moment(l, l)).sqrt();
+        if denom > 0.0 {
+            self.moment(j, l) / denom
+        } else {
+            f64::NAN
+        }
+    }
+}
+
+/// Accumulate the full moment matrix for `cols` in two sweeps.
+///
+/// A row contributes only when every column, and the weight, is non-null and
+/// the row is in-domain; that is the multivariate reading of the complete-pairs
+/// rule the bivariate kernel applies, and it matches R's `svyvar`, which drops
+/// a row from the whole matrix when any column is missing.
+pub fn multi_moments(
+    cols: &[&Float64Chunked],
+    weights: &Float64Chunked,
+    domain: Option<&BooleanChunked>,
+) -> PolarsResult<MomentMatrix> {
+    let k = cols.len();
+    if k == 0 {
+        return Err(PolarsError::ComputeError(
+            "multi_moments requires at least one column".into(),
+        ));
+    }
+    let len = weights.len();
+    if let Some(bad) = cols.iter().find(|c| c.len() != len) {
+        return Err(PolarsError::ComputeError(
+            format!("column length {} does not match weights length {len}", bad.len()).into(),
+        ));
+    }
+
+    // Contiguous, null-free, undomained input takes a raw-slice path. Going
+    // through `ChunkedArray::get` per element costs more than the O(k^2)->O(k)
+    // traffic saving is worth: measured, the `get`-based loop ran ~1.8x SLOWER
+    // than repeated pairwise kernels, which use `cont_slice` throughout.
+    let slices: Option<(Vec<&[f64]>, &[f64])> = if domain.is_none()
+        && weights.null_count() == 0
+        && cols.iter().all(|c| c.null_count() == 0)
+    {
+        let mut out = Vec::with_capacity(k);
+        let mut ok = weights.cont_slice().is_ok();
+        for c in cols {
+            match c.cont_slice() {
+                Ok(s) => out.push(s),
+                Err(_) => {
+                    ok = false;
+                    break;
+                }
+            }
+        }
+        if ok { weights.cont_slice().ok().map(|w| (out, w)) } else { None }
+    } else {
+        None
+    };
+
+    let mut sum_w = 0.0f64;
+    let mut sums = vec![0.0f64; k];
+    let mut n = 0usize;
+    let mut row = vec![0.0f64; k];
+
+    // ---- pass 1: weights, per-column means, and n -------------------------
+    if let Some((cs, ws)) = slices.as_ref() {
+        for i in 0..len {
+            let w = ws[i];
+            sum_w += w;
+            for j in 0..k {
+                sums[j] += w * cs[j][i];
+            }
+            if w != 0.0 {
+                n += 1;
+            }
+        }
+    } else {
+        for i in 0..len {
+            let Some(w) = weights.get(i) else { continue };
+            if domain.is_some_and(|d| d.get(i) != Some(true)) {
+                continue;
+            }
+            let mut complete = true;
+            for (j, c) in cols.iter().enumerate() {
+                match c.get(i) {
+                    Some(v) => row[j] = v,
+                    None => {
+                        complete = false;
+                        break;
+                    }
+                }
+            }
+            if !complete {
+                continue;
+            }
+            sum_w += w;
+            for j in 0..k {
+                sums[j] += w * row[j];
+            }
+            if w != 0.0 {
+                n += 1;
+            }
+        }
+    }
+
+    if sum_w == 0.0 {
+        return Ok(MomentMatrix {
+            sum_w: 0.0,
+            n,
+            k,
+            means: vec![f64::NAN; k],
+            m: vec![f64::NAN; k * k],
+        });
+    }
+
+    let means: Vec<f64> = sums.iter().map(|s| s / sum_w).collect();
+
+    // ---- pass 2: centered cross-products, upper triangle then mirrored ----
+    let mut m = vec![0.0f64; k * k];
+    let mut dev = vec![0.0f64; k];
+    if let Some((cs, ws)) = slices.as_ref() {
+        for i in 0..len {
+            let w = ws[i];
+            for j in 0..k {
+                dev[j] = cs[j][i] - means[j];
+            }
+            for j in 0..k {
+                let wj = w * dev[j];
+                for l in j..k {
+                    m[j * k + l] += wj * dev[l];
+                }
+            }
+        }
+    } else {
+        for i in 0..len {
+            let Some(w) = weights.get(i) else { continue };
+            if domain.is_some_and(|d| d.get(i) != Some(true)) {
+                continue;
+            }
+            let mut complete = true;
+            for (j, c) in cols.iter().enumerate() {
+                match c.get(i) {
+                    Some(v) => dev[j] = v - means[j],
+                    None => {
+                        complete = false;
+                        break;
+                    }
+                }
+            }
+            if !complete {
+                continue;
+            }
+            for j in 0..k {
+                let wj = w * dev[j];
+                for l in j..k {
+                    m[j * k + l] += wj * dev[l];
+                }
+            }
+        }
+    }
+
+    for j in 0..k {
+        for l in j..k {
+            m[j * k + l] /= sum_w;
+            m[l * k + j] = m[j * k + l];
+        }
+    }
+
+    Ok(MomentMatrix { sum_w, n, k, means, m })
+}
+
+// ============================================================================
+// Replication: precomputed products, one dot product set per replicate
+// ============================================================================
+
+/// Which association a replicate recomputes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AssocKind {
+    Corr,
+    Cov,
+}
+
+/// Full-sample-centered products for one pair, reused across every replicate.
+///
+/// `y*x`, `y^2` and `x^2` do not depend on the weights, so forming them once
+/// turns each replicate into six weighted dot products instead of redoing
+/// `R * n` multiplications. Centering by the full-sample mean first is free
+/// here and matters: covariance and correlation are translation-invariant, so
+/// the estimate is unchanged, but each replicate's `S/W - mean^2` subtraction
+/// is then taken between small numbers instead of cancelling two large ones.
+///
+/// R recomputes the mean inside every replicate (`svrepvar`'s `v(w)` closure,
+/// R/surveyrep.R:800-806); that is preserved exactly, because the per-replicate
+/// means reappear as the `mean_a`/`mean_b` terms below. What R fixes once,
+/// outside the closure, is `n` for the Kish factor -- so this does too.
+pub struct PairProducts {
+    a: Vec<f64>,
+    b: Vec<f64>,
+    aa: Vec<f64>,
+    bb: Vec<f64>,
+    ab: Vec<f64>,
+    /// Full-sample n, held fixed across replicates as R holds it.
+    n: usize,
+}
+
+impl PairProducts {
+    pub fn new(
+        y: &Float64Chunked,
+        x: &Float64Chunked,
+        weights: &Float64Chunked,
+        domain: Option<&BooleanChunked>,
+    ) -> PolarsResult<Self> {
+        let full = bivar_moments(y, x, weights, domain)?;
+        let (mean_y, mean_x) = if full.sum_w == 0.0 {
+            (0.0, 0.0)
+        } else {
+            (full.mean_y, full.mean_x)
+        };
+
+        let len = y.len();
+        let mut a = Vec::with_capacity(len);
+        let mut b = Vec::with_capacity(len);
+        let mut aa = Vec::with_capacity(len);
+        let mut bb = Vec::with_capacity(len);
+        let mut ab = Vec::with_capacity(len);
+
+        for i in 0..len {
+            // A row excluded here contributes zero to every replicate sum,
+            // which is how nulls and out-of-domain rows drop out without
+            // disturbing the design structure.
+            let keep = domain.is_none_or(|d| d.get(i) == Some(true));
+            let (av, bv) = match (y.get(i), x.get(i), keep) {
+                (Some(yv), Some(xv), true) => (yv - mean_y, xv - mean_x),
+                _ => (0.0, 0.0),
+            };
+            a.push(av);
+            b.push(bv);
+            aa.push(av * av);
+            bb.push(bv * bv);
+            ab.push(av * bv);
+        }
+
+        Ok(PairProducts { a, b, aa, bb, ab, n: full.n })
+    }
+
+    /// Recompute the association under one replicate weight column.
+    ///
+    /// Six row-ordered dot products; the summation order is a function of the
+    /// data alone, so this stays bit-identical across thread counts even though
+    /// replicates run concurrently.
+    pub fn estimate(&self, rep_w: &[f64], kind: AssocKind) -> f64 {
+        let (mut sw, mut sa, mut sb) = (0.0f64, 0.0f64, 0.0f64);
+        let (mut saa, mut sbb, mut sab) = (0.0f64, 0.0f64, 0.0f64);
+
+        // Pre-slicing all six arrays to a common length lets the bounds checks
+        // fall out of the loop body. The traversal is six-way parallel, so an
+        // index walk expresses it more directly than nested zips would.
+        let n = self.a.len().min(rep_w.len());
+        let (w_s, a_s, b_s) = (&rep_w[..n], &self.a[..n], &self.b[..n]);
+        let (aa_s, bb_s, ab_s) = (&self.aa[..n], &self.bb[..n], &self.ab[..n]);
+
+        #[allow(clippy::needless_range_loop)]
+        for i in 0..n {
+            let w = w_s[i];
+            sw += w;
+            sa += w * a_s[i];
+            sb += w * b_s[i];
+            saa += w * aa_s[i];
+            sbb += w * bb_s[i];
+            sab += w * ab_s[i];
+        }
+
+        if sw == 0.0 {
+            return f64::NAN;
+        }
+        let mean_a = sa / sw;
+        let mean_b = sb / sw;
+        let m_aa = saa / sw - mean_a * mean_a;
+        let m_bb = sbb / sw - mean_b * mean_b;
+        let m_ab = sab / sw - mean_a * mean_b;
+
+        match kind {
+            AssocKind::Cov => {
+                if self.n < 2 {
+                    f64::NAN
+                } else {
+                    m_ab * (self.n as f64 / (self.n as f64 - 1.0))
+                }
+            }
+            AssocKind::Corr => {
+                let denom = (m_aa * m_bb).sqrt();
+                if denom > 0.0 { m_ab / denom } else { f64::NAN }
+            }
+        }
+    }
+}
+
+/// Recompute the association across every replicate weight column.
+///
+/// Parallel over replicates -- an independent axis, so this respects the
+/// determinism policy in `mod.rs` while still using every core.
+pub fn replicate_association(
+    products: &PairProducts,
+    rep_cols: &[&[f64]],
+    kind: AssocKind,
+) -> Vec<f64> {
+    use rayon::prelude::*;
+    rep_cols.par_iter().map(|col| products.estimate(col, kind)).collect()
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fc(name: &str, v: &[f64]) -> Float64Chunked {
+        Float64Chunked::from_slice(name.into(), v)
+    }
+
+    /// y, x and weights from a small fixture whose moments are easy to verify
+    /// independently.
+    fn fixture() -> (Float64Chunked, Float64Chunked, Float64Chunked) {
+        let y = fc("y", &[1.0, 2.0, 3.0, 4.0, 5.0, 7.0]);
+        let x = fc("x", &[2.0, 1.0, 4.0, 3.0, 7.0, 6.0]);
+        let w = fc("w", &[1.0, 2.0, 1.5, 3.0, 2.5, 1.0]);
+        (y, x, w)
+    }
+
+    /// Reference moments computed straight from the definitions, independent of
+    /// the two-pass kernel under test.
+    /// Returns (sum_w, m_yy, m_xx, m_yx, mean_y).
+    fn reference(y: &[f64], x: &[f64], w: &[f64]) -> (f64, f64, f64, f64, f64) {
+        let sw: f64 = w.iter().sum();
+        let my: f64 = y.iter().zip(w).map(|(v, wi)| v * wi).sum::<f64>() / sw;
+        let mx: f64 = x.iter().zip(w).map(|(v, wi)| v * wi).sum::<f64>() / sw;
+        let mut yy = 0.0;
+        let mut xx = 0.0;
+        let mut yx = 0.0;
+        for i in 0..y.len() {
+            yy += w[i] * (y[i] - my).powi(2);
+            xx += w[i] * (x[i] - mx).powi(2);
+            yx += w[i] * (y[i] - my) * (x[i] - mx);
+        }
+        (sw, yy / sw, xx / sw, yx / sw, my)
+    }
+
+    #[test]
+    fn test_moments_match_definition() {
+        let (y, x, w) = fixture();
+        let m = bivar_moments(&y, &x, &w, None).unwrap();
+        let ys = y.cont_slice().unwrap();
+        let xs = x.cont_slice().unwrap();
+        let ws = w.cont_slice().unwrap();
+        let (sw, m_yy, m_xx, m_yx, mean_y) = reference(ys, xs, ws);
+
+        assert!((m.sum_w - sw).abs() < 1e-12);
+        assert!((m.mean_y - mean_y).abs() < 1e-12);
+        assert!((m.m_yy - m_yy).abs() < 1e-12);
+        assert!((m.m_xx - m_xx).abs() < 1e-12);
+        assert!((m.m_yx - m_yx).abs() < 1e-12);
+        assert_eq!(m.n, 6);
+    }
+
+    #[test]
+    fn test_corr_of_variable_with_itself_is_one() {
+        let (y, _, w) = fixture();
+        let r = point_estimate_corr(&y, &y, &w).unwrap();
+        assert!((r - 1.0).abs() < 1e-12, "corr(y,y) = {r}");
+    }
+
+    #[test]
+    fn test_cov_of_variable_with_itself_is_its_variance() {
+        let (y, _, w) = fixture();
+        let c = point_estimate_cov(&y, &y, &w).unwrap();
+        let m = bivar_moments(&y, &y, &w, None).unwrap();
+        let expected = m.m_yy * (m.n as f64 / (m.n as f64 - 1.0));
+        assert!((c - expected).abs() < 1e-12, "cov(y,y) = {c}, var = {expected}");
+    }
+
+    #[test]
+    fn test_corr_is_symmetric() {
+        let (y, x, w) = fixture();
+        let a = point_estimate_corr(&y, &x, &w).unwrap();
+        let b = point_estimate_corr(&x, &y, &w).unwrap();
+        assert_eq!(a.to_bits(), b.to_bits(), "corr must be order-independent");
+    }
+
+    #[test]
+    fn test_corr_is_translation_and_scale_invariant() {
+        let (y, x, w) = fixture();
+        let base = point_estimate_corr(&y, &x, &w).unwrap();
+
+        let ys: Vec<f64> = y.cont_slice().unwrap().iter().map(|v| v * 3.0 + 100.0).collect();
+        let xs: Vec<f64> = x.cont_slice().unwrap().iter().map(|v| v * 0.5 - 7.0).collect();
+        let shifted = point_estimate_corr(&fc("y", &ys), &fc("x", &xs), &w).unwrap();
+
+        assert!((base - shifted).abs() < 1e-12, "{base} vs {shifted}");
+    }
+
+    /// The two-pass kernel must survive a large offset that would destroy the
+    /// naive sum-of-squares form. With an offset of 1e9 on data of order 1, the
+    /// one-pass formula loses essentially all precision.
+    #[test]
+    fn test_corr_stable_under_large_offset() {
+        let (y, x, w) = fixture();
+        let base = point_estimate_corr(&y, &x, &w).unwrap();
+
+        let ys: Vec<f64> = y.cont_slice().unwrap().iter().map(|v| v + 1e9).collect();
+        let xs: Vec<f64> = x.cont_slice().unwrap().iter().map(|v| v + 1e9).collect();
+        let offset = point_estimate_corr(&fc("y", &ys), &fc("x", &xs), &w).unwrap();
+
+        assert!((base - offset).abs() < 1e-9, "offset broke stability: {base} vs {offset}");
+    }
+
+    /// A linearization for a scale-free statistic must have scores summing to
+    /// zero; a nonzero sum means the estimator drifts under the design.
+    #[test]
+    fn test_corr_scores_sum_to_zero() {
+        let (y, x, w) = fixture();
+        let s = scores_corr(&y, &x, &w).unwrap();
+        let total: f64 = s.cont_slice().unwrap().iter().sum();
+        assert!(total.abs() < 1e-14, "scores summed to {total}");
+    }
+
+    #[test]
+    fn test_cov_scores_sum_to_zero() {
+        let (y, x, w) = fixture();
+        let s = scores_cov(&y, &x, &w).unwrap();
+        let total: f64 = s.cont_slice().unwrap().iter().sum();
+        assert!(total.abs() < 1e-12, "scores summed to {total}");
+    }
+
+    /// Zero-weight rows must not shift the estimate and must not inflate `n`;
+    /// this is how `where=` and `drop_nulls` reach the kernel.
+    #[test]
+    fn test_zero_weight_rows_are_excluded() {
+        let (y, x, w) = fixture();
+        let mut ys = y.cont_slice().unwrap().to_vec();
+        let mut xs = x.cont_slice().unwrap().to_vec();
+        let mut ws = w.cont_slice().unwrap().to_vec();
+        // Append rows that are wild in value but carry zero weight.
+        ys.extend_from_slice(&[1e6, -1e6]);
+        xs.extend_from_slice(&[-1e6, 1e6]);
+        ws.extend_from_slice(&[0.0, 0.0]);
+
+        let base = bivar_moments(&y, &x, &w, None).unwrap();
+        let padded =
+            bivar_moments(&fc("y", &ys), &fc("x", &xs), &fc("w", &ws), None).unwrap();
+
+        assert_eq!(base.n, padded.n, "zero-weight rows must not count toward n");
+        assert!((base.corr() - padded.corr()).abs() < 1e-12);
+        assert!((base.cov() - padded.cov()).abs() < 1e-12);
+    }
+
+    /// A domain restricted to a subset must reproduce the estimate computed on
+    /// that subset alone.
+    #[test]
+    fn test_domain_matches_subset() {
+        let (y, x, w) = fixture();
+        let mask = BooleanChunked::from_slice(
+            "m".into(),
+            &[true, true, true, false, false, false],
+        );
+        let dom = point_estimate_corr_domain(&y, &x, &w, &mask).unwrap();
+
+        let sub = point_estimate_corr(
+            &fc("y", &y.cont_slice().unwrap()[..3]),
+            &fc("x", &x.cont_slice().unwrap()[..3]),
+            &fc("w", &w.cont_slice().unwrap()[..3]),
+        )
+        .unwrap();
+
+        assert!((dom - sub).abs() < 1e-12, "domain {dom} vs subset {sub}");
+    }
+
+    /// Out-of-domain rows carry a zero score so the vector stays aligned with
+    /// the shared design build.
+    #[test]
+    fn test_domain_scores_zero_outside() {
+        let (y, x, w) = fixture();
+        let mask = BooleanChunked::from_slice(
+            "m".into(),
+            &[true, true, true, false, false, false],
+        );
+        let s = scores_corr_domain(&y, &x, &w, &mask).unwrap();
+        let vals = s.cont_slice().unwrap();
+        assert!(vals[3..].iter().all(|v| *v == 0.0), "tail not zeroed: {vals:?}");
+        let total: f64 = vals.iter().sum();
+        assert!(total.abs() < 1e-14, "in-domain scores summed to {total}");
+    }
+
+    /// A constant column has no correlation to report; the ungrouped path says
+    /// so explicitly rather than emitting a silently meaningless number.
+    #[test]
+    fn test_constant_column_is_rejected() {
+        let (y, _, w) = fixture();
+        let konst = fc("k", &[2.0; 6]);
+        assert!(point_estimate_corr(&y, &konst, &w).unwrap().is_nan());
+        assert!(scores_corr(&y, &konst, &w).is_err());
+    }
+
+    // ------------------------------------------------------------------
+    // R golden fixtures
+    //
+    // survey 4.5, single-stage cluster design (8 PSUs x 3 rows, unequal
+    // weights). Covariance targets come from `svyvar(~y+x, d)`; the
+    // correlation targets come from `svycontrast` applied to the moment
+    // means, which is R computing the same delta method independently of our
+    // linearization:
+    //
+    //   mns <- svymean(~y+x+yy+xx+yx, d)
+    //   svycontrast(mns, quote((yx - y*x)/sqrt((yy-y^2)*(xx-x^2))))
+    //
+    // The SE comparisons are the load-bearing ones: a wrong score still
+    // reproduces the point estimate, but cannot reproduce the SE.
+    // ------------------------------------------------------------------
+
+    const G_Y: [f64; 24] = [
+        12.0, 15.0, 11.0, 22.0, 25.0, 19.0, 31.0, 29.0, 35.0, 41.0, 44.0, 39.0, 18.0, 16.0, 21.0,
+        27.0, 30.0, 24.0, 36.0, 33.0, 38.0, 45.0, 49.0, 43.0,
+    ];
+    const G_X: [f64; 24] = [
+        9.0, 4.0, 14.0, 6.0, 17.0, 8.0, 21.0, 11.0, 13.0, 12.0, 26.0, 7.0, 19.0, 5.0, 23.0, 10.0,
+        28.0, 15.0, 8.0, 22.0, 16.0, 18.0, 31.0, 20.0,
+    ];
+    const G_W: [f64; 24] = [
+        2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 1.5, 1.5, 1.5, 4.0, 4.0, 4.0, 2.5, 2.5, 2.5, 3.5, 3.5, 3.5,
+        1.0, 1.0, 1.0, 5.0, 5.0, 5.0,
+    ];
+
+    fn golden_psu() -> Column {
+        let v: Vec<i64> = (1..=8i64).flat_map(|c| std::iter::repeat_n(c, 3)).collect();
+        Column::from(Int64Chunked::from_slice("psu".into(), &v).into_series())
+    }
+
+    fn golden_strata() -> Column {
+        let v: Vec<i64> = (1..=2i64).flat_map(|s| std::iter::repeat_n(s, 12)).collect();
+        Column::from(Int64Chunked::from_slice("str".into(), &v).into_series())
+    }
+
+    fn se_of(scores: &Float64Chunked, strata: Option<&Column>, psu: Option<&Column>) -> f64 {
+        crate::estimation::taylor::taylor_variance(scores, strata, psu, None, None, None, None)
+            .unwrap()
+            .sqrt()
+    }
+
+    #[test]
+    fn test_golden_cov_matches_r_svyvar() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let est = point_estimate_cov(&y, &x, &w).unwrap();
+        assert!((est - 50.138658078368209).abs() < 1e-11, "cov est = {est}");
+
+        let se = se_of(&scores_cov(&y, &x, &w).unwrap(), None, Some(&golden_psu()));
+        assert!((se - 21.498361515848689).abs() < 1e-9, "cov se = {se}");
+    }
+
+    /// The diagonal of `svyvar` is the variance, so cov(y,y) must reproduce it
+    /// through exactly the same code path.
+    #[test]
+    fn test_golden_variance_matches_r_svyvar_diagonal() {
+        let (y, w) = (fc("y", &G_Y), fc("w", &G_W));
+        let est = point_estimate_cov(&y, &y, &w).unwrap();
+        assert!((est - 139.54576489533011).abs() < 1e-11, "var est = {est}");
+
+        let se = se_of(&scores_cov(&y, &y, &w).unwrap(), None, Some(&golden_psu()));
+        assert!((se - 37.342191100127813).abs() < 1e-9, "var se = {se}");
+    }
+
+    /// The decisive test for the correlation linearization: R computes this SE
+    /// by its own delta method over the five moment means, with no shared code
+    /// or algebra with our score.
+    #[test]
+    fn test_golden_corr_matches_r_svycontrast() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let est = point_estimate_corr(&y, &x, &w).unwrap();
+        assert!((est - 0.52860852253793722).abs() < 1e-12, "corr est = {est}");
+
+        let se = se_of(&scores_corr(&y, &x, &w).unwrap(), None, Some(&golden_psu()));
+        assert!((se - 0.15921590459764234).abs() < 1e-11, "corr se = {se}");
+    }
+
+    /// Stratification is handled by the shared variance kernel, but the score
+    /// must stay correct underneath it.
+    #[test]
+    fn test_golden_cov_stratified_matches_r() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let se = se_of(
+            &scores_cov(&y, &x, &w).unwrap(),
+            Some(&golden_strata()),
+            Some(&golden_psu()),
+        );
+        assert!((se - 23.178556453025269).abs() < 1e-9, "stratified cov se = {se}");
+    }
+
+    // ------------------------------------------------------------------
+    // SRS reference / deff
+    // ------------------------------------------------------------------
+
+    /// With equal weights and neither strata nor clusters, the design IS simple
+    /// random sampling, so the design variance must land on the SRS reference
+    /// and deff must be 1. Weights are large enough that the finite-population
+    /// correction is negligible, isolating the comparison from the FPC.
+    #[test]
+    fn test_deff_is_one_under_srs() {
+        let (y, x) = (fc("y", &G_Y), fc("x", &G_X));
+        let w = fc("w", &[1e6; 24]);
+
+        for kind in [AssocKind::Corr, AssocKind::Cov] {
+            let scores = match kind {
+                AssocKind::Corr => scores_corr(&y, &x, &w).unwrap(),
+                AssocKind::Cov => scores_cov(&y, &x, &w).unwrap(),
+            };
+            let design = se_of(&scores, None, None).powi(2);
+            let srs = match kind {
+                AssocKind::Corr => srs_variance_corr(&y, &x, &w).unwrap(),
+                AssocKind::Cov => srs_variance_cov(&y, &x, &w).unwrap(),
+            };
+            let deff = design / srs;
+            assert!((deff - 1.0).abs() < 1e-4, "{kind:?}: deff under SRS = {deff}");
+        }
+    }
+
+    /// The golden fixture is clustered with substantial between-PSU spread, so
+    /// its design effect must exceed 1 -- the whole point of reporting one.
+    #[test]
+    fn test_deff_exceeds_one_under_clustering() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let design = se_of(&scores_corr(&y, &x, &w).unwrap(), None, Some(&golden_psu())).powi(2);
+        let srs = srs_variance_corr(&y, &x, &w).unwrap();
+        let deff = design / srs;
+        assert!(deff > 1.0, "clustered deff should exceed 1, got {deff}");
+        assert!(deff.is_finite(), "deff must be finite, got {deff}");
+    }
+
+    /// deff is a ratio of two variances of the same estimator, so rescaling the
+    /// inputs must leave it untouched. For the covariance this also pins the
+    /// claim that the Kish factor cancels: it multiplies the influence function
+    /// and the estimate alike, so it cannot survive into deff.
+    #[test]
+    fn test_deff_is_scale_invariant() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let ys: Vec<f64> = G_Y.iter().map(|v| v * 1000.0 + 5.0).collect();
+        let xs: Vec<f64> = G_X.iter().map(|v| v * 0.01 - 3.0).collect();
+        let (y2, x2) = (fc("y", &ys), fc("x", &xs));
+
+        let deff = |yy: &Float64Chunked, xx: &Float64Chunked| {
+            let d = se_of(&scores_cov(yy, xx, &w).unwrap(), None, Some(&golden_psu())).powi(2);
+            d / srs_variance_cov(yy, xx, &w).unwrap()
+        };
+
+        let base = deff(&y, &x);
+        let scaled = deff(&y2, &x2);
+        assert!(
+            (base - scaled).abs() < 1e-9,
+            "deff moved under rescaling: {base} vs {scaled}"
+        );
+    }
+
+    /// The empirical SRS reference is claimed to converge to the textbook
+    /// `(1-rho^2)^2/n` under bivariate normality. Check that on generated
+    /// near-normal data; the tolerance is loose because this is an asymptotic
+    /// identity being checked at finite n, not an exact algebraic one.
+    #[test]
+    fn test_srs_corr_approaches_normal_theory() {
+        let n = 20_000usize;
+        let mut ys = Vec::with_capacity(n);
+        let mut xs = Vec::with_capacity(n);
+        let mut s = 987_654_321u64;
+        let mut next = || {
+            s = s.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            ((s >> 11) as f64) / ((1u64 << 53) as f64)
+        };
+        let rho_true = 0.6f64;
+        for _ in 0..n {
+            // Box-Muller for a standard normal pair, then induce correlation.
+            let (u1, u2) = (next().max(1e-12), next());
+            let r = (-2.0 * u1.ln()).sqrt();
+            let (z1, z2) = (r * (2.0 * std::f64::consts::PI * u2).cos(), r * (2.0 * std::f64::consts::PI * u2).sin());
+            ys.push(z1);
+            xs.push(rho_true * z1 + (1.0 - rho_true * rho_true).sqrt() * z2);
+        }
+        let y = fc("y", &ys);
+        let x = fc("x", &xs);
+        // Large weights so the FPC does not enter the comparison.
+        let w = fc("w", &vec![1e7; n]);
+
+        let rho = point_estimate_corr(&y, &x, &w).unwrap();
+        let srs = srs_variance_corr(&y, &x, &w).unwrap();
+        let normal_theory = (1.0 - rho * rho).powi(2) / n as f64;
+        let ratio = srs / normal_theory;
+
+        assert!(
+            (ratio - 1.0).abs() < 0.10,
+            "empirical SRS variance {srs:.3e} vs normal theory {normal_theory:.3e} (ratio {ratio:.4})"
+        );
+    }
+
+    /// Zero-weight rows must not enter n in the SRS reference either, or deff
+    /// would shrink simply because a filter left rows behind.
+    #[test]
+    fn test_srs_excludes_zero_weight_rows() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let base = srs_variance_corr(&y, &x, &w).unwrap();
+
+        let mut ys = G_Y.to_vec();
+        let mut xs = G_X.to_vec();
+        let mut ws = G_W.to_vec();
+        ys.extend_from_slice(&[1e6, -1e6]);
+        xs.extend_from_slice(&[-1e6, 1e6]);
+        ws.extend_from_slice(&[0.0, 0.0]);
+        let padded = srs_variance_corr(&fc("y", &ys), &fc("x", &xs), &fc("w", &ws)).unwrap();
+
+        assert!((base - padded).abs() < 1e-12, "{base} vs {padded}");
+    }
+
+    // ------------------------------------------------------------------
+    // All-pairs kernel
+    // ------------------------------------------------------------------
+
+    /// The one-sweep matrix must agree with the bivariate kernel pair for pair.
+    /// That kernel is the R-validated one, so agreement carries the validation
+    /// across without needing separate R fixtures per pair.
+    #[test]
+    fn test_multi_moments_matches_pairwise() {
+        let y = fc("y", &G_Y);
+        let x = fc("x", &G_X);
+        let z = fc("z", &G_W); // any third column with real spread
+        let w = fc("w", &G_W);
+
+        let mm = multi_moments(&[&y, &x, &z], &w, None).unwrap();
+        assert_eq!(mm.k, 3);
+        assert_eq!(mm.n, 24);
+
+        let cols = [&y, &x, &z];
+        for j in 0..3 {
+            for l in 0..3 {
+                let pair = bivar_moments(cols[j], cols[l], &w, None).unwrap();
+                assert!(
+                    (mm.corr(j, l) - pair.corr()).abs() < 1e-12,
+                    "corr({j},{l}): {} vs {}",
+                    mm.corr(j, l),
+                    pair.corr()
+                );
+                assert!(
+                    (mm.cov(j, l) - pair.cov()).abs() < 1e-10,
+                    "cov({j},{l}): {} vs {}",
+                    mm.cov(j, l),
+                    pair.cov()
+                );
+            }
+        }
+    }
+
+    /// The matrix must be symmetric and carry unit correlations on the diagonal.
+    #[test]
+    fn test_multi_moments_symmetry_and_diagonal() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let mm = multi_moments(&[&y, &x], &w, None).unwrap();
+        assert_eq!(mm.moment(0, 1).to_bits(), mm.moment(1, 0).to_bits());
+        for j in 0..2 {
+            assert!((mm.corr(j, j) - 1.0).abs() < 1e-12);
+        }
+        // Diagonal covariance is the variance R reports on svyvar's diagonal.
+        assert!((mm.cov(0, 0) - 139.54576489533011).abs() < 1e-10);
+        assert!((mm.cov(0, 1) - 50.138658078368209).abs() < 1e-10);
+    }
+
+    /// A row missing in ANY column leaves the whole matrix, matching how
+    /// `svyvar` drops an incomplete row from every cell.
+    #[test]
+    fn test_multi_moments_drops_row_missing_any_column() {
+        let y = Float64Chunked::from_slice_options(
+            "y".into(),
+            &[Some(1.0), Some(2.0), Some(3.0), Some(4.0)],
+        );
+        let x = Float64Chunked::from_slice_options(
+            "x".into(),
+            &[Some(2.0), Some(1.0), None, Some(3.0)],
+        );
+        let w = fc("w", &[1.0, 1.0, 1.0, 1.0]);
+        let mm = multi_moments(&[&y, &x], &w, None).unwrap();
+        assert_eq!(mm.n, 3, "row with a null in x must leave the matrix");
+        assert!((mm.sum_w - 3.0).abs() < 1e-12);
+    }
+
+    // ------------------------------------------------------------------
+    // Replication kernel
+    // ------------------------------------------------------------------
+
+    /// JK1 over the 8 golden PSUs: replicate r drops PSU r and inflates the
+    /// survivors by 8/7, which is what `as.svrepdesign(type="JK1")` produced.
+    fn jk1_rep_weights() -> Vec<Vec<f64>> {
+        (0..8usize)
+            .map(|r| {
+                (0..24usize)
+                    .map(|i| if i / 3 == r { 0.0 } else { G_W[i] * 8.0 / 7.0 })
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// R's per-replicate covariances, from
+    /// `svyvar(~y+x, as.svrepdesign(d, type="JK1"), return.replicates=TRUE)`.
+    const R_COV_REPS: [f64; 8] = [
+        40.722413332298757,
+        46.226109824772017,
+        53.735975549640145,
+        60.335842305289987,
+        53.635362318840571,
+        58.450198723353004,
+        52.940861100007069,
+        23.329713102632358,
+    ];
+
+    /// Correlations derived from each replicate's own variance matrix.
+    const R_CORR_REPS: [f64; 8] = [
+        0.48055776528106858,
+        0.48070293973143952,
+        0.53540826755142246,
+        0.63514953996442003,
+        0.58236081385363858,
+        0.57516710027925266,
+        0.54192817928138626,
+        0.31366849757047521,
+    ];
+
+    #[test]
+    fn test_replicate_cov_matches_r_jk1() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let p = PairProducts::new(&y, &x, &w, None).unwrap();
+        let reps = jk1_rep_weights();
+        let cols: Vec<&[f64]> = reps.iter().map(|v| v.as_slice()).collect();
+        let got = replicate_association(&p, &cols, AssocKind::Cov);
+
+        for (r, (g, e)) in got.iter().zip(R_COV_REPS.iter()).enumerate() {
+            assert!((g - e).abs() < 1e-10, "replicate {r}: {g} vs R {e}");
+        }
+    }
+
+    #[test]
+    fn test_replicate_corr_matches_r_jk1() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let p = PairProducts::new(&y, &x, &w, None).unwrap();
+        let reps = jk1_rep_weights();
+        let cols: Vec<&[f64]> = reps.iter().map(|v| v.as_slice()).collect();
+        let got = replicate_association(&p, &cols, AssocKind::Corr);
+
+        for (r, (g, e)) in got.iter().zip(R_CORR_REPS.iter()).enumerate() {
+            assert!((g - e).abs() < 1e-12, "replicate {r}: {g} vs R {e}");
+        }
+    }
+
+    /// The precomputed-products path must agree with recomputing from scratch
+    /// under each replicate's weights. Correlation is divisor-free, so this is
+    /// an exact cross-check of the optimization against the direct kernel.
+    #[test]
+    fn test_precomputed_products_match_direct_recompute() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let p = PairProducts::new(&y, &x, &w, None).unwrap();
+
+        for rep in jk1_rep_weights() {
+            let rw = fc("rw", &rep);
+            let direct = point_estimate_corr(&y, &x, &rw).unwrap();
+            let fast = p.estimate(&rep, AssocKind::Corr);
+            assert!((direct - fast).abs() < 1e-12, "{direct} vs {fast}");
+        }
+    }
+
+    /// R fixes `n` once outside its replicate closure, so a replicate that
+    /// zeroes a PSU keeps the full-sample Kish factor rather than shrinking it.
+    /// Recomputing `n` per replicate would silently rescale every covariance.
+    #[test]
+    fn test_replicate_cov_holds_n_fixed() {
+        let (y, x, w) = (fc("y", &G_Y), fc("x", &G_X), fc("w", &G_W));
+        let p = PairProducts::new(&y, &x, &w, None).unwrap();
+        let rep = &jk1_rep_weights()[0];
+
+        let fast = p.estimate(rep, AssocKind::Cov);
+        // Recomputing n from the replicate would use 21 rows, not 24.
+        let rw = fc("rw", rep);
+        let per_replicate_n = point_estimate_cov(&y, &x, &rw).unwrap();
+        let ratio = per_replicate_n / fast;
+        let expected_drift = (21.0 / 20.0) / (24.0 / 23.0);
+
+        assert!((fast - R_COV_REPS[0]).abs() < 1e-10, "fixed-n must match R");
+        assert!(
+            (ratio - expected_drift).abs() < 1e-9,
+            "per-replicate n drifts by {ratio}, confirming why n is held fixed"
+        );
+    }
+
+    /// Nulls in either column drop that row from both the sums and `n`.
+    #[test]
+    fn test_nulls_are_skipped() {
+        let y = Float64Chunked::from_slice_options(
+            "y".into(),
+            &[Some(1.0), Some(2.0), None, Some(4.0)],
+        );
+        let x = Float64Chunked::from_slice_options(
+            "x".into(),
+            &[Some(2.0), Some(1.0), Some(9.0), Some(3.0)],
+        );
+        let w = fc("w", &[1.0, 1.0, 5.0, 1.0]);
+        let m = bivar_moments(&y, &x, &w, None).unwrap();
+        assert_eq!(m.n, 3, "null row must not count toward n");
+        assert!((m.sum_w - 3.0).abs() < 1e-12, "null row must not add weight");
+    }
+}

--- a/packages/svy-rs/src/estimation/mod.rs
+++ b/packages/svy-rs/src/estimation/mod.rs
@@ -15,6 +15,7 @@
 // rayon worker threads from ever running the closures, so the `par_iter` /
 // per-replicate parallelism silently executes serially. Release-then-parallelise
 // is what turns the fan-out into real wall-clock speedup (measured 3–6×).
+pub mod association;
 pub mod replication;
 pub mod replication_api;
 pub mod taylor;

--- a/packages/svy-rs/src/estimation/replication_api.rs
+++ b/packages/svy-rs/src/estimation/replication_api.rs
@@ -9,6 +9,9 @@ use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 
 use crate::estimation::taylor::SvyQuantileMethod;
+use crate::estimation::association::{
+    AssocKind, PairProducts, replicate_association,
+};
 use crate::estimation::replication::{
     RepMethod, VarianceCenter,
     extract_rep_weights_matrix,
@@ -335,6 +338,216 @@ fn compute_replicate_total_grouped(
     }
     df![by_col => by_vals, "y" => vec![value_col; n_domains], "est" => estimates,
         "se" => ses, "var" => variances, "df" => dfs, "n" => ns]
+}
+
+// ============================================================================
+// Association (covariance / correlation)
+// ============================================================================
+
+/// Replicate-weight covariance or correlation over one or more column pairs.
+///
+/// Every replicate re-centers on its own weighted means -- that is what R's
+/// `svrepvar` does inside its `v(w)` closure -- while `n` for the covariance's
+/// Kish factor stays fixed at the full-sample value, as R fixes it outside that
+/// closure. Both fall out of `PairProducts`, which forms the weight-independent
+/// products once so each replicate costs six dot products rather than a full
+/// recomputation.
+#[pyfunction]
+#[pyo3(signature = (data, y_cols, x_cols, kind, weight_col, rep_weight_cols, method, fay_coef=0.0, rscales=None, center="rep_mean", degrees_of_freedom=None, by_col=None, domain_mask_col=None))]
+#[allow(clippy::too_many_arguments)]
+pub fn replicate_assoc(
+    _py: Python,
+    data: PyDataFrame,
+    y_cols: Vec<String>,
+    x_cols: Vec<String>,
+    kind: String,
+    weight_col: String,
+    rep_weight_cols: Vec<String>,
+    method: String,
+    fay_coef: f64,
+    rscales: Option<Vec<f64>>,
+    center: &str,
+    degrees_of_freedom: Option<u32>,
+    by_col: Option<String>,
+    domain_mask_col: Option<String>,
+) -> PyResult<PyDataFrame> {
+    let df: DataFrame = data.into();
+    let n_reps = rep_weight_cols.len();
+    let rep_method = parse_rep_method(&method)?;
+    let variance_center = parse_variance_center(center)?;
+    if let Some(r) = &rscales
+        && r.len() != n_reps
+    {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "rscales has {} entries but there are {} replicate weight columns",
+            r.len(),
+            n_reps
+        )));
+    }
+    if y_cols.len() != x_cols.len() {
+        return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+            "pair columns must be equal length, got {} and {}",
+            y_cols.len(),
+            x_cols.len()
+        )));
+    }
+    let df_val = degrees_of_freedom.unwrap_or(n_reps.saturating_sub(1) as u32);
+
+    let result = _py.detach(|| {
+        let assoc_kind = AssocKind::from_name(&kind)?;
+        compute_replicate_assoc(
+            &df,
+            &y_cols,
+            &x_cols,
+            assoc_kind,
+            &weight_col,
+            &rep_weight_cols,
+            rep_method,
+            fay_coef,
+            rscales.as_deref(),
+            variance_center,
+            df_val,
+            by_col.as_deref(),
+            domain_mask_col.as_deref(),
+        )
+    });
+    result
+        .map(PyDataFrame)
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_replicate_assoc(
+    df: &DataFrame,
+    y_cols: &[String],
+    x_cols: &[String],
+    kind: AssocKind,
+    weight_col: &str,
+    rep_weight_cols: &[String],
+    method: RepMethod,
+    fay_coef: f64,
+    rscales: Option<&[f64]>,
+    center: VarianceCenter,
+    df_val: u32,
+    by_col: Option<&str>,
+    domain_mask_col: Option<&str>,
+) -> PolarsResult<DataFrame> {
+    let weights = df.column(weight_col)?.f64()?;
+    let n = weights.len();
+    let n_reps = rep_weight_cols.len();
+
+    let ys: Vec<&Float64Chunked> = y_cols
+        .iter()
+        .map(|c| df.column(c).and_then(|s| s.f64()))
+        .collect::<PolarsResult<Vec<_>>>()?;
+    let xs: Vec<&Float64Chunked> = x_cols
+        .iter()
+        .map(|c| df.column(c).and_then(|s| s.f64()))
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    // Replicate weights as slices; materialize only when they are not already
+    // contiguous, so the common case borrows straight from the frame.
+    let cont = get_cont_rep_cols(df, rep_weight_cols)?;
+    let owned: Option<Vec<Vec<f64>>> = if cont.is_none() {
+        Some(
+            rep_weight_cols
+                .iter()
+                .map(|c| {
+                    df.column(c)
+                        .and_then(|s| s.f64())
+                        .map(|ca| ca.iter().map(|v| v.unwrap_or(0.0)).collect::<Vec<f64>>())
+                })
+                .collect::<PolarsResult<Vec<_>>>()?,
+        )
+    } else {
+        None
+    };
+    let rep_cols: Vec<&[f64]> = match (&cont, &owned) {
+        (Some(c), _) => c.clone(),
+        (None, Some(o)) => o.iter().map(|v| v.as_slice()).collect(),
+        (None, None) => Vec::new(),
+    };
+
+    // Ungrouped runs as a single unnamed domain, so one path covers both shapes.
+    let by_str = by_col.map(|c| df.column(c).and_then(|s| s.str())).transpose()?;
+    let unique_groups = by_str.map(|s| s.unique()).transpose()?;
+    let group_names: Vec<Option<&str>> = match unique_groups.as_ref() {
+        Some(u) => u.iter().flatten().map(Some).collect(),
+        None => vec![None],
+    };
+    let explicit_mask = get_domain_mask(df, domain_mask_col)?;
+    let group_masks: Vec<Option<Vec<f64>>> = group_names
+        .iter()
+        .map(|g| match (g, by_str) {
+            (Some(gv), Some(bs)) => Some(
+                bs.equal(*gv)
+                    .iter()
+                    .map(|v| if v == Some(true) { 1.0 } else { 0.0 })
+                    .collect(),
+            ),
+            _ => explicit_mask.clone(),
+        })
+        .collect();
+
+    let rep_coefs = rscales
+        .map(<[f64]>::to_vec)
+        .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
+
+    let n_pairs = ys.len();
+    let combos: Vec<(usize, usize)> = (0..group_names.len())
+        .flat_map(|gi| (0..n_pairs).map(move |pi| (gi, pi)))
+        .collect();
+
+    // Sequential over (group, pair): `replicate_association` already fans out
+    // across replicates, which is the wide axis. Nesting a second rayon level
+    // here would oversubscribe without adding usable parallelism.
+    let w_full: Vec<f64> = weights.iter().map(|v| v.unwrap_or(0.0)).collect();
+    let rows = combos
+        .iter()
+        .map(|&(gi, pi)| -> PolarsResult<(usize, usize, f64, f64, f64, u32)> {
+            let mask = group_masks[gi].as_deref();
+            let products = PairProducts::new(ys[pi], xs[pi], weights, mask)?;
+            let theta_full = products.estimate(&w_full, kind);
+            let theta_reps = replicate_association(&products, &rep_cols, kind);
+            let variance =
+                variance_from_replicates(method, theta_full, &theta_reps, &rep_coefs, center);
+            let n_rows = match mask {
+                Some(m) => m.iter().filter(|v| **v != 0.0).count() as u32,
+                None => n as u32,
+            };
+            Ok((gi, pi, theta_full, variance.sqrt(), variance, n_rows))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let nv = rows.len();
+    let mut by_vals: Vec<&str> = Vec::with_capacity(nv);
+    let mut y_names: Vec<&str> = Vec::with_capacity(nv);
+    let mut x_names: Vec<&str> = Vec::with_capacity(nv);
+    let mut estimates: Vec<f64> = Vec::with_capacity(nv);
+    let mut ses: Vec<f64> = Vec::with_capacity(nv);
+    let mut variances: Vec<f64> = Vec::with_capacity(nv);
+    let mut ns: Vec<u32> = Vec::with_capacity(nv);
+    for (gi, pi, est, se, var, n_rows) in rows {
+        if let Some(g) = group_names[gi] {
+            by_vals.push(g);
+        }
+        y_names.push(y_cols[pi].as_str());
+        x_names.push(x_cols[pi].as_str());
+        estimates.push(est);
+        ses.push(se);
+        variances.push(var);
+        ns.push(n_rows);
+    }
+
+    let mut out = df![
+        "y" => y_names, "x" => x_names, "kind" => vec![kind.as_str(); nv],
+        "est" => estimates, "se" => ses, "var" => variances,
+        "df" => vec![df_val; nv], "n" => ns
+    ]?;
+    if let Some(name) = by_col {
+        out.insert_column(0, Column::new(name.into(), by_vals))?;
+    }
+    Ok(out)
 }
 
 // ============================================================================

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -1775,7 +1775,7 @@ pub fn median_variance_woodruff_domain(
 // SRS Variance (Simple Random Sampling)
 // ============================================================================
 
-fn weighted_s2(y: &[f64], wn: &[f64]) -> f64 {
+pub(crate) fn weighted_s2(y: &[f64], wn: &[f64]) -> f64 {
     let n = y.len() as f64;
     if n <= 1.0 {
         return f64::NAN;

--- a/packages/svy-rs/src/estimation/taylor_api.rs
+++ b/packages/svy-rs/src/estimation/taylor_api.rs
@@ -10,6 +10,9 @@ use numpy::PyReadonlyArray1;
 use pyo3_polars::PyDataFrame;
 use rayon::prelude::*;
 
+use crate::estimation::association::{
+    AssocKind, point_estimate_assoc, scores_assoc, srs_variance_assoc_of,
+};
 use crate::estimation::taylor::{
     SvyQuantileMethod,
     TaylorDesign,
@@ -821,6 +824,192 @@ fn compute_ratio_grouped(
     let dfs = group_dfs;
     df![by_col => by_vals, "y" => vec![numerator_col; n_groups], "x" => vec![denominator_col; n_groups],
         "est" => estimates, "se" => ses, "var" => variances, "df" => dfs, "n" => ns, "deff" => deffs]
+}
+
+// ============================================================================
+// Association (covariance / correlation)
+// ============================================================================
+
+/// Covariance or correlation over one or more column pairs sharing one design.
+///
+/// Pairs are always plural at this boundary. `corr`/`cov` take a set of columns
+/// and report every requested pair, so unlike `ratio` there is no single-pair
+/// entry point to mirror -- `taylor_assoc` covers the batched and grouped cases
+/// alike. With `by_col` set the result carries one row per (group, pair); the
+/// pair columns are named `y`/`x` positionally, and carry no directional
+/// meaning, since both statistics are symmetric.
+#[pyfunction]
+#[pyo3(signature = (data, y_cols, x_cols, kind, weight_col, strata_col=None, psu_col=None, ssu_col=None, fpc_col=None, fpc_ssu_col=None, by_col=None, singleton_method=None))]
+pub fn taylor_assoc(
+    _py: Python,
+    data: PyDataFrame,
+    y_cols: Vec<String>,
+    x_cols: Vec<String>,
+    kind: String,
+    weight_col: String,
+    strata_col: Option<String>,
+    psu_col: Option<String>,
+    ssu_col: Option<String>,
+    fpc_col: Option<String>,
+    fpc_ssu_col: Option<String>,
+    by_col: Option<String>,
+    singleton_method: Option<String>,
+) -> PyResult<PyDataFrame> {
+    let df = into_contiguous(data);
+    let result = _py
+        .detach(|| {
+            let kind = AssocKind::from_name(&kind)?;
+            if y_cols.len() != x_cols.len() {
+                return Err(PolarsError::ComputeError(
+                    format!(
+                        "pair columns must be equal length, got {} and {}",
+                        y_cols.len(),
+                        x_cols.len()
+                    )
+                    .into(),
+                ));
+            }
+            if y_cols.is_empty() {
+                return Err(PolarsError::ComputeError(
+                    "at least one column pair is required".into(),
+                ));
+            }
+            compute_assoc(
+                &df,
+                &y_cols,
+                &x_cols,
+                kind,
+                &weight_col,
+                strata_col.as_deref(),
+                psu_col.as_deref(),
+                ssu_col.as_deref(),
+                fpc_col.as_deref(),
+                fpc_ssu_col.as_deref(),
+                by_col.as_deref(),
+                singleton_method.as_deref(),
+            )
+        })
+        .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+    Ok(PyDataFrame(result))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compute_assoc(
+    df: &DataFrame,
+    y_cols: &[String],
+    x_cols: &[String],
+    kind: AssocKind,
+    weight_col: &str,
+    strata_col: Option<&str>,
+    psu_col: Option<&str>,
+    ssu_col: Option<&str>,
+    fpc_col: Option<&str>,
+    fpc_ssu_col: Option<&str>,
+    by_col: Option<&str>,
+    singleton_method: Option<&str>,
+) -> PolarsResult<DataFrame> {
+    let weights = df.column(weight_col)?.f64()?;
+    let strata = strata_col.map(|c| df.column(c)).transpose()?;
+    let psu = psu_col.map(|c| df.column(c)).transpose()?;
+    let ssu = ssu_col.map(|c| df.column(c)).transpose()?;
+    let fpc = fpc_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
+    let fpc_ssu = fpc_ssu_col.map(|c| df.column(c).and_then(|s| s.f64())).transpose()?;
+
+    // Hoist column resolution out of the parallel region, as the other multi
+    // kernels do.
+    let ys: Vec<&Float64Chunked> = y_cols
+        .iter()
+        .map(|c| df.column(c).and_then(|s| s.f64()))
+        .collect::<PolarsResult<Vec<_>>>()?;
+    let xs: Vec<&Float64Chunked> = x_cols
+        .iter()
+        .map(|c| df.column(c).and_then(|s| s.f64()))
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let design = build_taylor_design(strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
+
+    // Ungrouped is modelled as a single group with no domain mask, so the
+    // (group x pair) fan-out below covers both shapes with one code path.
+    let by_str = by_col.map(|c| df.column(c).and_then(|s| s.str())).transpose()?;
+    let unique_groups = by_str.map(|s| s.unique()).transpose()?;
+    let groups: Vec<Option<&str>> = match unique_groups.as_ref() {
+        Some(u) => u.iter().flatten().map(Some).collect(),
+        None => vec![None],
+    };
+
+    // A by-group is a domain, so its df is counted on its own active
+    // PSUs/strata rather than inherited from the frame (issue #3).
+    let group_dfs: Vec<u32> = groups
+        .par_iter()
+        .map(|g| match (g, by_str) {
+            (Some(gv), Some(bs)) => {
+                degrees_of_freedom_in_domain(weights, strata, psu, Some(&bs.equal(*gv)))
+            }
+            _ => Ok(degrees_of_freedom_from_design(weights, &design, None)),
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let n_pairs = ys.len();
+    let combos: Vec<(usize, usize)> = (0..groups.len())
+        .flat_map(|gi| (0..n_pairs).map(move |pi| (gi, pi)))
+        .collect();
+
+    let rows = combos
+        .par_iter()
+        .map(|&(gi, pi)| -> PolarsResult<(usize, usize, f64, f64, f64, u32, f64)> {
+            let mask = match (groups[gi], by_str) {
+                (Some(g), Some(bs)) => Some(bs.equal(g)),
+                _ => None,
+            };
+            let (y, x) = (ys[pi], xs[pi]);
+            let estimate = point_estimate_assoc(kind, y, x, weights, mask.as_ref())?;
+            let scores = scores_assoc(kind, y, x, weights, mask.as_ref())?;
+            let scores_arr: Vec<f64> = scores.iter().map(|s| s.unwrap_or(0.0)).collect();
+            let variance = taylor_variance_apply(&scores_arr, &design);
+            let se = variance.max(0.0).sqrt();
+            let srs_var = srs_variance_assoc_of(kind, y, x, weights, mask.as_ref())?;
+            let deff = if srs_var > 0.0 { variance / srs_var } else { f64::NAN };
+            let n = match mask.as_ref() {
+                Some(m) => m.sum().unwrap_or(0),
+                None => y.len() as u32,
+            };
+            Ok((gi, pi, estimate, se, variance, n, deff))
+        })
+        .collect::<PolarsResult<Vec<_>>>()?;
+
+    let nv = rows.len();
+    let mut by_vals: Vec<&str> = Vec::with_capacity(nv);
+    let mut y_names: Vec<&str> = Vec::with_capacity(nv);
+    let mut x_names: Vec<&str> = Vec::with_capacity(nv);
+    let mut estimates: Vec<f64> = Vec::with_capacity(nv);
+    let mut ses: Vec<f64> = Vec::with_capacity(nv);
+    let mut variances: Vec<f64> = Vec::with_capacity(nv);
+    let mut dfs: Vec<u32> = Vec::with_capacity(nv);
+    let mut ns: Vec<u32> = Vec::with_capacity(nv);
+    let mut deffs: Vec<f64> = Vec::with_capacity(nv);
+    for (gi, pi, est, se, var, n, deff) in rows {
+        if let Some(g) = groups[gi] {
+            by_vals.push(g);
+        }
+        y_names.push(y_cols[pi].as_str());
+        x_names.push(x_cols[pi].as_str());
+        estimates.push(est);
+        ses.push(se);
+        variances.push(var);
+        dfs.push(group_dfs[gi]);
+        ns.push(n);
+        deffs.push(deff);
+    }
+
+    let kinds = vec![kind.as_str(); nv];
+    let mut out = df![
+        "y" => y_names, "x" => x_names, "kind" => kinds, "est" => estimates,
+        "se" => ses, "var" => variances, "df" => dfs, "n" => ns, "deff" => deffs
+    ]?;
+    if let Some(name) = by_col {
+        out.insert_column(0, Column::new(name.into(), by_vals))?;
+    }
+    Ok(out)
 }
 
 // ============================================================================

--- a/packages/svy-rs/src/lib.rs
+++ b/packages/svy-rs/src/lib.rs
@@ -25,6 +25,7 @@ fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_total_multi, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_ratio, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_ratio_multi, m)?)?;
+    m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_assoc, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_prop, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_prop_multi, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::taylor_api::taylor_median, m)?)?;
@@ -36,6 +37,7 @@ fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_mean, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_total, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_ratio, m)?)?;
+    m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_assoc, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_prop, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_median, m)?)?;
     m.add_function(wrap_pyfunction!(estimation::replication_api::replicate_quantile, m)?)?;

--- a/packages/svy-rs/svy_rs/__init__.py
+++ b/packages/svy-rs/svy_rs/__init__.py
@@ -22,6 +22,7 @@ from svy_rs._internal import (
     rake,
     ranktest_rs,
     # Replication
+    replicate_assoc,
     replicate_mean,
     replicate_median,
     replicate_prop,
@@ -33,6 +34,7 @@ from svy_rs._internal import (
     select_srs_rs,
     tabulate_rs,
     # Taylor linearization
+    taylor_assoc,
     taylor_mean,
     taylor_mean_multi,
     taylor_median,

--- a/packages/svy-rs/tests/test_estimation.py
+++ b/packages/svy-rs/tests/test_estimation.py
@@ -682,3 +682,133 @@ def test_prop_domain_estimates(synthetic_sample_df, design_kwargs, expected):
         exp = expected[domain][level]
         assert row["est"] == pytest.approx(exp["est"], rel=TOL), f"Failed est for {domain}/{level}"
         assert row["se"] == pytest.approx(exp["se"], rel=TOL), f"Failed se for {domain}/{level}"
+
+
+# =============================================================================
+# ASSOCIATION (COVARIANCE / CORRELATION) TESTS
+#
+# Golden values from R survey 4.5 on a single-stage cluster design (8 PSUs of
+# 3 rows, unequal weights):
+#
+#   d  <- svydesign(id=~psu, weights=~w, data=dat)
+#   v  <- svyvar(~y+x, d)                       # covariance + its SE
+#   ct <- svycontrast(svymean(~y+x+yy+xx+yx, d),
+#                     quote((yx - y*x)/sqrt((yy-y^2)*(xx-x^2))))
+#
+# The correlation targets come from svycontrast rather than svyvar because R
+# offers no correlation SE: svycontrast applies its own delta method over the
+# moment means, so it is an independent check of our linearization.
+# =============================================================================
+
+_ASSOC_Y = [12, 15, 11, 22, 25, 19, 31, 29, 35, 41, 44, 39,
+            18, 16, 21, 27, 30, 24, 36, 33, 38, 45, 49, 43]
+_ASSOC_X = [9, 4, 14, 6, 17, 8, 21, 11, 13, 12, 26, 7,
+            19, 5, 23, 10, 28, 15, 8, 22, 16, 18, 31, 20]
+_ASSOC_W = [2, 2, 2, 3, 3, 3, 1.5, 1.5, 1.5, 4, 4, 4,
+            2.5, 2.5, 2.5, 3.5, 3.5, 3.5, 1, 1, 1, 5, 5, 5]
+
+
+@pytest.fixture
+def assoc_df():
+    """Clustered fixture matching the R golden design."""
+    return pl.DataFrame(
+        {
+            "y": [float(v) for v in _ASSOC_Y],
+            "x": [float(v) for v in _ASSOC_X],
+            "w": [float(v) for v in _ASSOC_W],
+            "psu": [str(i // 3 + 1) for i in range(24)],
+            "stratum": ["1"] * 12 + ["2"] * 12,
+            "grp": ["A"] * 12 + ["B"] * 12,
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "kind,strata,expected",
+    [
+        ("cov", None, {"est": 50.138658078368209, "se": 21.498361515848689}),
+        ("corr", None, {"est": 0.52860852253793722, "se": 0.15921590459764234}),
+        # svyvar under svydesign(id=~psu, strata=~stratum, ...)
+        ("cov", "stratum", {"est": 50.138658078368209, "se": 23.178556453025269}),
+    ],
+)
+def test_assoc_matches_r(assoc_df, kind, strata, expected):
+    """Point estimate and SE both match R; the SE is what validates the score."""
+    result = ps.taylor_assoc(
+        assoc_df, ["y"], ["x"], kind, "w", strata_col=strata, psu_col="psu"
+    )
+    assert result["est"][0] == pytest.approx(expected["est"], rel=1e-10)
+    assert result["se"][0] == pytest.approx(expected["se"], rel=1e-9)
+    assert result["kind"][0] == kind
+
+
+def test_assoc_is_symmetric(assoc_df):
+    """Both statistics are symmetric, so argument order cannot matter."""
+    fwd = ps.taylor_assoc(assoc_df, ["y"], ["x"], "corr", "w", psu_col="psu")
+    rev = ps.taylor_assoc(assoc_df, ["x"], ["y"], "corr", "w", psu_col="psu")
+    assert fwd["est"][0] == pytest.approx(rev["est"][0], rel=1e-14)
+    assert fwd["se"][0] == pytest.approx(rev["se"][0], rel=1e-14)
+
+
+def test_assoc_batches_pairs(assoc_df):
+    """One row per pair, in the order requested; corr(y,y) is 1 by definition."""
+    result = ps.taylor_assoc(
+        assoc_df, ["y", "y"], ["x", "y"], "corr", "w", psu_col="psu"
+    )
+    assert result.height == 2
+    assert list(result["y"]) == ["y", "y"]
+    assert list(result["x"]) == ["x", "y"]
+    assert result["est"][1] == pytest.approx(1.0, abs=1e-12)
+
+
+def test_assoc_by_group(assoc_df):
+    """`by` yields one row per (group, pair) with the group column first."""
+    result = ps.taylor_assoc(
+        assoc_df, ["y"], ["x"], "corr", "w", psu_col="psu", by_col="grp"
+    )
+    assert result.height == 2
+    assert result.columns[0] == "grp"
+    assert sorted(result["grp"]) == ["A", "B"]
+
+
+def test_assoc_reports_deff(assoc_df):
+    """The clustered fixture must show a design effect above 1."""
+    result = ps.taylor_assoc(assoc_df, ["y"], ["x"], "corr", "w", psu_col="psu")
+    assert result["deff"][0] > 1.0
+
+
+@pytest.mark.parametrize(
+    "kind,expected_est",
+    [("cov", 50.138658078368209), ("corr", 0.52860852253793722)],
+)
+def test_replicate_assoc_matches_r_jk1(assoc_df, kind, expected_est):
+    """JK1 replicate weights: full-sample estimate and SE both match R.
+
+    R: svyvar(~y+x, as.svrepdesign(d, type="JK1")) gives cov SE
+    29.751032168261617.
+    """
+    reps = {
+        f"rep{r}": [
+            0.0 if i // 3 == r else _ASSOC_W[i] * 8 / 7 for i in range(24)
+        ]
+        for r in range(8)
+    }
+    df = assoc_df.with_columns([pl.Series(k, v) for k, v in reps.items()])
+    result = ps.replicate_assoc(
+        df, ["y"], ["x"], kind, "w", list(reps), "Jackknife"
+    )
+    assert result["est"][0] == pytest.approx(expected_est, rel=1e-10)
+    if kind == "cov":
+        assert result["se"][0] == pytest.approx(29.751032168261617, rel=1e-9)
+
+
+def test_assoc_rejects_unknown_kind(assoc_df):
+    """An unimplemented coefficient must say so, not fall back silently."""
+    with pytest.raises(Exception, match="unknown association kind"):
+        ps.taylor_assoc(assoc_df, ["y"], ["x"], "spearman", "w")
+
+
+def test_assoc_rejects_mismatched_pairs(assoc_df):
+    """Pair columns are positional, so unequal lengths are a caller error."""
+    with pytest.raises(Exception, match="equal length"):
+        ps.taylor_assoc(assoc_df, ["y", "x"], ["x"], "corr", "w")

--- a/packages/svy/src/svy/core/enumerations.py
+++ b/packages/svy/src/svy/core/enumerations.py
@@ -168,6 +168,10 @@ class PopParam(StrEnum):
     RATIO = "Ratio"
     MEDIAN = "Median"
     QUANTILE = "Quantile"
+    # Member names stay abbreviated for code, values carry the full word for
+    # display — the same split PROP = "Proportion" already uses.
+    CORR = "Correlation"
+    COV = "Covariance"
 
 
 @unique

--- a/packages/svy/src/svy/estimation/association.py
+++ b/packages/svy/src/svy/estimation/association.py
@@ -1,0 +1,355 @@
+"""Design-based association estimators: correlation and covariance.
+
+Both statistics are symmetric, so unlike ``ratio`` there is no numerator or
+denominator here: a call names a *set* of columns and every requested pair is
+reported as its own row. The ``y``/``x`` fields on the resulting ``ParamEst``
+hold the two column names positionally and carry no directional meaning.
+
+Confidence intervals differ between the two because their ranges do. A
+correlation is bounded in [-1, 1], so the default interval is built on Fisher's
+z scale and transformed back — the same move ``prop`` makes with a logit, and
+for the same reason: a symmetric Wald interval can otherwise spill past the
+bound. A covariance is unbounded, so it takes the plain Wald interval.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from itertools import combinations
+from typing import TYPE_CHECKING
+
+import numpy as np
+import polars as pl
+import svy_rs as rs
+
+from svy.core.enumerations import EstimationMethod, PopParam
+from svy.errors import DimensionError, MethodError
+
+from .estimate import Estimate, ParamEst
+from .replication import _get_rep_params, get_rep_method_str
+
+
+if TYPE_CHECKING:
+    from svy.core.data_prep import PreparedData
+
+    from .base import Estimation
+
+
+#: Coefficients ``kind=`` accepts today. Widening this tuple is backward
+#: compatible; ``_KNOWN_KINDS`` below is what keeps an unimplemented but
+#: recognised name reporting "not supported yet" instead of "invalid".
+SUPPORTED_KINDS = ("pearson",)
+
+#: Recognised but not yet implemented — named so the error can say so.
+_PLANNED_KINDS = ("spearman", "kendall")
+
+
+def normalize_kind(kind: str) -> str:
+    """Canonicalise ``kind``, distinguishing "not yet" from "no such thing"."""
+    k = str(kind).lower().replace("_", "-").strip()
+    if k in ("pearson", "corr", "correlation"):
+        return "pearson"
+    if k in _PLANNED_KINDS:
+        raise MethodError(
+            title=f"Correlation kind {k!r} is not supported yet",
+            detail=(
+                f"Only {', '.join(SUPPORTED_KINDS)} is implemented today. "
+                f"{k!r} is planned but needs its own linearization: its ranks "
+                "are themselves estimated, so the Pearson score would "
+                "understate the variance."
+            ),
+            code="CORR_KIND_NOT_IMPLEMENTED",
+            where="estimation.corr",
+            param="kind",
+            expected=f"one of {SUPPORTED_KINDS}",
+            got=k,
+            hint="Use kind='pearson', or track the issue for rank-based support.",
+        )
+    raise MethodError(
+        title=f"Unknown correlation kind {k!r}",
+        detail=f"kind must be one of {SUPPORTED_KINDS}.",
+        code="CORR_KIND_UNKNOWN",
+        where="estimation.corr",
+        param="kind",
+        expected=f"one of {SUPPORTED_KINDS}",
+        got=k,
+        hint="Use kind='pearson'.",
+    )
+
+
+def guard_pandas_method(method: object) -> None:
+    """Redirect ``method='spearman'`` to ``kind=``.
+
+    pandas spells the coefficient ``method=``; here ``method`` selects the
+    variance estimator. Someone reaching for muscle memory should be told which
+    argument they wanted, not handed a message about Taylor linearization.
+    """
+    if isinstance(method, str) and method.lower() in ("pearson", *_PLANNED_KINDS):
+        raise MethodError(
+            title=f"{method!r} is a correlation kind, not a variance method",
+            detail=(
+                "In svy, method= selects the variance estimator ('taylor' or "
+                "'replication'); the coefficient is chosen with kind=. pandas "
+                "spells the coefficient method=, which is the likely mix-up."
+            ),
+            code="CORR_METHOD_IS_KIND",
+            where="estimation.corr",
+            param="method",
+            expected="'taylor' or 'replication'",
+            got=method,
+            hint=f"Use kind={method!r} instead of method={method!r}.",
+        )
+
+
+def parse_cols(cols: object, *, where: str) -> list[tuple[str, str]]:
+    """Resolve the ``cols`` argument into an ordered list of column pairs.
+
+    Three spellings, disambiguated by element type, and agreeing wherever they
+    overlap:
+
+    - ``("a", "b")`` or ``["a", "b"]`` — that single pair
+    - ``["a", "b", "c"]`` — every unique pair, in ``i < j`` order
+    - ``[("a", "b"), ("a", "c")]`` — exactly those pairs
+
+    A flat list yields off-diagonal pairs only. Self-pairs are never implied,
+    for covariance as much as correlation, so the two stay consistent; ask for
+    a variance explicitly with ``cov(("a", "a"))``.
+    """
+
+    def _fail(detail: str, got: object, hint: str) -> DimensionError:
+        return DimensionError(
+            title="Invalid cols argument",
+            detail=detail,
+            code="ASSOC_COLS_INVALID",
+            where=where,
+            param="cols",
+            expected="a pair, a list of columns, or a list of pairs",
+            got=got,
+            hint=hint,
+        )
+
+    if isinstance(cols, str):
+        raise _fail(
+            "A single column name has nothing to pair with.",
+            cols,
+            "Pass at least two columns, e.g. cols=('a', 'b').",
+        )
+    if not isinstance(cols, Sequence):
+        raise _fail("cols must be a sequence.", type(cols).__name__, "Pass a tuple or list.")
+
+    items = list(cols)
+    if not items:
+        raise _fail("cols is empty.", items, "Pass at least two columns.")
+
+    if all(isinstance(c, str) for c in items):
+        if len(items) < 2:
+            raise _fail(
+                "A single column name has nothing to pair with.",
+                items,
+                "Pass at least two columns.",
+            )
+        if len(items) == 2:
+            # An explicit pair, so a self-pair is meaningful: cov(("a", "a"))
+            # is the variance, and corr(("a", "a")) is 1 by construction.
+            return [(items[0], items[1])]
+        if len(set(items)) != len(items):
+            # Beyond two columns the list expands to all unique pairs, where a
+            # repeat would silently generate a degenerate self-pair.
+            raise _fail(
+                "cols contains duplicate column names.",
+                items,
+                "Remove duplicates, or request a self-pair explicitly as a tuple.",
+            )
+        return list(combinations(items, 2))
+
+    pairs: list[tuple[str, str]] = []
+    for item in items:
+        if isinstance(item, str) or not isinstance(item, Sequence) or len(item) != 2:
+            raise _fail(
+                "cols mixes column names and pairs, or contains an entry that "
+                "is not a pair of two column names.",
+                item,
+                "Use either a flat list of columns or a list of 2-tuples.",
+            )
+        a, b = item
+        if not (isinstance(a, str) and isinstance(b, str)):
+            raise _fail("Each pair must hold two column names.", item, "Use strings.")
+        pairs.append((a, b))
+    return pairs
+
+
+def _fisher_ci(
+    est: np.ndarray, se: np.ndarray, t_crit: np.ndarray
+) -> tuple[np.ndarray, np.ndarray]:
+    """Fisher z interval for a correlation, back-transformed to [-1, 1].
+
+    ``z = arctanh(r)`` with ``se_z = se / (1 - r^2)`` by the delta method, then
+    ``tanh(z +/- t*se_z)``. Rows at ``|r| >= 1`` have no z to work on, so the
+    interval degenerates to the point estimate rather than producing infinities.
+    """
+    lci = est.copy()
+    uci = est.copy()
+    valid = np.isfinite(est) & np.isfinite(se) & (np.abs(est) < 1.0)
+    if valid.any():
+        r, s, t = est[valid], se[valid], t_crit[valid]
+        with np.errstate(divide="ignore", invalid="ignore"):
+            se_z = s / (1.0 - r * r)
+        z = np.arctanh(r)
+        lci[valid] = np.tanh(z - t * se_z)
+        uci[valid] = np.tanh(z + t * se_z)
+    return lci, uci
+
+
+def result_to_param_est(
+    est: Estimation,
+    result_df: pl.DataFrame,
+    param: PopParam,
+    alpha: float,
+    deff: bool,
+    by_col: str | None,
+    ci_method: str,
+) -> list[ParamEst]:
+    """Build one ``ParamEst`` per result row.
+
+    Distinct from ``_polars_result_to_param_est`` because there each row is a
+    by-group of one variable, while here every row carries its own column pair.
+    """
+    n_rows = result_df.height
+    if n_rows == 0:
+        return []
+
+    est_arr = result_df["est"].to_numpy()
+    se_arr = result_df["se"].to_numpy()
+    df_arr = result_df["df"].to_numpy().astype(np.float64)
+    deff_arr = result_df["deff"].to_numpy() if (deff and "deff" in result_df.columns) else None
+    t_crits = est._t_crit_arr(alpha, df_arr)
+
+    with np.errstate(divide="ignore", invalid="ignore"):
+        cv_arr = np.where(est_arr != 0, se_arr / est_arr, np.inf)
+
+    if param == PopParam.CORR and ci_method == "fisher":
+        lci_arr, uci_arr = _fisher_ci(est_arr, se_arr, t_crits)
+    else:
+        lci_arr = est_arr - t_crits * se_arr
+        uci_arr = est_arr + t_crits * se_arr
+
+    y_names = result_df["y"].to_list()
+    x_names = result_df["x"].to_list()
+    by_tuple = (by_col,) if by_col else None
+    by_levels: list = [None] * n_rows
+    if by_col and by_col in result_df.columns:
+        by_levels = [(v,) for v in result_df[by_col].to_list()]
+
+    return [
+        ParamEst(
+            y=y_names[i],
+            x=x_names[i],
+            est=float(est_arr[i]),
+            se=float(se_arr[i]),
+            cv=float(cv_arr[i]),
+            lci=float(lci_arr[i]),
+            uci=float(uci_arr[i]),
+            deff=float(deff_arr[i]) if deff_arr is not None else None,
+            df=int(df_arr[i]),
+            by=by_tuple,
+            by_level=by_levels[i],
+        )
+        for i in range(n_rows)
+    ]
+
+
+def _kind_arg(param: PopParam) -> str:
+    return "corr" if param == PopParam.CORR else "cov"
+
+
+def taylor_assoc(
+    est: Estimation,
+    prep: PreparedData,
+    pairs: list[tuple[str, str]],
+    param: PopParam,
+    *,
+    deff: bool = False,
+    alpha: float = 0.05,
+    ci_method: str = "fisher",
+) -> Estimate:
+    """Taylor-linearized correlation or covariance over ``pairs``."""
+    pop_size = getattr(est._sample._design, "pop_size", None)
+    df, fpc_col, fpc_ssu_col = (
+        est._compute_fpc_columns(prep.df, pop_size, prep.strata_col, prep.psu_col, prep.ssu_col)
+        if pop_size is not None
+        else (prep.df, None, None)
+    )
+
+    df = est._ensure_float64(df, sorted({c for p in pairs for c in p}))
+    result_df = rs.taylor_assoc(
+        df,
+        [p[0] for p in pairs],
+        [p[1] for p in pairs],
+        _kind_arg(param),
+        prep.weight_col,
+        strata_col=prep.strata_col,
+        psu_col=prep.psu_col,
+        ssu_col=prep.ssu_col,
+        fpc_col=fpc_col,
+        fpc_ssu_col=fpc_ssu_col,
+        by_col=prep.by_col,
+        singleton_method=est._get_center_method(),
+    )
+
+    est_list = result_to_param_est(est, result_df, param, alpha, deff, prep.by_col, ci_method)
+    est_cov = np.diag(result_df["var"].to_numpy())
+    return est._build_estimate_result_light(
+        est_list,
+        est_cov,
+        param,
+        alpha,
+        prep.by_cols,
+        as_factor=False,
+        method=EstimationMethod.TAYLOR,
+    )
+
+
+def replicate_assoc(
+    est: Estimation,
+    prep: PreparedData,
+    pairs: list[tuple[str, str]],
+    param: PopParam,
+    method: EstimationMethod,
+    *,
+    fay_coef: float = 0.0,
+    variance_center: str = "rep_mean",
+    alpha: float = 0.05,
+    ci_method: str = "fisher",
+) -> Estimate:
+    """Replicate-weight correlation or covariance over ``pairs``."""
+    rep_weight_cols, df_val, final_fay, rscales = _get_rep_params(est, fay_coef)
+    data = est._ensure_float64(prep.df, [*rep_weight_cols, *sorted({c for p in pairs for c in p})])
+    result_df = rs.replicate_assoc(
+        data,
+        [p[0] for p in pairs],
+        [p[1] for p in pairs],
+        _kind_arg(param),
+        weight_col=prep.weight_col,
+        rep_weight_cols=rep_weight_cols,
+        method=get_rep_method_str(method),
+        fay_coef=final_fay,
+        rscales=rscales,
+        center=variance_center,
+        degrees_of_freedom=df_val,
+        by_col=prep.by_col,
+        domain_mask_col=prep.domain_mask_col,
+    )
+
+    # The replicate kernel reports no deff (no SRS reference on that path),
+    # so `deff` is never populated here.
+    est_list = result_to_param_est(est, result_df, param, alpha, False, prep.by_col, ci_method)
+    est_cov = np.diag(result_df["var"].to_numpy())
+    return est._build_estimate_result_light(
+        est_list,
+        est_cov,
+        param,
+        alpha,
+        prep.by_cols,
+        as_factor=False,
+        method=method,
+    )

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -66,6 +66,12 @@ from svy.ui.printing import format_where_clause
 from svy.utils.helpers import _colspec_to_list
 from svy.wrangling.rows import _compile_where_to_pl_expr
 
+from .association import guard_pandas_method as _guard_pandas_method
+from .association import normalize_kind as _normalize_assoc_kind
+from .association import parse_cols as _parse_assoc_cols
+from .association import replicate_assoc as _replicate_assoc
+from .association import taylor_assoc as _taylor_assoc
+
 
 log = logging.getLogger(__name__)
 
@@ -1679,6 +1685,189 @@ class Estimation:
         if where is not None:
             result.where_clause = format_where_clause(where)
         return result
+
+    def _assoc(
+        self,
+        param: PopParam,
+        cols,
+        *,
+        by,
+        where,
+        method,
+        ci_method: str,
+        deff: bool,
+        fay_coef: float,
+        variance_center: str,
+        alpha: float,
+        drop_nulls: bool,
+    ) -> Estimate:
+        """Shared machinery behind ``corr`` and ``cov``.
+
+        The two differ only in which coefficient the kernel computes and, for
+        the interval, whether the parameter is bounded.
+        """
+        verb = "corr" if param == PopParam.CORR else "cov"
+        pairs = _parse_assoc_cols(cols, where=f"estimation.{verb}")
+        target_method = self._resolve_method(method)
+
+        # Every named column must survive preparation, so the first drives
+        # `y` and the rest ride along as extras.
+        named = list(dict.fromkeys([c for pair in pairs for c in pair]))
+        prep = prepare_data(
+            self._sample,
+            y=named[0],
+            extra_cols=named[1:],
+            by=by,
+            where=where,
+            drop_nulls=drop_nulls,
+            cast_y_float=True,
+            apply_singleton_filter=True,
+            select_columns=True,
+            domain_mask_for_replication=(target_method != EstimationMethod.TAYLOR and by is None),
+        )
+
+        try:
+            if target_method == EstimationMethod.TAYLOR:
+                result = _taylor_assoc(
+                    self,
+                    prep=prep,
+                    pairs=pairs,
+                    param=param,
+                    deff=deff,
+                    alpha=alpha,
+                    ci_method=ci_method,
+                )
+            else:
+                result = _replicate_assoc(
+                    self,
+                    prep=prep,
+                    pairs=pairs,
+                    param=param,
+                    method=target_method,
+                    fay_coef=fay_coef,
+                    variance_center=variance_center,
+                    alpha=alpha,
+                    ci_method=ci_method,
+                )
+        except RuntimeError as e:
+            if "weights is zero" in str(e).lower() or "sum of weights" in str(e).lower():
+                result = self._empty_estimate(param, alpha, _colspec_to_list(by), target_method)
+            else:
+                raise
+
+        if where is not None:
+            result.where_clause = format_where_clause(where)
+        return result
+
+    def corr(
+        self,
+        cols: tuple[str, str] | Sequence[str] | Sequence[tuple[str, str]],
+        *,
+        kind: Literal["pearson"] = "pearson",
+        by: str | Sequence[str] | None = None,
+        where: WhereArg = None,
+        method: Literal["taylor", "replication"] | None = None,
+        ci_method: Literal["fisher", "wald"] = "fisher",
+        deff: bool = False,
+        fay_coef: float = 0.0,
+        variance_center: Literal["rep_mean", "estimate"] = "rep_mean",
+        alpha: float = 0.05,
+        drop_nulls: bool = False,
+    ) -> Estimate:
+        """Estimate design-based correlation with standard errors.
+
+        Correlation is symmetric, so there is no numerator/denominator here and
+        no ``y``/``x`` argument: name the columns and every requested pair is
+        returned as its own row.
+
+        Parameters
+        ----------
+        cols : pair, sequence of str, or sequence of pairs
+            ``("a", "b")`` estimates that one pair. A flat list of three or
+            more columns estimates every unique pair, in ``i < j`` order. A
+            list of 2-tuples estimates exactly those pairs, which is how you
+            ask for one column against several without also getting the pairs
+            among the others.
+        kind : {'pearson'}, default 'pearson'
+            Which coefficient. Rank-based kinds are planned; asking for one
+            today reports that it is not implemented rather than silently
+            falling back.
+        method : {'taylor', 'replication'} | None
+            Variance estimator, auto-detected from the design when None. Note
+            this selects the *variance* method — pandas spells the coefficient
+            ``method=``, which here is ``kind=``.
+        ci_method : {'fisher', 'wald'}, default 'fisher'
+            ``'fisher'`` builds the interval on the arctanh scale and
+            transforms back, keeping it inside [-1, 1]. ``'wald'`` gives the
+            symmetric ``est ± t·se``, which can exceed the bounds.
+
+        Returns
+        -------
+        Estimate
+            One row per pair, or per (group, pair) when ``by`` is set.
+
+        Examples
+        --------
+        >>> sample.est.corr(("income", "age"))                    # doctest: +SKIP
+        >>> sample.est.corr(["income", "age", "educ"])            # 3 pairs
+        >>> sample.est.corr([("income", "age"), ("income", "educ")])
+        """
+        _guard_pandas_method(method)
+        _normalize_assoc_kind(kind)
+        return self._assoc(
+            PopParam.CORR,
+            cols,
+            by=by,
+            where=where,
+            method=method,
+            ci_method=ci_method,
+            deff=deff,
+            fay_coef=fay_coef,
+            variance_center=variance_center,
+            alpha=alpha,
+            drop_nulls=drop_nulls,
+        )
+
+    def cov(
+        self,
+        cols: tuple[str, str] | Sequence[str] | Sequence[tuple[str, str]],
+        *,
+        by: str | Sequence[str] | None = None,
+        where: WhereArg = None,
+        method: Literal["taylor", "replication"] | None = None,
+        deff: bool = False,
+        fay_coef: float = 0.0,
+        variance_center: Literal["rep_mean", "estimate"] = "rep_mean",
+        alpha: float = 0.05,
+        drop_nulls: bool = False,
+    ) -> Estimate:
+        """Estimate design-based covariance with standard errors.
+
+        Takes the same symmetric ``cols`` argument as :meth:`corr`. Estimates
+        are on R ``svyvar``'s scale, carrying its n/(n-1) factor. There is no
+        ``ci_method``: a covariance is unbounded, so the interval is Wald.
+
+        A flat list gives off-diagonal pairs only, exactly as for ``corr``. To
+        get a variance, name the self-pair: ``cov(("income", "income"))``.
+
+        Returns
+        -------
+        Estimate
+            One row per pair, or per (group, pair) when ``by`` is set.
+        """
+        return self._assoc(
+            PopParam.COV,
+            cols,
+            by=by,
+            where=where,
+            method=method,
+            ci_method="wald",
+            deff=deff,
+            fay_coef=fay_coef,
+            variance_center=variance_center,
+            alpha=alpha,
+            drop_nulls=drop_nulls,
+        )
 
     @staticmethod
     def _normalize_probs(p: float | Sequence[float]) -> tuple[list[float], bool]:

--- a/packages/svy/tests/svy/estimation/test_association.py
+++ b/packages/svy/tests/svy/estimation/test_association.py
@@ -1,0 +1,287 @@
+# tests/svy/estimation/test_association.py
+"""Tests for the design-based ``corr`` and ``cov`` estimators.
+
+Golden values come from R survey 4.5 on a single-stage cluster design (8 PSUs
+of 3 rows, unequal weights)::
+
+    d  <- svydesign(id=~psu, weights=~w, data=dat)
+    v  <- svyvar(~y+x, d)                        # covariance and its SE
+    ct <- svycontrast(svymean(~y+x+yy+xx+yx, d),
+                      quote((yx - y*x)/sqrt((yy-y^2)*(xx-x^2))))
+    rd <- as.svrepdesign(d, type="JK1"); svyvar(~y+x, rd)
+
+The correlation SE comes from ``svycontrast`` rather than ``svyvar`` because R
+has no correlation SE of its own: ``svycontrast`` applies its own delta method
+over the moment means, so agreement is an independent check of the
+linearization rather than a restatement of the same formula.
+"""
+
+from __future__ import annotations
+
+import polars as pl
+import pytest
+
+from svy import EstimationMethod, Sample
+from svy.core.design import Design, RepWeights
+from svy.core.enumerations import PopParam
+from svy.errors import DimensionError, MethodError
+
+
+R_CORR = 0.52860852253793722
+R_CORR_SE = 0.15921590459764234
+R_COV = 50.138658078368209
+R_COV_SE = 21.498361515848689
+R_VAR_Y = 139.54576489533011
+R_COV_STRAT_SE = 23.178556453025269
+R_COV_JK1_SE = 29.751032168261617
+
+_Y = [
+    12,
+    15,
+    11,
+    22,
+    25,
+    19,
+    31,
+    29,
+    35,
+    41,
+    44,
+    39,
+    18,
+    16,
+    21,
+    27,
+    30,
+    24,
+    36,
+    33,
+    38,
+    45,
+    49,
+    43,
+]
+_X = [9, 4, 14, 6, 17, 8, 21, 11, 13, 12, 26, 7, 19, 5, 23, 10, 28, 15, 8, 22, 16, 18, 31, 20]
+_W = [2, 2, 2, 3, 3, 3, 1.5, 1.5, 1.5, 4, 4, 4, 2.5, 2.5, 2.5, 3.5, 3.5, 3.5, 1, 1, 1, 5, 5, 5]
+_PSU = [i // 3 + 1 for i in range(24)]
+
+
+def _frame() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "id": list(range(24)),
+            "y": [float(v) for v in _Y],
+            "x": [float(v) for v in _X],
+            # Deliberately an exact linear function of x, so corr(x, z) must be
+            # 1 and corr(y, z) must equal corr(y, x) -- a scale/shift check.
+            "z": [float(v) * 1.7 + 3.0 for v in _X],
+            "w": [float(v) for v in _W],
+            "psu": _PSU,
+            "stratum": ["1"] * 12 + ["2"] * 12,
+            "grp": ["A"] * 12 + ["B"] * 12,
+        }
+    )
+
+
+@pytest.fixture
+def sample() -> Sample:
+    return Sample(_frame(), Design(row_index="id", wgt="w", psu="psu"))
+
+
+@pytest.fixture
+def strat_sample() -> Sample:
+    return Sample(_frame(), Design(row_index="id", wgt="w", psu="psu", stratum="stratum"))
+
+
+@pytest.fixture
+def rep_sample() -> Sample:
+    df = _frame()
+    reps = {
+        f"jk_{r + 1}": [0.0 if _PSU[i] == r + 1 else _W[i] * 8 / 7 for i in range(24)]
+        for r in range(8)
+    }
+    df = df.with_columns([pl.Series(k, v) for k, v in reps.items()])
+    design = Design(
+        row_index="id",
+        wgt="w",
+        psu="psu",
+        rep_wgts=RepWeights(method=EstimationMethod.JACKKNIFE, prefix="jk_", n_reps=8, df=7),
+    )
+    return Sample(df, design)
+
+
+def _row(estimate, i: int = 0) -> dict:
+    return estimate.to_dicts()[i]
+
+
+# ---------------------------------------------------------------------------
+# Agreement with R
+# ---------------------------------------------------------------------------
+
+
+def test_corr_matches_r(sample):
+    r = _row(sample.estimation.corr(("y", "x")))
+    assert r["est"] == pytest.approx(R_CORR, rel=1e-10)
+    assert r["se"] == pytest.approx(R_CORR_SE, rel=1e-9)
+
+
+def test_cov_matches_r(sample):
+    r = _row(sample.estimation.cov(("y", "x")))
+    assert r["est"] == pytest.approx(R_COV, rel=1e-10)
+    assert r["se"] == pytest.approx(R_COV_SE, rel=1e-9)
+
+
+def test_cov_stratified_matches_r(strat_sample):
+    r = _row(strat_sample.estimation.cov(("y", "x")))
+    assert r["se"] == pytest.approx(R_COV_STRAT_SE, rel=1e-9)
+
+
+def test_cov_self_pair_is_the_variance(sample):
+    """An explicit self-pair is the variance on svyvar's diagonal."""
+    r = _row(sample.estimation.cov(("y", "y")))
+    assert r["est"] == pytest.approx(R_VAR_Y, rel=1e-9)
+
+
+def test_replication_matches_r(rep_sample):
+    est = rep_sample.estimation
+    c = _row(est.cov(("y", "x"), method="replication"))
+    assert c["est"] == pytest.approx(R_COV, rel=1e-9)
+    assert c["se"] == pytest.approx(R_COV_JK1_SE, rel=1e-7)
+
+    r = _row(est.corr(("y", "x"), method="replication"))
+    assert r["est"] == pytest.approx(R_CORR, rel=1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Symmetry — the reason there is no y/x argument
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("verb", ["corr", "cov"])
+def test_argument_order_does_not_matter(sample, verb):
+    fn = getattr(sample.estimation, verb)
+    a, b = _row(fn(("y", "x"))), _row(fn(("x", "y")))
+    assert a["est"] == pytest.approx(b["est"], rel=1e-14)
+    assert a["se"] == pytest.approx(b["se"], rel=1e-14)
+
+
+def test_corr_is_scale_and_shift_invariant(sample):
+    """z is an exact affine function of x, so both must follow from that."""
+    d = {(r["y"], r["x"]): r["est"] for r in sample.estimation.corr(["y", "x", "z"]).to_dicts()}
+    assert d[("x", "z")] == pytest.approx(1.0, abs=1e-12)
+    assert d[("y", "z")] == pytest.approx(d[("y", "x")], rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# cols spellings
+# ---------------------------------------------------------------------------
+
+
+def test_pair_returns_one_row(sample):
+    assert sample.estimation.corr(("y", "x")).to_dicts().__len__() == 1
+
+
+def test_two_element_list_is_the_same_as_a_tuple(sample):
+    """The two spellings coincide at two columns, so they must agree."""
+    a = _row(sample.estimation.corr(("y", "x")))
+    b = _row(sample.estimation.corr(["y", "x"]))
+    assert a["est"] == pytest.approx(b["est"], rel=1e-14)
+
+
+def test_flat_list_expands_to_all_unique_pairs(sample):
+    rows = sample.estimation.corr(["y", "x", "z"]).to_dicts()
+    assert [(r["y"], r["x"]) for r in rows] == [("y", "x"), ("y", "z"), ("x", "z")]
+
+
+def test_pair_list_selects_exactly_those_pairs(sample):
+    """A focal variable against several others, without the others' pairs."""
+    rows = sample.estimation.corr([("y", "x"), ("y", "z")]).to_dicts()
+    assert [(r["y"], r["x"]) for r in rows] == [("y", "x"), ("y", "z")]
+
+
+def test_by_group_yields_a_row_per_group_and_pair(sample):
+    rows = sample.estimation.corr([("y", "x"), ("y", "z")], by="grp").to_dicts()
+    assert len(rows) == 4
+
+
+# ---------------------------------------------------------------------------
+# Confidence intervals
+# ---------------------------------------------------------------------------
+
+
+def test_fisher_interval_is_asymmetric_and_bounded(sample):
+    r = _row(sample.estimation.corr(("y", "x")))
+    assert -1.0 <= r["lci"] <= r["est"] <= r["uci"] <= 1.0
+    lower_arm = r["est"] - r["lci"]
+    upper_arm = r["uci"] - r["est"]
+    assert abs(upper_arm - lower_arm) > 1e-6, "Fisher arms should not be equal"
+
+
+def test_wald_interval_is_symmetric(sample):
+    r = _row(sample.estimation.corr(("y", "x"), ci_method="wald"))
+    assert (r["uci"] - r["est"]) == pytest.approx(r["est"] - r["lci"], rel=1e-12)
+
+
+def test_fisher_and_wald_differ(sample):
+    f = _row(sample.estimation.corr(("y", "x")))
+    w = _row(sample.estimation.corr(("y", "x"), ci_method="wald"))
+    assert f["lci"] != pytest.approx(w["lci"], rel=1e-9)
+
+
+def test_cov_interval_is_wald(sample):
+    """Covariance is unbounded, so it takes the symmetric interval."""
+    r = _row(sample.estimation.cov(("y", "x")))
+    assert (r["uci"] - r["est"]) == pytest.approx(r["est"] - r["lci"], rel=1e-12)
+
+
+# ---------------------------------------------------------------------------
+# Metadata and deff
+# ---------------------------------------------------------------------------
+
+
+def test_param_carries_the_full_word(sample):
+    assert sample.estimation.corr(("y", "x")).param == PopParam.CORR
+    assert str(sample.estimation.cov(("y", "x")).param) == "Covariance"
+
+
+def test_deff_exceeds_one_under_clustering(sample):
+    r = _row(sample.estimation.corr(("y", "x"), deff=True))
+    assert r["deff"] > 1.0
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+def test_single_column_is_rejected(sample):
+    with pytest.raises(DimensionError, match="nothing to pair with"):
+        sample.estimation.corr("y")
+
+
+def test_duplicate_columns_rejected_in_flat_list(sample):
+    """Three or more columns expand to all pairs, where a repeat is degenerate."""
+    with pytest.raises(DimensionError, match="duplicate"):
+        sample.estimation.corr(["y", "x", "y"])
+
+
+def test_planned_kind_reports_not_implemented(sample):
+    """'spearman' is recognised, so say it is unimplemented, not invalid."""
+    with pytest.raises(MethodError, match="not supported yet"):
+        sample.estimation.corr(("y", "x"), kind="spearman")
+
+
+def test_unknown_kind_is_rejected(sample):
+    with pytest.raises(MethodError, match="Unknown correlation kind"):
+        sample.estimation.corr(("y", "x"), kind="nonsense")
+
+
+def test_pandas_style_method_is_redirected_to_kind(sample):
+    """pandas spells the coefficient method=; point the user at kind=."""
+    with pytest.raises(MethodError, match="not a variance method"):
+        sample.estimation.corr(("y", "x"), method="spearman")
+
+
+def test_mixed_cols_are_rejected(sample):
+    with pytest.raises(DimensionError, match="mixes column names and pairs"):
+        sample.estimation.corr(["y", ("x", "z")])


### PR DESCRIPTION
Adds `sample.est.corr()` and `sample.est.cov()` — design-based Pearson correlation and covariance, with Taylor and replication variance.

## API

Neither statistic has a direction, so neither takes `y`/`x`. A call names a set of columns through one symmetric `cols` argument, and every requested pair comes back as its own row:

```python
sample.est.corr(("income", "age"))                        # one pair
sample.est.corr(["income", "age", "educ"])                # every unique pair
sample.est.corr([("income", "age"), ("income", "educ")])  # exactly these pairs
```

The three spellings are disambiguated by element type and agree wherever they overlap, so a two-element list and a two-element tuple mean the same thing. A flat list yields off-diagonal pairs only — for covariance as much as correlation, so the two stay consistent; a variance is requested explicitly as `cov(("a", "a"))`.

`kind=` selects the coefficient; `method=` remains the variance estimator. Because pandas spells the coefficient `method=`, that mix-up is caught by name and redirected, rather than surfacing as a confusing message about Taylor linearization. A recognised but unimplemented kind reports that it is *not supported yet* rather than *invalid*, so `"spearman"` tells the caller to wait rather than to look elsewhere.

Correlation is bounded, so its interval is built on Fisher's z scale and transformed back — the same move `prop` makes with a logit, and for the same reason: a symmetric Wald interval can otherwise report bounds outside [-1, 1]. `ci_method="wald"` opts out. Covariance is unbounded and takes Wald with no such option.

## Estimands and linearization

Both follow R's `survey`. The covariance carries the Kish n/(n-1) factor `svyvar` applies, with `n` counted as rows having nonzero weight and no missing value — so `where=`/`drop_nulls` rows, which reach the kernel zero-weighted rather than deleted, drop out exactly as R drops them. Correlation is divisor-invariant and needs no such choice.

The linearization is the load-bearing part. For covariance the terms from estimating the means cancel identically, leaving `a*b - m_yx`; that is why R's `svymean(a*b*n/(n-1))` shortcut is exactly the delta method rather than an approximation. For correlation they do **not** cancel, because the standard deviations are themselves estimated, so the score carries the `-(rho/2)(yt^2 + xt^2)` terms. Using a covariance-style score for a correlation would silently understate its variance.

Scores and the deff denominator share a single influence-function definition, so a design effect cannot be measured against a different linearization than the SE it is divided by.

## Validation against R survey 4.5

Checked through the public Python API, not just the Rust internals:

| | svy | R |
|---|---:|---:|
| covariance | 50.138658078368 | 50.138658078368 |
| covariance SE | 21.498361515849 | 21.498361515849 |
| stratified SE | 23.178556453025 | 23.178556453025 |
| correlation | 0.528608522538 | 0.528608522538 |
| correlation SE | 0.159215904598 | 0.159215904598 |
| JK1 replicate SE | 29.751032168 | 29.751032168262 |

Covariance targets come from `svyvar`. Correlation targets come from `svycontrast` over the moment means, because R has no correlation SE of its own — `svycontrast` runs its own delta method, so agreement is an independent check of the linearization rather than a restatement of the same formula. Replicate targets come from `svyvar` on an `as.svrepdesign(type="JK1")` design, including a per-replicate comparison.

Two R behaviours were matched deliberately: `svrepvar` recomputes the mean inside every replicate but fixes `n` once outside it, and a test asserts that recomputing `n` per replicate would drift every covariance by ~0.6% on the fixture. One R inconsistency was **not** copied — its Taylor path counts `n` as nonzero-weight non-missing rows while its replicate path uses the raw row count; svy uses the former in both.

## Numerical stability

Moments accumulate in two passes rather than from raw sums of squares. The one-pass form cancels catastrophically when the mean is large relative to the spread — for income-like data it discards roughly seven significant digits, and for a covariance that error lands directly in the reported estimate. The second pass is free on the Taylor path, since scores cannot be formed until rho and the means are known. A test pins stability under a 1e9 offset.

## Performance

Two optimizations, both benchmarked in the criterion suite (`association_*` groups):

- **Replication precomputes the weight-independent products once**, turning each replicate into six dot products instead of a full recomputation: **12.8x** faster (3.3ms vs 42.1ms, n=100k, 200 replicates).
- **An all-pairs sweep** builds the whole moment matrix in one pass, cutting column traffic from O(k²) to O(k): ties at k=5, ~1.5–1.8x at k=10. The benefit grows with k only.

Accumulation stays row-ordered and parallelism stays on the replicate axis, per the determinism policy in `estimation/mod.rs` — output remains bit-identical across thread counts.

## Tests

- 29 Rust unit tests, including 6 R golden fixtures
- 11 svy-rs Python binding tests
- 25 svy tests covering the API surface, both interval methods, symmetry, scale/shift invariance, and every error path

Full suites green: 2,895 svy, 36 svy-rs Python, 109 Rust. `make lint-svy` clean.

## Follow-up, not in this PR

svy applies the finite-population correction to the deff denominator unconditionally, which breaks on rescaled weights: weights normalized to sum to n drive deff to infinity, and normalized to sum to 1 drive it negative. R handles this with `deff="replace"`, whose docs state plainly that the default "will be incorrect if the weights have been rescaled so that they are not reciprocals of sampling probabilities". This affects every estimator, so the new `srs_variance_corr`/`srs_variance_cov` deliberately follow the existing house rule rather than diverging. Worth its own change, with the API decided first.