### PR TITLE
release: svy 0.24.1

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.24.1] — 2026-08-11
+
 ### Fixed
 
 - **Value labels survive being written.** Reading back what `apply_labels` had just stored raised `AttributeError: 'int' object has no attribute 'code'` ([#127](https://github.com/samplics-org/svy/pull/127)):
@@ -412,7 +414,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.24.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.24.1...HEAD
+[0.24.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.1
 [0.24.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.0
 [0.23.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.23.0
 [0.22.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.22.1

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.24.0"
+version = "0.24.1"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -129,7 +129,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.24.0"
+__version__ = "0.24.1"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.24.0"
+version = "0.24.1"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Patch release for the value-label clone fix in #127.

`apply_labels` stored the authoring dict verbatim on msgspec < 0.21, so reading the labels back raised `AttributeError: 'int' object has no attribute 'code'` — the whole documented path for labelling a variable, including the wrangling tutorial. Cloning now goes through the constructor, and the msgspec floor moves to `>=0.21.0`, the first release where `structs.replace` runs `__post_init__`.

The floor raise is why this is not a pure patch in dependency terms. 0.19 and 0.20 were never a working configuration for any code path that clones metadata, and every lockfile in the repo already resolved 0.21.1, so it only rules out an installation that was never tested.

## Contents

- `packages/svy/pyproject.toml` and `src/svy/__init__.py`: 0.24.0 → 0.24.1
- `packages/svy/CHANGELOG.md`: `[Unreleased]` promoted to `[0.24.1] — 2026-08-11`, footer compare links updated
- `uv.lock` re-resolved

No source changes — #127 is already on main.

svy-rs and svy-io have no commits since `svy-rs-v0.14.0` / `svy-io-v0.2.0` and are not re-released, so `svy-v0.24.1` can be tagged on its own.

## Verification

- `make test-svy` — 2939 passed, 1 skipped
- `make lint-svy` — clean
- `make build-svy` — sdist and wheel build as 0.24.1

`make lint-svy-io` and `make fmt` fail identically on `main` (11 lint errors in `packages/svy-io/tests`, 25 files with format drift). Both are pre-existing and untouched here; CI runs only `make test-svy`.