### PR TITLE
fix(metadata): normalize value labels on clone; require msgspec>=0.21

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -16,9 +16,17 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
   s.wrangling.apply_labels(categories={"q1": {1: "Yes", 2: "No"}}).labels
   ```
 
-  `VariableMeta.clone` copied through `msgspec.structs.replace`, which does not run `__post_init__` before msgspec 0.21 — and svy accepts `msgspec>=0.19.0`. `__post_init__` is the one place that turns the authoring dict `{1: "Yes"}` into the `ValueLabel` pairs the field is declared to hold, so on a resolved 0.20 the dict was stored verbatim and the failure surfaced at the next read rather than at the write. Since `apply_labels` reaches `clone` through `set_value_labels`, the whole documented path for labelling a variable was affected on that msgspec.
+  `VariableMeta.clone` copied through `msgspec.structs.replace`, which does not run `__post_init__` before msgspec 0.21 — and the floor was `>=0.19.0`. `__post_init__` is the one place that turns the authoring dict `{1: "Yes"}` into the `ValueLabel` pairs the field is declared to hold, so on a resolved 0.20 the dict was stored verbatim and the failure surfaced at the next read rather than at the write. Since `apply_labels` reaches `clone` through `set_value_labels`, the whole documented path for labelling a variable was affected on that msgspec.
 
-  Cloning now goes through the constructor, which normalizes and re-checks the invariants on every version supported. Applied to `VariableMeta`, `Label` and `CategoryScheme` — the three structs that normalize in `__post_init__`.
+  Cloning now goes through the constructor, which normalizes and re-checks the invariants by definition, on any msgspec. The floor moved to 0.21 as well (see below) — two fixes for one defect, deliberately: the pin closes it for `replace` everywhere in the codebase, and the constructor closes it here regardless of what the pin later becomes. Applied to `VariableMeta`, `Label` and `CategoryScheme` — the three structs that normalize in `__post_init__`.
+
+### Changed
+
+- **msgspec floor raised to 0.21.** `msgspec>=0.19.0` became `msgspec>=0.21.0` ([#127](https://github.com/samplics-org/svy/pull/127)).
+
+  0.21 is the first release where `structs.replace` runs `__post_init__`; 0.19 and 0.20 skip it, verified directly against each. Any struct that normalizes or validates in `__post_init__` is therefore only as sound as the resolved msgspec, and svy has several — the value-label defect above is what that looks like in practice, and it reached users because a lockfile resolving 0.21 hid it from the test suite while a docs environment resolving 0.20 published the traceback.
+
+  Nothing in svy needs a 0.20 or 0.19 runtime, and 0.21.1 was already what every lockfile here resolved, so this only rules out an installation that was never tested.
 
 ## [0.24.0] — 2026-08-10
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,18 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Fixed
+
+- **Value labels survive being written.** Reading back what `apply_labels` had just stored raised `AttributeError: 'int' object has no attribute 'code'` ([#127](https://github.com/samplics-org/svy/pull/127)):
+
+  ```python
+  s.wrangling.apply_labels(categories={"q1": {1: "Yes", 2: "No"}}).labels
+  ```
+
+  `VariableMeta.clone` copied through `msgspec.structs.replace`, which does not run `__post_init__` before msgspec 0.21 — and svy accepts `msgspec>=0.19.0`. `__post_init__` is the one place that turns the authoring dict `{1: "Yes"}` into the `ValueLabel` pairs the field is declared to hold, so on a resolved 0.20 the dict was stored verbatim and the failure surfaced at the next read rather than at the write. Since `apply_labels` reaches `clone` through `set_value_labels`, the whole documented path for labelling a variable was affected on that msgspec.
+
+  Cloning now goes through the constructor, which normalizes and re-checks the invariants on every version supported. Applied to `VariableMeta`, `Label` and `CategoryScheme` — the three structs that normalize in `__post_init__`.
+
 ## [0.24.0] — 2026-08-10
 
 ### Added

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -22,7 +22,10 @@ requires-python = ">=3.11"
 dependencies = [
   "httpx>=0.28.1",
   "numpy>=2.0",
-  "msgspec>=0.19.0",
+  # 0.21 is the first release where structs.replace runs __post_init__.
+  # Below it, every clone silently skipped the normalization that keeps
+  # value labels as ValueLabel pairs (see CHANGELOG, value-label clone fix).
+  "msgspec>=0.21.0",
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
   "svy-io>=0.2.0,<0.3.0",

--- a/packages/svy/src/svy/metadata/labels.py
+++ b/packages/svy/src/svy/metadata/labels.py
@@ -10,11 +10,11 @@ from typing import Iterable, Mapping, Self
 
 import msgspec
 
-from msgspec.structs import force_setattr, replace
+from msgspec.structs import force_setattr
 
 from svy.core.types import Category
 from svy.errors.label_errors import LabelError
-from svy.metadata.variable_meta import ValueLabel, _coerce_labels
+from svy.metadata.variable_meta import ValueLabel, _clone_struct, _coerce_labels
 
 
 log = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class Label(msgspec.Struct, frozen=True):
         return {vl.code: vl.label for vl in self.categories or ()}
 
     def clone(self, **overrides) -> Self:
-        return replace(self, **overrides)
+        return _clone_struct(self, overrides)
 
 
 class SchemeEntry(msgspec.Struct, frozen=True):
@@ -135,7 +135,7 @@ class CategoryScheme(msgspec.Struct, kw_only=True, frozen=True):
         return {e.code: e.label for e in self.entries}
 
     def clone(self, **overrides) -> Self:
-        return replace(self, **overrides)
+        return _clone_struct(self, overrides)
 
 
 def _coerce_entries(value) -> tuple[SchemeEntry, ...]:

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -99,13 +99,15 @@ _StructT = TypeVar("_StructT", bound=msgspec.Struct)
 def _clone_struct(struct: _StructT, overrides: dict[str, Any]) -> _StructT:
     """Copy a frozen struct through its constructor, so ``__post_init__`` runs.
 
-    Not ``msgspec.structs.replace``: it skips ``__post_init__`` before msgspec
-    0.21, and svy supports 0.19+. The structs here normalize in
-    ``__post_init__`` — a dict of value labels becomes ``ValueLabel`` pairs —
-    so ``replace`` on an older msgspec stored the authoring dict verbatim and
-    every later read of ``.labels`` raised ``AttributeError: 'int' object has
-    no attribute 'code'``. The constructor normalizes on every version we
-    support, and re-checks the invariants while it is there.
+    The structs here normalize in ``__post_init__`` — a dict of value labels
+    becomes ``ValueLabel`` pairs — so a copy that skips it stores the authoring
+    dict verbatim, and every later read of ``.labels`` raises ``AttributeError:
+    'int' object has no attribute 'code'``.
+
+    ``msgspec.structs.replace`` did exactly that before msgspec 0.21, which is
+    why the floor is pinned there. This does not depend on that pin: the
+    constructor runs the normalization by definition, on any version, and
+    re-checks the invariants while it is there.
     """
     return type(struct)(**{**asdict(struct), **overrides})
 

--- a/packages/svy/src/svy/metadata/variable_meta.py
+++ b/packages/svy/src/svy/metadata/variable_meta.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 import logging
 import math
 
-from typing import TYPE_CHECKING, Any, Iterable, Mapping, Self
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, Self, TypeVar
 
 import msgspec
 import polars as pl
 
-from msgspec.structs import force_setattr, replace
+from msgspec.structs import asdict, force_setattr
 
 
 if TYPE_CHECKING:
@@ -91,6 +91,23 @@ def _coerce_labels(value) -> tuple[ValueLabel, ...] | None:
     if isinstance(value, Mapping):
         return tuple(ValueLabel(code=c, label=lbl) for c, lbl in value.items())
     return tuple(v if isinstance(v, ValueLabel) else ValueLabel(*v) for v in value)
+
+
+_StructT = TypeVar("_StructT", bound=msgspec.Struct)
+
+
+def _clone_struct(struct: _StructT, overrides: dict[str, Any]) -> _StructT:
+    """Copy a frozen struct through its constructor, so ``__post_init__`` runs.
+
+    Not ``msgspec.structs.replace``: it skips ``__post_init__`` before msgspec
+    0.21, and svy supports 0.19+. The structs here normalize in
+    ``__post_init__`` — a dict of value labels becomes ``ValueLabel`` pairs —
+    so ``replace`` on an older msgspec stored the authoring dict verbatim and
+    every later read of ``.labels`` raised ``AttributeError: 'int' object has
+    no attribute 'code'``. The constructor normalizes on every version we
+    support, and re-checks the invariants while it is there.
+    """
+    return type(struct)(**{**asdict(struct), **overrides})
 
 
 # =============================================================================
@@ -261,7 +278,7 @@ class VariableMeta(msgspec.Struct, frozen=True):
 
     def clone(self, **overrides: Any) -> VariableMeta:
         """Create a copy with optional field overrides."""
-        return replace(self, **overrides)
+        return _clone_struct(self, overrides)
 
     def with_label(self, label: str) -> VariableMeta:
         """Return a copy with updated variable label."""

--- a/packages/svy/tests/svy/metadata/test_variable_meta.py
+++ b/packages/svy/tests/svy/metadata/test_variable_meta.py
@@ -7,8 +7,18 @@ import msgspec
 import polars as pl
 import pytest
 
+from svy import Sample
 from svy.core.enumerations import MeasurementType, MetadataSource
-from svy.metadata import MetadataStore, ResolvedLabels, SchemeRef, VariableMeta
+from svy.metadata import (
+    CategoryScheme,
+    Label,
+    MetadataStore,
+    ResolvedLabels,
+    SchemeRef,
+    VariableMeta,
+)
+from svy.metadata.labels import SchemeEntry
+from svy.metadata.variable_meta import ValueLabel
 
 
 class TestValueLabelRoundTrip:
@@ -51,6 +61,59 @@ class TestValueLabelRoundTrip:
         payload = {name: store.get(name) for name in store.variables}
         back = msgspec.json.decode(msgspec.json.encode(payload), type=dict[str, VariableMeta])
         assert back["sex"].labels == {1: "Male", 2: "Female", 8: "Don't know"}
+
+
+class TestCloneNormalizes:
+    """`clone` must normalize exactly like the constructor.
+
+    It used to delegate to `msgspec.structs.replace`, which does not run
+    `__post_init__` before msgspec 0.21 — and svy supports 0.19+. So
+    `with_value_labels({1: "Yes"})` stored the authoring dict verbatim on an
+    older msgspec, and the next read of `.labels` raised
+    `AttributeError: 'int' object has no attribute 'code'`.
+
+    These assert the stored *shape*, not `.labels`: a `.labels` assertion
+    passes on 0.21+ whether or not `clone` normalizes, so it cannot catch a
+    regression here.
+    """
+
+    def test_with_value_labels_stores_pairs(self):
+        m = VariableMeta(name="q1", label="Satisfied?").with_value_labels({1: "Yes", 2: "No"})
+        assert m.value_labels == (
+            ValueLabel(code=1, label="Yes"),
+            ValueLabel(code=2, label="No"),
+        )
+        assert m.labels == {1: "Yes", 2: "No"}
+
+    def test_clone_stores_pairs(self):
+        m = VariableMeta(name="q1").clone(value_labels={1: "Yes"})
+        assert m.value_labels == (ValueLabel(code=1, label="Yes"),)
+
+    def test_clone_still_enforces_the_invariants(self):
+        m = VariableMeta(name="q1")
+        with pytest.raises(ValueError, match="both value_labels and scheme_ref"):
+            m.clone(value_labels={1: "Yes"}, scheme_ref=SchemeRef(concept="yes_no"))
+
+    def test_label_clone_stores_pairs(self):
+        lab = Label(label="Sex").clone(categories={1: "Male", 2: "Female"})
+        assert lab.categories == (
+            ValueLabel(code=1, label="Male"),
+            ValueLabel(code=2, label="Female"),
+        )
+
+    def test_scheme_clone_stores_entries(self):
+        scheme = CategoryScheme(concept="sex").clone(entries={1: "Male", 2: "Female"})
+        assert scheme.labels == {1: "Male", 2: "Female"}
+        assert all(isinstance(e, SchemeEntry) for e in scheme.entries)
+
+    def test_apply_labels_survives_the_read_back(self):
+        """The tutorial cell that surfaced this, end to end."""
+        s = Sample(pl.DataFrame({"q1": [1, 2, 1, 2]}))
+        out = s.wrangling.apply_labels(
+            labels={"q1": "Satisfaction with service"},
+            categories={"q1": {1: "Yes", 2: "No"}},
+        )
+        assert out.labels["q1"] == {1: "Yes", 2: "No"}
 
 
 class TestSchemeRef:

--- a/packages/svy/tests/svy/metadata/test_variable_meta.py
+++ b/packages/svy/tests/svy/metadata/test_variable_meta.py
@@ -67,14 +67,15 @@ class TestCloneNormalizes:
     """`clone` must normalize exactly like the constructor.
 
     It used to delegate to `msgspec.structs.replace`, which does not run
-    `__post_init__` before msgspec 0.21 — and svy supports 0.19+. So
-    `with_value_labels({1: "Yes"})` stored the authoring dict verbatim on an
-    older msgspec, and the next read of `.labels` raised
+    `__post_init__` before msgspec 0.21 — and the floor was 0.19. So
+    `with_value_labels({1: "Yes"})` stored the authoring dict verbatim on a
+    resolved 0.20, and the next read of `.labels` raised
     `AttributeError: 'int' object has no attribute 'code'`.
 
-    These assert the stored *shape*, not `.labels`: a `.labels` assertion
-    passes on 0.21+ whether or not `clone` normalizes, so it cannot catch a
-    regression here.
+    These assert the stored *shape*, not `.labels`. Now that the floor is
+    0.21 the dependency alone would keep `replace` honest, so a `.labels`
+    assertion cannot tell a normalizing `clone` from a lucky one — only the
+    shape can.
     """
 
     def test_with_value_labels_stores_pairs(self):

--- a/uv.lock
+++ b/uv.lock
@@ -2375,7 +2375,7 @@ requires-dist = [
     { name = "great-tables", marker = "extra == 'all'", specifier = ">=0.18" },
     { name = "great-tables", marker = "extra == 'report'", specifier = ">=0.18" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "msgspec", specifier = ">=0.19.0" },
+    { name = "msgspec", specifier = ">=0.21.0" },
     { name = "numpy", specifier = ">=2.0" },
     { name = "polars", extras = ["pyarrow"], specifier = ">=1.33.1" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=14.1" },


### PR DESCRIPTION
## What broke

Reading back the value labels that `apply_labels` just wrote raises:

```python
s.wrangling.apply_labels(
    labels={"q1": "Satisfaction with service"},
    categories={"q1": {1: "Yes", 2: "No"}},
).labels
# AttributeError: 'int' object has no attribute 'code'
```

The wrangling tutorial does exactly this, so the published page carries the traceback — `execute: error: true` renders it instead of failing the build, so it shipped silently. Anyone following that page hits the same crash.

## Why

`VariableMeta.clone` delegated to `msgspec.structs.replace`, which does **not** run `__post_init__` before msgspec 0.21. The floor was `msgspec>=0.19.0`, so a resolved 0.20 skips the only place that coerces an authoring dict of value labels into `ValueLabel` pairs. The dict is stored verbatim and the failure surfaces at the next read rather than at the write.

`apply_labels` reaches `clone` via `set_value_labels` → `with_value_labels`, so the whole documented path for labelling a variable was broken on that msgspec.

## Fix, at both layers

1. **`_clone_struct`** copies a frozen struct through its constructor, which runs the normalization by definition and re-checks the invariants. Applied to the three `clone` methods whose structs normalize in `__post_init__`: `VariableMeta`, `Label`, `CategoryScheme`.
2. **`msgspec>=0.21.0`.** 0.21 is the first release where `replace` runs `__post_init__` — 0.19 and 0.20 skip it, verified directly against each.

Deliberately both, because they guard different scopes. The pin closes this for every `replace` in the codebase — including `_naming`'s `RepWeights` prefix swap, which skipped the empty-prefix check for the same reason. The constructor copy closes it here regardless of what the pin later becomes.

Nothing in svy needs a 0.20 runtime and every lockfile already resolved 0.21.1, so the floor only rules out an installation that was never tested.

## Tests

The existing tests could not have caught this: they assert on `.labels`, which reads identically on 0.21 whether or not `clone` normalizes, and every lockfile resolves a msgspec that runs `__post_init__`. That is exactly how a floor of 0.19 went unexercised at its own boundary while a docs environment on 0.20 published the traceback.

`TestCloneNormalizes` asserts the stored *shape* instead, plus one end-to-end case driving the tutorial cell.

Workspace suite: 3232 passed, 10 skipped, 11 xfailed, 3 xpassed. Rebuilt `wrangling.html` has no traceback and renders `{'q1': {1: 'Yes', 2: 'No'}, 'q2': {1: 'Yes', 2: 'No'}}`.