### PR TITLE
feat(io): resolve measurement type on import so labelled variables are categorical

### DIFF
--- a/packages/svy-io/CHANGELOG.md
+++ b/packages/svy-io/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to **svy-io**, high-speed reading and writing of survey file
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Added
+
+- **Readers surface the declared measurement level ([#130](https://github.com/samplics-org/svy/issues/130)).** Each entry in `meta["vars"]` now carries `measure` — `"nominal"`, `"ordinal"`, or `"scale"` — read from ReadStat's `readstat_variable_get_measure`. A format that carries no such attribute (Stata) or a variable whose writer never set one reports `None` rather than `"scale"`, so a caller can tell "declared continuous" from "never declared". Worth knowing before relying on it: SPSS defaults numeric variables to `"scale"` whether or not anyone meant it, so only `"nominal"` and `"ordinal"` are positive declarations.
+
 ## [0.2.0] — 2026-07-23
 
 ### Changed

--- a/packages/svy-io/native/svyreadstat_rs/src/core.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/core.rs
@@ -11,15 +11,19 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::sync::Arc;
 
 use readstat_sys::{
-    readstat_double_value, readstat_get_file_label, readstat_get_row_count, readstat_metadata_t,
+    readstat_double_value, readstat_get_file_label, readstat_get_row_count,
+    readstat_measure_e_READSTAT_MEASURE_NOMINAL as MEASURE_NOMINAL,
+    readstat_measure_e_READSTAT_MEASURE_ORDINAL as MEASURE_ORDINAL,
+    readstat_measure_e_READSTAT_MEASURE_SCALE as MEASURE_SCALE, readstat_metadata_t,
     readstat_string_value, readstat_type_class_e_READSTAT_TYPE_CLASS_STRING as TCLASS_STRING,
     readstat_type_e_READSTAT_TYPE_STRING as T_STRING,
     readstat_type_e_READSTAT_TYPE_STRING_REF as T_STRING_REF, readstat_value_is_system_missing,
     readstat_value_is_tagged_missing, readstat_value_t, readstat_value_tag,
     readstat_value_type as rs_value_type, readstat_variable_get_format,
-    readstat_variable_get_label, readstat_variable_get_missing_range_hi,
-    readstat_variable_get_missing_range_lo, readstat_variable_get_missing_ranges_count,
-    readstat_variable_get_name, readstat_variable_get_type_class, readstat_variable_t,
+    readstat_variable_get_label, readstat_variable_get_measure,
+    readstat_variable_get_missing_range_hi, readstat_variable_get_missing_range_lo,
+    readstat_variable_get_missing_ranges_count, readstat_variable_get_name,
+    readstat_variable_get_type_class, readstat_variable_t,
 };
 
 pub(crate) const HANDLER_OK: c_int = 0;
@@ -88,6 +92,12 @@ pub struct VarMeta {
     pub label_set: Option<String>,
     pub fmt: Option<String>,
     pub kind: String,
+    /// The measurement level the file declares: "nominal", "ordinal", or
+    /// "scale". `None` when the format carries no such attribute (Stata) or
+    /// the writer never set one. Note that SPSS defaults numeric variables to
+    /// "scale", so only "nominal"/"ordinal" are positive declarations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub measure: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub user_missing: Option<UserMissing>,
 }
@@ -134,6 +144,7 @@ pub(crate) struct ColBuilders {
     pub(crate) label: Option<String>,
     pub(crate) label_set: Option<String>,
     pub(crate) fmt: Option<String>,
+    pub(crate) measure: Option<String>,
     pub(crate) user_missing: Option<UserMissing>,
     pub(crate) sb: Option<StringBuilder>,
     pub(crate) fb: Option<Float64Builder>,
@@ -351,6 +362,7 @@ unsafe fn on_variable_impl(
                 label: None,
                 label_set: None,
                 fmt: None,
+                measure: None,
                 user_missing: None,
                 sb: Some(StringBuilder::with_capacity(
                     cap,
@@ -392,6 +404,16 @@ unsafe fn on_variable_impl(
                 Some(st.to_string())
             }
         }
+    };
+
+    // The measurement level the file declares. SPSS carries this; Stata has
+    // no equivalent and always reports UNKNOWN, which we surface as None so a
+    // caller can tell "not declared" from "declared as scale".
+    let measure = match readstat_variable_get_measure(var) {
+        m if m == MEASURE_NOMINAL => Some("nominal".to_string()),
+        m if m == MEASURE_ORDINAL => Some("ordinal".to_string()),
+        m if m == MEASURE_SCALE => Some("scale".to_string()),
+        _ => None,
     };
 
     let kind = if readstat_variable_get_type_class(var) == TCLASS_STRING {
@@ -458,6 +480,7 @@ unsafe fn on_variable_impl(
             label,
             label_set,
             fmt,
+            measure,
             user_missing,
             sb: Some(StringBuilder::with_capacity(
                 cap,
@@ -471,6 +494,7 @@ unsafe fn on_variable_impl(
             label,
             label_set,
             fmt,
+            measure,
             user_missing,
             sb: None,
             fb: Some(Float64Builder::with_capacity(cap)),
@@ -697,6 +721,7 @@ pub(crate) fn finalize_to_ipc(mut ctx: ParseCtx) -> Result<(Vec<u8>, MetaOut)> {
                     label_set: col.label_set,
                     fmt: col.fmt,
                     kind: "string".into(),
+                    measure: col.measure,
                     user_missing: col.user_missing,
                 });
             }
@@ -719,6 +744,7 @@ pub(crate) fn finalize_to_ipc(mut ctx: ParseCtx) -> Result<(Vec<u8>, MetaOut)> {
                     label_set: col.label_set,
                     fmt: col.fmt,
                     kind: "double".into(),
+                    measure: col.measure,
                     user_missing: col.user_missing,
                 });
             }

--- a/packages/svy-io/tests/test_spss.py
+++ b/packages/svy-io/tests/test_spss.py
@@ -67,6 +67,25 @@ def test_variable_label_stored_as_metadata(test_data_dir):
     assert labels.get("sex") == "Gender"
 
 
+def test_declared_measure_is_surfaced(test_data_dir):
+    """SPSS carries a nominal/ordinal/scale measurement level; expose it."""
+    _df, meta = read_sav(test_data_dir / "spss/variable-label.sav")
+    measures = {v["name"]: v.get("measure") for v in meta["vars"]}
+
+    assert measures == {"sex": "nominal"}
+
+
+def test_undeclared_measure_is_absent_rather_than_scale(test_data_dir):
+    """
+    A file that never set a measurement level must read back as None, not as
+    "scale". SPSS defaults numeric variables to scale, so a caller has to be
+    able to tell "declared continuous" from "never declared".
+    """
+    _df, meta = read_sav(test_data_dir / "spss/labelled-num.sav")
+
+    assert meta["vars"][0].get("measure") is None
+
+
 def test_value_labels_stored_in_metadata(test_data_dir):
     """Value labels should be preserved in metadata"""
     df_num, meta_num = read_sav(test_data_dir / "spss/labelled-num.sav")

--- a/packages/svy-io/tests/test_stata.py
+++ b/packages/svy-io/tests/test_stata.py
@@ -295,6 +295,19 @@ def test_factors_become_labelleds_on_write(tmp_path):
     assert df2.schema["category"] == pl.Float64  # Stata reads as numeric
 
 
+def test_stata_has_no_declared_measure(tmp_path):
+    """
+    dta carries no measurement-level attribute, so `measure` must be absent
+    rather than guessed. Consumers fall back to other signals for Stata.
+    """
+    if not HAVE_READ_DTA:
+        pytest.xfail("stub pending")
+
+    _df, meta = _read_dta(tpath("types.dta"))
+
+    assert all(v.get("measure") is None for v in meta["vars"])
+
+
 def test_labels_are_preserved(tmp_path):
     """Variable labels should survive roundtrip"""
     if not HAVE_READ_DTA or not HAVE_WRITE_DTA:

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -15,7 +15,7 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Changed
 
-- `import_labels_from_svyio_meta` takes an optional third argument, the frame the metadata describes. Without it the function only imports labels, exactly as before, so existing callers are unaffected.
+- **`import_labels_from_svyio_meta` now requires the frame** the metadata describes as its third argument. Resolving a measurement type depends on how well the value labels cover the observed values, which cannot be judged without the data. It is required rather than optional on purpose: an omitted frame would silently fall back to the very behavior this release fixes. The function is internal (`svy.engine.io`, not exported from the top-level `svy` namespace) and had a single production call site.
 
 ## [0.24.1] — 2026-08-11
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,15 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Fixed
+
+- **Labelled variables were never `is_categorical` ([#130](https://github.com/samplics-org/svy/issues/130)).** `Sample(data=df)` infers `mtype` from the polars dtype, and `import_labels_from_svyio_meta` brought across labels while leaving that untouched — so every labelled variable in a survey recode stayed `Numerical Continuous` and `is_categorical` was `False`. Deriving a codebook from it classified an entire DHS-style file as continuous. The importer now revises `mtype` on import: it honours a measurement level the file declares, and otherwise asks whether the value labels cover every observed value. On a Stata census file this takes 16 labelled variables from 0 categorical to 16.
+- **Measurement type is inferred from label coverage, not label presence.** "Has labels" alone would misread a continuous variable that labels only a sentinel code — a "how many TVs?" count labelling just `0 = none` and `4 = 4 or more` is not a five-level factor. A variable becomes `NOMINAL` only when every observed non-null value carries a label; partial coverage, an all-null column, and a column absent from the frame all leave `mtype` alone, as does a type the user set by hand. `ORDINAL` is assigned only when the file says so, since coverage cannot distinguish it from `NOMINAL`.
+
+### Changed
+
+- `import_labels_from_svyio_meta` takes an optional third argument, the frame the metadata describes. Without it the function only imports labels, exactly as before, so existing callers are unaffected.
+
 ## [0.24.1] — 2026-08-11
 
 ### Fixed

--- a/packages/svy/src/svy/engine/io/core.py
+++ b/packages/svy/src/svy/engine/io/core.py
@@ -129,7 +129,7 @@ def _labels_cover_all_observed(series: pl.Series, codes: set[str]) -> bool:
 def _resolve_mtype(
     measure: str | None,
     value_labels: dict[Category, str],
-    series: pl.Series | None,
+    series: pl.Series,
 ) -> MeasurementType | None:
     """
     Decide the measurement type a file implies, or None to keep what the
@@ -144,7 +144,7 @@ def _resolve_mtype(
     if measure == "nominal":
         return MeasurementType.NOMINAL
 
-    if not value_labels or series is None:
+    if not value_labels:
         return None
 
     codes = {_canonical_code(c) for c in value_labels}
@@ -157,7 +157,7 @@ def _mtype_for(
     var: str,
     measure: str | None,
     values: dict[Category, str],
-    df: pl.DataFrame | None,
+    df: pl.DataFrame,
     store: MetadataStore,
 ) -> MeasurementType | None:
     """
@@ -166,7 +166,7 @@ def _mtype_for(
     A type the user set by hand outranks anything the file claims, so those are
     left untouched.
     """
-    if df is None or var not in df.columns:
+    if var not in df.columns:
         return None
     existing = store.get(var)
     if existing is not None and existing.source == MetadataSource.USER:
@@ -177,7 +177,7 @@ def _mtype_for(
 def import_labels_from_svyio_meta(
     store: MetadataStore,
     meta: Dict[str, Any],
-    df: pl.DataFrame | None = None,
+    df: pl.DataFrame,
 ) -> None:
     """
     Import variable and value labels from svy-io metadata into a MetadataStore.
@@ -195,10 +195,10 @@ def import_labels_from_svyio_meta(
         The metadata store to populate.
     meta : dict
         The metadata dict from svy-io.
-    df : pl.DataFrame, optional
-        The frame the metadata describes. When given, the measurement type is
-        revised to match what the file declares (or what its value labels
-        imply); without it only labels are imported, as before.
+    df : pl.DataFrame
+        The frame the metadata describes. Required: the measurement type is
+        resolved partly from how well the value labels cover the observed
+        values, which cannot be judged without the data.
     """
     # New/normalized form (A)
     variables = meta.get("variables")

--- a/packages/svy/src/svy/engine/io/core.py
+++ b/packages/svy/src/svy/engine/io/core.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 
 import polars as pl
 
-from svy.core.enumerations import MetadataSource
+from svy.core.enumerations import MeasurementType, MetadataSource
 from svy.core.types import Category
 from svy.metadata import MetadataStore, VariableMeta
 
@@ -75,9 +75,109 @@ def to_writer_table(df: pl.DataFrame) -> Any:
     return df.to_pandas()
 
 
+def _canonical_code(x: Any) -> str:
+    """
+    Render a value-label code and a data value into one comparable form.
+
+    Codes arrive from svy-io as strings ("1"), while the column that carries
+    them is usually Float64 (1.0), so the two never compare equal as-is. Whole
+    floats collapse to their integer spelling; everything else falls back to
+    str().
+    """
+    x = _py_scalar(x)
+    if isinstance(x, bool):
+        return str(int(x))
+    if isinstance(x, float):
+        if x != x or x in (float("inf"), float("-inf")):  # NaN / +-Inf
+            return str(x)
+        if x.is_integer():
+            return str(int(x))
+        return str(x)
+    if isinstance(x, int):
+        return str(x)
+    if isinstance(x, str):
+        # A string code may itself be a numeric spelling ("1.0" vs "1").
+        try:
+            return _canonical_code(float(x))
+        except ValueError:
+            return x
+    return str(x)
+
+
+def _labels_cover_all_observed(series: pl.Series, codes: set[str]) -> bool:
+    """
+    True when every observed non-null value in `series` carries a label.
+
+    This is what separates a real categorical from a continuous variable that
+    merely labels a few sentinel codes. A survey's "how many TVs?" labels only
+    `0 = none` and `4 = 4 or more` out of {0,1,2,3,4}, so it fails here and
+    stays continuous; a 4-category nominal labels all four and passes.
+    """
+    if not codes:
+        return False
+    try:
+        observed = series.drop_nulls().unique().to_list()
+    except Exception:
+        return False
+    if not observed:
+        # Nothing observed (all-null column): no evidence either way, and
+        # calling it categorical on an empty column would be a guess.
+        return False
+    return all(_canonical_code(v) in codes for v in observed)
+
+
+def _resolve_mtype(
+    measure: str | None,
+    value_labels: dict[Category, str],
+    series: pl.Series | None,
+) -> MeasurementType | None:
+    """
+    Decide the measurement type a file implies, or None to keep what the
+    dtype-based inference already chose.
+
+    `measure` is authoritative only when it positively says nominal or ordinal.
+    SPSS defaults every numeric variable to "scale" and Stata carries no such
+    attribute at all, so those cases fall through to the label-coverage rule.
+    """
+    if measure == "ordinal":
+        return MeasurementType.ORDINAL
+    if measure == "nominal":
+        return MeasurementType.NOMINAL
+
+    if not value_labels or series is None:
+        return None
+
+    codes = {_canonical_code(c) for c in value_labels}
+    if _labels_cover_all_observed(series, codes):
+        return MeasurementType.NOMINAL
+    return None
+
+
+def _mtype_for(
+    var: str,
+    measure: str | None,
+    values: dict[Category, str],
+    df: pl.DataFrame | None,
+    store: MetadataStore,
+) -> MeasurementType | None:
+    """
+    Measurement type to apply to `var` on import, or None to leave it alone.
+
+    A type the user set by hand outranks anything the file claims, so those are
+    left untouched.
+    """
+    if df is None or var not in df.columns:
+        return None
+    existing = store.get(var)
+    if existing is not None and existing.source == MetadataSource.USER:
+        return None
+    return _resolve_mtype(measure, values, df.get_column(var))
+
+
 def import_labels_from_svyio_meta(
     store: MetadataStore,
     meta: Dict[str, Any],
+    df: pl.DataFrame | None = None,
 ) -> None:
     """
     Import variable and value labels from svy-io metadata into a MetadataStore.
@@ -95,6 +195,10 @@ def import_labels_from_svyio_meta(
         The metadata store to populate.
     meta : dict
         The metadata dict from svy-io.
+    df : pl.DataFrame, optional
+        The frame the metadata describes. When given, the measurement type is
+        revised to match what the file declares (or what its value labels
+        imply); without it only labels are imported, as before.
     """
     # New/normalized form (A)
     variables = meta.get("variables")
@@ -102,6 +206,7 @@ def import_labels_from_svyio_meta(
         for var, vmeta in variables.items():
             var_label = vmeta.get("label") or None
             values = vmeta.get("values") or {}
+            mtype = _mtype_for(var, vmeta.get("measure"), values, df, store)
 
             existing = store.get(var)
             if existing is not None:
@@ -109,6 +214,7 @@ def import_labels_from_svyio_meta(
                 new_meta = existing.clone(
                     label=var_label if var_label else existing.label,
                     value_labels=dict(values) if values else existing.value_labels,
+                    mtype=mtype if mtype is not None else existing.mtype,
                     source=MetadataSource.IMPORTED,
                 )
                 store.set(var, new_meta)
@@ -120,6 +226,7 @@ def import_labels_from_svyio_meta(
                         name=var,
                         label=var_label,
                         value_labels=dict(values) if values else None,
+                        **({"mtype": mtype} if mtype is not None else {}),
                         source=MetadataSource.IMPORTED,
                     ),
                 )
@@ -139,6 +246,7 @@ def import_labels_from_svyio_meta(
             var_label = v.get("label") or None
             set_name = v.get("label_set")
             values = lblsets.get(set_name) or {}
+            mtype = _mtype_for(var, v.get("measure"), values, df, store)
 
             existing = store.get(var)
             if existing is not None:
@@ -146,6 +254,7 @@ def import_labels_from_svyio_meta(
                 new_meta = existing.clone(
                     label=var_label if var_label else existing.label,
                     value_labels=dict(values) if values else existing.value_labels,
+                    mtype=mtype if mtype is not None else existing.mtype,
                     source=MetadataSource.IMPORTED,
                 )
                 store.set(var, new_meta)
@@ -157,6 +266,7 @@ def import_labels_from_svyio_meta(
                         name=var,
                         label=var_label,
                         value_labels=dict(values) if values else None,
+                        **({"mtype": mtype} if mtype is not None else {}),
                         source=MetadataSource.IMPORTED,
                     ),
                 )

--- a/packages/svy/src/svy/io/base.py
+++ b/packages/svy/src/svy/io/base.py
@@ -257,7 +257,7 @@ def _create_sample_with_labels(
     sample = Sample(data=df)
 
     # Import labels from file into MetadataStore
-    import_labels_from_svyio_meta(sample.meta, raw_meta)
+    import_labels_from_svyio_meta(sample.meta, raw_meta, df)
 
     if name:
         setattr(sample, "name", name)

--- a/packages/svy/tests/svy/engine/test_io_mtype.py
+++ b/packages/svy/tests/svy/engine/test_io_mtype.py
@@ -1,0 +1,204 @@
+"""Measurement type is resolved on import, not left at the storage type.
+
+`Sample(data=df)` infers `mtype` from the polars dtype, so every numeric
+column starts out CONTINUOUS. The label importer used to bring across labels
+and leave that untouched, which made `is_categorical` False for every labelled
+variable in a survey recode (issue #130).
+
+SPSS declares a measurement level but defaults numeric variables to "scale",
+and Stata has no such attribute at all, so the declaration alone fixes
+nothing. Label coverage of the observed values carries the rest.
+"""
+
+import polars as pl
+import pytest
+
+from svy.core.enumerations import MeasurementType, MetadataSource
+from svy.engine.io.core import (
+    _canonical_code,
+    _resolve_mtype,
+    import_labels_from_svyio_meta,
+)
+from svy.metadata import MetadataStore, VariableMeta
+
+
+def _meta(name="v106", *, measure=None, mapping=None):
+    """svy-io's classic split metadata shape."""
+    var = {"name": name, "label": "Educ", "kind": "double"}
+    if measure is not None:
+        var["measure"] = measure
+    out = {"vars": [var], "value_labels": []}
+    if mapping is not None:
+        var["label_set"] = f"{name}_set"
+        out["value_labels"] = [{"set_name": f"{name}_set", "mapping": mapping}]
+    return out
+
+
+# ---- code canonicalization ------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", "1"),  # code as svy-io returns it
+        (1.0, "1"),  # the same value as the Float64 column holds it
+        ("1.0", "1"),  # a code that spells itself as a float
+        (1, "1"),
+        (True, "1"),
+        (-9.0, "-9"),
+        (1.5, "1.5"),
+        ("F", "F"),  # string codes pass through
+    ],
+)
+def test_codes_and_values_canonicalize_to_one_form(value, expected):
+    """Codes arrive as strings, columns hold floats; they must compare equal."""
+    assert _canonical_code(value) == expected
+
+
+# ---- the coverage rule ----------------------------------------------------
+
+
+def test_full_label_coverage_is_categorical():
+    series = pl.Series("x", [1.0, 2.0, 1.0, 2.0])
+    got = _resolve_mtype(None, {"1": "Urban", "2": "Rural"}, series)
+
+    assert got == MeasurementType.NOMINAL
+
+
+def test_partial_label_coverage_is_left_alone():
+    """
+    A count variable that labels only its endpoints -- "how many TVs?" with
+    0 = none and 4 = 4 or more -- is continuous, not a 5-level factor. This is
+    the case the issue warned about when rejecting "has labels -> categorical".
+    """
+    series = pl.Series("tv", [0.0, 1.0, 2.0, 3.0, 4.0])
+    got = _resolve_mtype(None, {"0": "None", "4": "4 or more"}, series)
+
+    assert got is None
+
+
+def test_nulls_do_not_count_against_coverage():
+    series = pl.Series("x", [1.0, None, 2.0, None])
+    got = _resolve_mtype(None, {"1": "Urban", "2": "Rural"}, series)
+
+    assert got == MeasurementType.NOMINAL
+
+
+def test_all_null_column_is_left_alone():
+    """No observed values means no evidence, so do not guess."""
+    series = pl.Series("x", [None, None], dtype=pl.Float64)
+
+    assert _resolve_mtype(None, {"1": "Urban"}, series) is None
+
+
+def test_labels_without_a_frame_are_not_enough():
+    assert _resolve_mtype(None, {"1": "Urban"}, None) is None
+
+
+def test_no_labels_and_no_measure_leaves_mtype_alone():
+    assert _resolve_mtype(None, {}, pl.Series("x", [1.0, 2.0])) is None
+
+
+# ---- the declared measure -------------------------------------------------
+
+
+def test_declared_nominal_wins_without_needing_labels():
+    assert _resolve_mtype("nominal", {}, None) == MeasurementType.NOMINAL
+
+
+def test_declared_ordinal_is_honored():
+    """Coverage cannot tell ordinal from nominal; only the file can."""
+    assert _resolve_mtype("ordinal", {}, None) == MeasurementType.ORDINAL
+
+
+def test_declared_scale_does_not_veto_the_coverage_rule():
+    """
+    SPSS defaults numeric variables to "scale" whether or not anyone meant it,
+    so it must not be read as a positive claim of continuity.
+    """
+    series = pl.Series("x", [1.0, 2.0])
+    got = _resolve_mtype("scale", {"1": "Urban", "2": "Rural"}, series)
+
+    assert got == MeasurementType.NOMINAL
+
+
+# ---- the importer end to end ----------------------------------------------
+
+
+def test_import_sets_categorical_for_a_fully_labelled_column():
+    store = MetadataStore()
+    df = pl.DataFrame({"v106": [0.0, 1.0, 2.0, 3.0]})
+    mapping = {"0": "None", "1": "Primary", "2": "Secondary", "3": "Higher"}
+
+    import_labels_from_svyio_meta(store, _meta(mapping=mapping), df)
+
+    got = store.get("v106")
+    assert got.has_labels
+    assert got.mtype == MeasurementType.NOMINAL
+    assert got.is_categorical
+
+
+def test_import_without_a_frame_still_only_imports_labels():
+    """The df parameter is optional; older callers must behave as before."""
+    store = MetadataStore()
+    store.set("v106", VariableMeta(name="v106", mtype=MeasurementType.CONTINUOUS))
+
+    import_labels_from_svyio_meta(store, _meta(mapping={"0": "None"}))
+
+    got = store.get("v106")
+    assert got.has_labels
+    assert got.mtype == MeasurementType.CONTINUOUS
+
+
+def test_import_does_not_override_a_user_set_mtype():
+    store = MetadataStore()
+    store.set(
+        "v106",
+        VariableMeta(
+            name="v106",
+            mtype=MeasurementType.CONTINUOUS,
+            source=MetadataSource.USER,
+        ),
+    )
+    df = pl.DataFrame({"v106": [0.0, 1.0]})
+
+    import_labels_from_svyio_meta(store, _meta(mapping={"0": "No", "1": "Yes"}), df)
+
+    assert store.get("v106").mtype == MeasurementType.CONTINUOUS
+
+
+def test_import_leaves_a_partially_labelled_column_continuous():
+    store = MetadataStore()
+    store.set("tv", VariableMeta(name="tv", mtype=MeasurementType.CONTINUOUS))
+    df = pl.DataFrame({"tv": [0.0, 1.0, 2.0, 3.0, 4.0]})
+    mapping = {"0": "None", "4": "4 or more"}
+
+    import_labels_from_svyio_meta(store, _meta("tv", mapping=mapping), df)
+
+    got = store.get("tv")
+    assert got.has_labels
+    assert not got.is_categorical
+
+
+def test_import_handles_the_variables_metadata_shape():
+    """The other shape the importer accepts must resolve mtype too."""
+    store = MetadataStore()
+    df = pl.DataFrame({"v106": [1.0, 2.0]})
+    meta = {
+        "variables": {
+            "v106": {"label": "Educ", "values": {"1": "Yes", "2": "No"}},
+        }
+    }
+
+    import_labels_from_svyio_meta(store, meta, df)
+
+    assert store.get("v106").mtype == MeasurementType.NOMINAL
+
+
+def test_import_ignores_labels_for_a_column_not_in_the_frame():
+    store = MetadataStore()
+    df = pl.DataFrame({"other": [1.0]})
+
+    import_labels_from_svyio_meta(store, _meta(mapping={"1": "Yes"}), df)
+
+    assert store.get("v106").mtype != MeasurementType.NOMINAL

--- a/packages/svy/tests/svy/engine/test_io_mtype.py
+++ b/packages/svy/tests/svy/engine/test_io_mtype.py
@@ -91,10 +91,6 @@ def test_all_null_column_is_left_alone():
     assert _resolve_mtype(None, {"1": "Urban"}, series) is None
 
 
-def test_labels_without_a_frame_are_not_enough():
-    assert _resolve_mtype(None, {"1": "Urban"}, None) is None
-
-
 def test_no_labels_and_no_measure_leaves_mtype_alone():
     assert _resolve_mtype(None, {}, pl.Series("x", [1.0, 2.0])) is None
 
@@ -103,12 +99,17 @@ def test_no_labels_and_no_measure_leaves_mtype_alone():
 
 
 def test_declared_nominal_wins_without_needing_labels():
-    assert _resolve_mtype("nominal", {}, None) == MeasurementType.NOMINAL
+    """A declaration decides on its own; no labels need exist to corroborate."""
+    unlabelled = pl.Series("x", [1.0, 2.0, 3.0])
+
+    assert _resolve_mtype("nominal", {}, unlabelled) == MeasurementType.NOMINAL
 
 
 def test_declared_ordinal_is_honored():
     """Coverage cannot tell ordinal from nominal; only the file can."""
-    assert _resolve_mtype("ordinal", {}, None) == MeasurementType.ORDINAL
+    unlabelled = pl.Series("x", [1.0, 2.0, 3.0])
+
+    assert _resolve_mtype("ordinal", {}, unlabelled) == MeasurementType.ORDINAL
 
 
 def test_declared_scale_does_not_veto_the_coverage_rule():
@@ -136,18 +137,6 @@ def test_import_sets_categorical_for_a_fully_labelled_column():
     assert got.has_labels
     assert got.mtype == MeasurementType.NOMINAL
     assert got.is_categorical
-
-
-def test_import_without_a_frame_still_only_imports_labels():
-    """The df parameter is optional; older callers must behave as before."""
-    store = MetadataStore()
-    store.set("v106", VariableMeta(name="v106", mtype=MeasurementType.CONTINUOUS))
-
-    import_labels_from_svyio_meta(store, _meta(mapping={"0": "None"}))
-
-    got = store.get("v106")
-    assert got.has_labels
-    assert got.mtype == MeasurementType.CONTINUOUS
 
 
 def test_import_does_not_override_a_user_set_mtype():

--- a/packages/svy/tests/svy/engine/test_io_roundtrip.py
+++ b/packages/svy/tests/svy/engine/test_io_roundtrip.py
@@ -47,7 +47,7 @@ def test_spss_carries_variable_and_value_labels(store, df, tmp):
     assert back["q"].to_list() == [1.0, 99.0, 1.0]
 
     recovered = MetadataStore()
-    import_labels_from_svyio_meta(recovered, meta)
+    import_labels_from_svyio_meta(recovered, meta, back)
     assert recovered.get("q").label == "Question"
     assert recovered.get("age").label == "Age"
     # 99 is a value like any other, and it travels with its label.
@@ -64,10 +64,10 @@ def test_a_label_read_back_from_spss_still_applies(store, df, tmp):
     """
     path = tmp / "t.sav"
     _write_spss(df, store, path)
-    _, meta, _ = _read_spss(path)
+    back, meta, _ = _read_spss(path)
 
     recovered = MetadataStore()
-    import_labels_from_svyio_meta(recovered, meta)
+    import_labels_from_svyio_meta(recovered, meta, back)
     resolved = recovered.resolve_labels("q")
 
     assert resolved.display(1.0) == "Yes"
@@ -82,7 +82,7 @@ def test_stata_carries_labels_too(store, df, tmp):
 
     assert back["q"].to_list() == [1.0, 99.0, 1.0]
     recovered = MetadataStore()
-    import_labels_from_svyio_meta(recovered, meta)
+    import_labels_from_svyio_meta(recovered, meta, back)
     assert recovered.get("q").label == "Question"
 
 


### PR DESCRIPTION
Closes #130.

## Root cause (narrower than the issue states)

The readers don't derive `mtype` at all. `Sample(data=df)` infers it from the polars dtype via `_infer_mtype`, and `import_labels_from_svyio_meta` then imports `label` and `value_labels` while **leaving `mtype` untouched**. So `Float64 → CONTINUOUS` sticks regardless of what the file said. The bug is in `svy`, not in the svy-io readers.

## Reading `measure` alone does not fix this

Before building, I checked ground truth against every data file in the repo:

| Source | `measure` reported |
|---|---|
| `tic_domicilios_2025` (real, 271 vars) | **`scale` for all 271** — including all 67 carrying value labels |
| svy-io test `.sav` files | mostly `unknown` |
| `variable-label.sav`, `labelled-str.sav` | `nominal` |
| every `.dta` | `unknown` (dta has no such attribute) |

SPSS defaults numeric variables to `scale` and nobody re-sets it. Implemented verbatim, the issue's proposal would be a **no-op for the Stata case it was filed about**, and would stamp `CONTINUOUS` with *more* apparent authority on 67 labelled variables in the real `.sav`. The declaration is trustworthy only when it positively says `nominal`/`ordinal`.

## What this does instead

**svy-io** surfaces `measure` in `meta["vars"]` — genuine file information, cheap to expose, and `None` rather than `"scale"` when undeclared so callers can distinguish "declared continuous" from "never declared".

**svy** resolves `mtype` on import: honour `measure` when it is a positive declaration, otherwise fall back to **label coverage of observed values**.

Coverage is what separates the cases the issue rightly worried about. A "how many TVs?" count labelling only `0 = none` and `4 = 4 or more` is not a five-level factor — that's the income/`99` objection, and coverage catches it:

| Variable | Observed | Labelled | Coverage | Result |
|---|---|---|---|---|
| `area` (urban/rural) | `{1,2}` | `{1,2}` | 1.00 | `NOMINAL` ✅ |
| `tv` (count) | `{0,1,2,3,4}` | `{0,4}` | 0.40 | stays continuous ✅ |

A variable becomes `NOMINAL` only at **full coverage**. Partial coverage, an all-null column, a column absent from the frame, and a type the user set by hand all leave `mtype` alone. `ORDINAL` is assigned only when the file declares it, since coverage cannot distinguish it from `NOMINAL`.

Codes arrive from svy-io as strings (`'1'`) while the column holding them is `Float64` (`1.0`), so both sides are canonicalized before comparing.

## Results on real data

- **Stata census (`WLD_2023_SYNTH-CEN-IND`)**: 16 labelled variables, **0 → 16** categorical — `sex`, `marstat`, `religion`, `literacy`, `occupation`, …
- **Real `.sav`**: 67 labelled, **50** categorical; the 17 left continuous are dominated by count variables with labelled endpoints.

## Verification

- `svy`: **3054 passed**, 1 skipped.
- `svy-io`: **176 passed**, 9 skipped.
- Zero new clippy warnings in `core.rs` (4 before, 4 after — all pre-existing).
- `measure` output matches `pyreadstat`'s `variable_measure` exactly on every file tested.

## API note

`import_labels_from_svyio_meta` now **requires** the frame the metadata describes as its third argument. Resolving a measurement type depends on how well the value labels cover the observed values, which cannot be judged without the data.

Required rather than optional on purpose: an omitted frame would silently fall back to the exact behavior this PR fixes — no type resolved, no warning, no error — which is the same silent-failure class #132 removes. The compatibility cost is near zero: one production call site (already passing the frame), and the function is internal (`svy.engine.io.import_labels_from_svyio_meta`; absent from the top-level `svy` namespace, `engine` not in `svy.__all__`). The three pre-existing test call sites all had a frame in scope and were updated.

## Notes for review

- **Known limitation: unlabelled sentinels.** On the real `.sav`, 17 of the 67 labelled variables fall below full coverage — but **13 of those are the rule working correctly**: the asset battery (`TV`, `RADIO`, `GELADEIRA`, `AUTOMOVEL`, …) asks "have you got X? how many?", observes `{0,1,2,3,4}`, and labels only `0` and `4`, so the unlabelled values are `1,2,3` and the variables are genuine counts.

  The remaining **4 are misclassified** — `A5_NENHUM`, `A7_AGREG`, `DIC_CEL`, `A9_FAIXA` — all categorical variables tripped by an unlabelled sentinel (`99` = not applicable, or `0`) sitting alongside the labelled categories. `A5_NENHUM` is the extreme: all 27,177 rows hold `99`, its label set defines only `1`, and `1` is never observed, so coverage is 0.00.

  This is not fixable from the file. It declares **zero** user-missing ranges, so dropping declared-missing codes from the denominator would be a no-op; `measure` says `scale` for all 271 variables; and `99` is indistinguishable from a data value without the questionnaire. The rule correctly reports that it has no evidence and declines to guess. `measure` is consulted first precisely so that a file which *does* declare `nominal` never reaches this path. Affected variables can be set explicitly — `MetadataSource.USER` is not overridden.
- **New svy tests use synthetic frames only.** `packages/svy/data/` is gitignored, so a real-file test could not run in CI.
- **CI does not run the svy-io suite** — `svy-tests.yml` runs `make test-svy` only, and svy-io's workflow builds wheels. The two new svy-io tests were verified locally; they also depend on the gitignored `tests/data/`, and the existing `test_data_dir` fixture skips when it is absent.
- **Pre-existing lint/format debt left alone**, same as #132: formatting was applied only to files this change already edits.

## Relationship to #132

Independent — branched off `origin/main`, not off `fix/write-dta-value-labels`. #132 touches the Stata *write* path; this touches the *read* path plus `svy`. The only shared file is `packages/svy-io/CHANGELOG.md`, where both add under `## [Unreleased]`. Whichever merges second takes a one-line conflict resolution.

