### PR TITLE
fix(svy-io): write_dta was dropping value labels

### DIFF
--- a/packages/svy-io/CHANGELOG.md
+++ b/packages/svy-io/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to **svy-io**, high-speed reading and writing of survey file
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Fixed
+
+- **`write_dta` silently dropped value labels ([#129](https://github.com/samplics-org/svy/issues/129)).** The native writer accepted `value_labels_json` and never read it, so a `.dta` was written with its variable labels intact and its value labels gone — no error, and the loss only visible on read-back. The Stata writer now emits a label set per labelled column and points the variable at it, verified against `pandas.io.stata` for formats 113 through 119. The set is named after the column (Stata's own `label values v106 v106` convention) rather than the SAV writer's `{col}_labels`, because dta 113–117 allow only 33 bytes for the name and ReadStat truncates a longer one without complaint.
+- **`write_dta` value-label validation.** Codes are now rejected when they fall outside `[-2147483647, 2147483620]` (Stata stores a code as int32 and reserves the top of that range for `.` through `.z`, so a wider code was truncated silently), when they name a column absent from the frame, and when they target a string column (Stata has no string value labels, unlike SPSS). `bool` and whole-`float` codes are canonicalized to plain integers, so `{True: "yes"}` writes code `1` instead of failing at the JSON boundary.
+
 ## [0.2.0] — 2026-07-23
 
 ### Changed

--- a/packages/svy-io/native/svyreadstat_rs/src/stata_write.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/stata_write.rs
@@ -23,13 +23,14 @@ use arrow::ipc::reader::{FileReader, StreamReader};
 use arrow::record_batch::RecordBatch;
 
 use readstat_sys::{
-    readstat_add_variable, readstat_begin_row, readstat_begin_writing_dta, readstat_end_row,
-    readstat_end_writing, readstat_insert_double_value, readstat_insert_missing_value,
-    readstat_insert_string_value, readstat_set_data_writer,
+    readstat_add_label_set, readstat_add_variable, readstat_begin_row, readstat_begin_writing_dta,
+    readstat_end_row, readstat_end_writing, readstat_insert_double_value,
+    readstat_insert_missing_value, readstat_insert_string_value, readstat_label_double_value,
+    readstat_label_set_t, readstat_set_data_writer,
     readstat_type_e_READSTAT_TYPE_DOUBLE as T_DOUBLE,
     readstat_type_e_READSTAT_TYPE_STRING as T_STRING, readstat_variable_set_label,
-    readstat_variable_t, readstat_writer_init, readstat_writer_set_file_format_version,
-    readstat_writer_set_file_label,
+    readstat_variable_set_label_set, readstat_variable_t, readstat_writer_init,
+    readstat_writer_set_file_format_version, readstat_writer_set_file_label,
 };
 
 use crate::core::WriterGuard;
@@ -191,6 +192,7 @@ fn write_stata_minimal(
     version_internal: i32,
     strl_threshold: i32,
     var_labels: Option<&HashMap<String, String>>,
+    value_labels: Option<&HashMap<String, HashMap<String, String>>>,
 ) -> Result<()> {
     if batches.is_empty() {
         let _ = File::create(out_path)?;
@@ -229,6 +231,7 @@ fn write_stata_minimal(
 
     let mut rvars: Vec<*const readstat_variable_t> = Vec::with_capacity(ncols);
     let mut _keep_names: Vec<CString> = Vec::with_capacity(ncols);
+    let mut _keep_label_sets: Vec<(*const readstat_label_set_t, Vec<CString>)> = Vec::new();
 
     // Define variables
     for (j, field) in schema.fields().iter().enumerate() {
@@ -286,6 +289,70 @@ fn write_stata_minimal(
             }
         }
 
+        // Value labels. Stata attaches a *named* label set to a variable, so
+        // the set is named after the column, matching Stata's own
+        // `label values v106 v106` convention. Do not decorate the name (the
+        // SAV writer uses "{col}_labels"): dta 113-117 give the name 33 bytes,
+        // and a longer one is truncated by ReadStat without an error.
+        if let Some(map) = value_labels
+            && let Some(labels) = map.get(field.name())
+            && !labels.is_empty()
+        {
+            if is_str_col[j] {
+                return Err(anyhow!(
+                    "column '{}' holds strings; Stata value labels apply only to \
+                     numeric variables",
+                    field.name()
+                ));
+            }
+
+            // Sorted so the emitted table is byte-stable across runs.
+            // ReadStat re-sorts by value for dta >= 117 but not below.
+            let mut entries: Vec<(f64, &str)> = Vec::with_capacity(labels.len());
+            for (value, label) in labels {
+                let code: f64 = value.parse().map_err(|_| {
+                    anyhow!(
+                        "value label code {:?} on column '{}' is not numeric",
+                        value,
+                        field.name()
+                    )
+                })?;
+                entries.push((code, label.as_str()));
+            }
+            entries.sort_by(|a, b| a.0.total_cmp(&b.0));
+
+            let c_set_name = CString::new(field.name().as_str())?;
+            let label_set =
+                unsafe { readstat_add_label_set(writer, T_DOUBLE, c_set_name.as_ptr()) };
+            if label_set.is_null() {
+                return Err(anyhow!(
+                    "readstat_add_label_set failed for '{}'",
+                    field.name()
+                ));
+            }
+
+            let mut c_labels = Vec::with_capacity(entries.len());
+            for (code, label) in entries {
+                let c_label = CString::new(label).map_err(|_| {
+                    anyhow!(
+                        "value label {:?} on column '{}' contains an embedded NUL",
+                        label,
+                        field.name()
+                    )
+                })?;
+                unsafe {
+                    readstat_label_double_value(label_set, code, c_label.as_ptr());
+                }
+                c_labels.push(c_label);
+            }
+
+            unsafe {
+                readstat_variable_set_label_set(var, label_set);
+            }
+            c_labels.push(c_set_name);
+            _keep_label_sets.push((label_set, c_labels));
+        }
+
         _keep_names.push(cname);
         rvars.push(var);
     }
@@ -296,11 +363,8 @@ fn write_stata_minimal(
         .try_into()
         .map_err(|_| anyhow!("row count {total_rows} exceeds platform limit"))?;
     unsafe {
-        let rc = readstat_begin_writing_dta(
-            writer,
-            &mut outfile as *mut File as *mut c_void,
-            row_count,
-        );
+        let rc =
+            readstat_begin_writing_dta(writer, &mut outfile as *mut File as *mut c_void, row_count);
         if rc != 0 {
             return Err(anyhow!("readstat_begin_writing_dta failed with rc={}", rc));
         }
@@ -400,7 +464,7 @@ fn write_stata_minimal(
     version,
     file_label=None,
     var_labels_json=None,
-    _value_labels_json=None,
+    value_labels_json=None,
     strl_threshold=2045,
     _user_missing_json=None
 ))]
@@ -410,7 +474,7 @@ pub fn df_write_dta_file(
     version: i32,
     file_label: Option<&str>,
     var_labels_json: Option<&str>,
-    _value_labels_json: Option<&str>,
+    value_labels_json: Option<&str>,
     strl_threshold: i32,
     _user_missing_json: Option<&str>,
 ) -> PyResult<()> {
@@ -431,6 +495,19 @@ pub fn df_write_dta_file(
         None
     };
 
+    // JSON object keys are always strings, so integer codes arrive as e.g.
+    // {"v106": {"0": "None"}} and are parsed back to f64 by the writer.
+    let value_labels: Option<HashMap<String, HashMap<String, String>>> =
+        if let Some(js) = value_labels_json {
+            Some(serde_json::from_str(js).map_err(|e| {
+                pyo3::exceptions::PyValueError::new_err(format!(
+                    "value_labels_json must be a JSON object of {{col: {{code: label}}}}: {e}"
+                ))
+            })?)
+        } else {
+            None
+        };
+
     write_stata_minimal(
         &batches,
         out_path,
@@ -438,6 +515,7 @@ pub fn df_write_dta_file(
         version,
         strl_threshold,
         var_labels.as_ref(),
+        value_labels.as_ref(),
     )
     .map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(format!("df_write_dta_file: {}", e)))
 }

--- a/packages/svy-io/python/svy_io/stata.py
+++ b/packages/svy-io/python/svy_io/stata.py
@@ -24,6 +24,12 @@ from .tagged_na import TaggedNA
 
 _STATA_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
+# Stata holds a value-label code in an int32 and reserves 0x7FFFFFE5 upward for
+# the missing values (. and .a through .z), so the usable span stops just short
+# of int32 max.
+_DTA_CODE_MIN = -2147483647
+_DTA_CODE_MAX = 2147483620
+
 
 def _hydrate_tagged_na(df: pl.DataFrame, meta: Dict[str, Any]) -> pl.DataFrame:
     """
@@ -292,7 +298,30 @@ def _validate_dta_names_and_labels(
 
     # Validate value labels
     if value_labels:
+        # A label set is written per column, so a key naming a column that is
+        # not in the frame would be dropped without a trace.
+        unknown = [v for v in value_labels if v not in df.columns]
+        if unknown:
+            raise ValueError(
+                "Value labels name columns that are not in the DataFrame: "
+                f"{sorted(unknown)}. Available columns: {df.columns}"
+            )
+
+        # Stata attaches label sets to numeric variables only; there is no
+        # string equivalent (unlike SPSS, where write_sav accepts both).
+        string_cols = [
+            v
+            for v, mp in value_labels.items()
+            if mp and df.schema[v] in (pl.String, pl.Categorical, pl.Enum)
+        ]
+        if string_cols:
+            raise ValueError(
+                "Stata value labels apply only to numeric variables; these columns hold "
+                f"strings: {sorted(string_cols)}"
+            )
+
         offenders: dict[str, list] = {}
+        out_of_range: dict[str, list] = {}
         for var, mp in value_labels.items():
             bad_keys = [
                 k
@@ -305,9 +334,27 @@ def _validate_dta_names_and_labels(
             if bad_keys:
                 offenders[var] = bad_keys
 
+            # Stata stores a value-label code as int32 and reserves the top of
+            # that range for the missing values (. through .z, from
+            # 0x7FFFFFE5 up). A code outside the usable span is silently
+            # truncated by the writer, so reject it here.
+            wide = [
+                k
+                for k in mp.keys()
+                if k not in bad_keys and not (_DTA_CODE_MIN <= int(k) <= _DTA_CODE_MAX)
+            ]
+            if wide:
+                out_of_range[var] = wide
+
         if offenders:
             raise ValueError(
                 "Value labels must use integer codes; offending keys: " + str(offenders)
+            )
+        if out_of_range:
+            raise ValueError(
+                f"Value label codes must be within [{_DTA_CODE_MIN}, {_DTA_CODE_MAX}] "
+                "(Stata stores them as int32 and reserves the top of the range for "
+                f"missing values); offending keys: {out_of_range}"
             )
 
 
@@ -395,8 +442,7 @@ def _adjust_temporals(df: pl.DataFrame, *, adjust_tz: bool) -> pl.DataFrame:
             import warnings
 
             warnings.warn(
-                f"Could not adjust timezone for column {name!r}; "
-                f"writing it unchanged ({ex}).",
+                f"Could not adjust timezone for column {name!r}; writing it unchanged ({ex}).",
                 UserWarning,
                 stacklevel=2,
             )
@@ -526,7 +572,15 @@ def write_dta(
 
     ipc_bytes = _df_to_ipc_bytes(df_w)
     var_labels_json = json.dumps(var_labels) if var_labels else None
-    value_labels_json = json.dumps(value_labels) if value_labels else None
+    # Codes are validated as integers above, but may arrive as bool or whole
+    # float; canonicalize so json.dumps emits "1" rather than "true"/"1.0".
+    value_labels_json = (
+        json.dumps(
+            {v: {str(int(k)): lbl for k, lbl in mp.items()} for v, mp in value_labels.items()}
+        )
+        if value_labels
+        else None
+    )
     user_missing_json = json.dumps(user_missing_specs) if user_missing_specs else None
 
     if not hasattr(native, "df_write_dta_file"):

--- a/packages/svy-io/tests/test_stata.py
+++ b/packages/svy-io/tests/test_stata.py
@@ -311,7 +311,6 @@ def test_labels_are_preserved(tmp_path):
     assert actual_labels == var_labels
 
 
-@pytest.mark.xfail(reason="Value labels on write not implemented yet")
 def test_labelleds_are_round_tripped(tmp_path):
     """Value labels (integer -> string mappings) should survive roundtrip"""
     if not HAVE_READ_DTA or not HAVE_WRITE_DTA:
@@ -320,7 +319,6 @@ def test_labelleds_are_round_tripped(tmp_path):
     df = pl.DataFrame({"status": [1, 2, 3, 1, 2]})
     value_labels = {"status": {1: "Active", 2: "Inactive", 3: "Pending"}}
 
-    # This should work once value_labels_json is implemented in the writer
     df2, meta, _ = _roundtrip(tmp_path, df, version=118, value_labels=value_labels)
 
     # Check that value labels are in meta
@@ -331,6 +329,90 @@ def test_labelleds_are_round_tripped(tmp_path):
             break
 
     assert status_labels == {"1": "Active", "2": "Inactive", "3": "Pending"}
+    # The variable must point at the set, or Stata shows bare codes.
+    assert {v["name"]: v["label_set"] for v in meta["vars"]} == {"status": "status"}
+
+
+@pytest.mark.parametrize("version", [113, 114, 115, 117, 118, 119])
+def test_value_labels_round_trip_on_every_supported_format(tmp_path, version):
+    """The label-set name field is 33 bytes below format 118 and 129 at/above."""
+    if not HAVE_READ_DTA or not HAVE_WRITE_DTA:
+        pytest.xfail("stub pending")
+
+    df = pl.DataFrame({"v106": [0, 1, 2, 3], "sex": [1, 2, 1, 2]})
+    value_labels = {
+        "v106": {0: "None", 1: "Primary", 2: "Secondary", 3: "Higher"},
+        "sex": {1: "Male", 2: "Female"},
+    }
+    out = tmp_path / f"vl{version}.dta"
+    _write_dta(df, out, version=version, value_labels=value_labels)
+    _df2, meta = _read_dta(str(out))
+
+    assert {vl["set_name"]: vl["mapping"] for vl in meta["value_labels"]} == {
+        "v106": {"0": "None", "1": "Primary", "2": "Secondary", "3": "Higher"},
+        "sex": {"1": "Male", "2": "Female"},
+    }
+
+
+def test_value_labels_survive_alongside_var_labels(tmp_path):
+    """Regression for #129: var labels were written, value labels dropped."""
+    if not HAVE_READ_DTA or not HAVE_WRITE_DTA:
+        pytest.xfail("stub pending")
+
+    df = pl.DataFrame({"v106": [0, 1, 2, 3]})
+    df2, meta, _ = _roundtrip(
+        tmp_path,
+        df,
+        version=118,
+        var_labels={"v106": "Educ"},
+        value_labels={"v106": {0: "None", 1: "Primary"}},
+    )
+
+    assert meta["vars"][0]["label"] == "Educ"
+    assert meta["value_labels"] == [{"set_name": "v106", "mapping": {"0": "None", "1": "Primary"}}]
+
+
+@pytest.mark.parametrize(
+    "codes,expected",
+    [
+        # bool and whole-float codes canonicalize to plain integers
+        ({True: "yes", False: "no"}, {"0": "no", "1": "yes"}),
+        ({2.0: "two"}, {"2": "two"}),
+        ({-9: "missing", 0: "none"}, {"-9": "missing", "0": "none"}),
+        # the widest codes Stata's int32 storage leaves usable
+        ({2147483620: "max", -2147483647: "min"}, {"2147483620": "max", "-2147483647": "min"}),
+    ],
+)
+def test_value_label_codes_are_canonicalized(tmp_path, codes, expected):
+    if not HAVE_READ_DTA or not HAVE_WRITE_DTA:
+        pytest.xfail("stub pending")
+
+    df = pl.DataFrame({"v106": [0, 1, 2, 3]})
+    _df2, meta, _ = _roundtrip(tmp_path, df, version=118, value_labels={"v106": codes})
+
+    assert meta["value_labels"] == [{"set_name": "v106", "mapping": expected}]
+
+
+def test_cant_label_a_column_that_is_absent(tmp_path):
+    """A typo'd column key would otherwise drop its labels silently."""
+    df = pl.DataFrame({"v106": [0, 1, 2, 3]})
+    with pytest.raises(ValueError, match="not in the DataFrame"):
+        _write_dta(df, tmp_path / "x.dta", version=118, value_labels={"nope": {1: "a"}})
+
+
+def test_cant_label_a_string_column(tmp_path):
+    """Stata has no string value labels; SPSS does, so this must not be assumed."""
+    df = pl.DataFrame({"name": ["a", "b"]})
+    with pytest.raises(ValueError, match="only to numeric variables"):
+        _write_dta(df, tmp_path / "x.dta", version=118, value_labels={"name": {1: "a"}})
+
+
+@pytest.mark.parametrize("code", [2147483621, -2147483648])
+def test_cant_write_value_label_codes_outside_int32_span(tmp_path, code):
+    """Stata stores the code as int32 and reserves the top for missing values."""
+    df = pl.DataFrame({"v106": [0, 1, 2, 3]})
+    with pytest.raises(ValueError, match="must be within"):
+        _write_dta(df, tmp_path / "x.dta", version=118, value_labels={"v106": {code: "a"}})
 
 
 def test_can_write_labelled_with_null_labels(tmp_path):


### PR DESCRIPTION
Closes #129.

## Root cause

The native writer accepted `value_labels_json` and never read it. The parameter was named `_value_labels_json` (leading underscore to silence the unused warning) and `write_stata_minimal` had no `value_labels` parameter at all, so `readstat_add_label_set` was never called for `.dta`.

A file was written with its variable labels intact and its value labels gone — no error, and the loss only visible on read-back. The Python plumbing was correct the whole way down, which is why the issue's `.sav` control worked: the SPSS writer has its own, working implementation.

## Fix

The Stata writer now emits a label set per labelled column and points the variable at it.

The set is named **exactly the column name**, not the SAV writer's `{col}_labels`. It matches Stata's own `label values v106 v106` convention, and dta 113–117 allow only 33 bytes for the name (`readstat_dta.c:98`) — a decorated name would be truncated by ReadStat without an error for columns over 24 chars, reintroducing the same class of silent loss. Entries are sorted by code so the emitted table is byte-stable; ReadStat re-sorts for dta ≥ 117 but not below.

## Validation

Three checks close the remaining silent-loss paths:

- **Codes outside `[-2147483647, 2147483620]`.** ReadStat stores the code as `int32_t` (`readstat_dta_write.c:795`) and Stata reserves `0x7FFFFFE5` upward for `.` through `.z`, so a wider code was truncated silently even though it passed the existing "must be an integer" check.
- **Labels naming a column absent from the frame** — a typo'd key was the same failure mode this issue reports.
- **Labels on a string column** — Stata has no string value labels, unlike SPSS.

`bool` and whole-`float` codes are canonicalized to plain integers, since `json.dumps({True: "yes"})` would otherwise emit `"true"` as the key.

All raise `ValueError`, consistent with the rest of `svy_io`. `svy-io` cannot use `svy.errors` — `svy` depends on `svy-io`, so importing them would be circular.

## Verification

The issue's reproducer now round-trips:

```
meta['value_labels']         -> [{'set_name': 'v106', 'mapping': {'0': 'None', '1': 'Primary'}}]
meta['vars'][0]['label_set'] -> 'v106'
b'Primary' in file           -> True
```

- All six supported formats (113–119) round-trip both the labels and the variable→set link.
- **Cross-checked with `pandas.io.stata`**, so the files are valid Stata rather than merely readable by our own reader — `read_stata(convert_categoricals=True)` yields `['None', 'Primary', 'Secondary', 'Higher']`.
- Full suite: **189 passed, 0 failed**. The 3 XPASSes are pre-existing in `test_labelled.py` / `test_sas.py` / `test_zap.py` and unrelated.
- Zero new clippy warnings — the new block uses let-chains so the count stays flat.

## Tests

Removed the now-stale `@pytest.mark.xfail("Value labels on write not implemented yet")` from `test_labelleds_are_round_tripped` so it guards the fix, and added parametrized coverage for the format matrix, code canonicalization, and all three error paths. No existing assertion was changed.

## Notes for review

- **Pre-existing lint debt left alone.** `cargo fmt`, `ruff format`, and `cargo clippy -- -D warnings` all fail on `main` today (28 clippy errors on `svyreadstat_rs`). Formatting was applied only to files this fix already edits; the rest was reverted to keep the diff surgical. `make lint` and `make format-check` will still be red for reasons that predate this change.
- **`_user_missing_json` is still ignored** by the same function in the same way, so Stata tagged missings (`.a`–`.z`) are also dropped on write. That is a genuinely unimplemented feature with its own xfail at `test_stata.py:264`, not a silent regression, so it is out of scope here.
- The `write_dta` / `write_sav` signature asymmetry the issue flags as "possibly contributing" is not the cause, and unifying it would be a breaking API change — also left out of scope.