### PR TITLE
Restore the replicate coefficient override, and finish the RepWgts migration

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,13 +8,64 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Added
+
+- **Poisson bootstrap replicate weights ([#131](https://github.com/samplics-org/svy/pull/131)).** `sample.weighting.create_bs_wgts(kind="poisson")` generates Beaumont–Patak generalized bootstrap weights, which need only a weight column. The default `kind="rao-wu"` is the stratified Rao–Wu–Yue rescaling bootstrap and still requires `psu` on the design — the guard is deliberately not shared, since the Poisson bootstrap exists precisely for files that have no PSU. Both kinds use the same `1/R` per-replicate coefficient; they differ in how the replicates are drawn, not in how the variance is scaled.
+
+  Beaumont, J.-F. and Patak, Z. (2012). On the generalized bootstrap for sample surveys with special attention to Poisson sampling. *International Statistical Review*, 80(1), 127–148.
+
+- **`scale`: the coefficients a producer publishes ([#7](https://github.com/samplics-org/svy/issues/7)).** Replicate weights often ship with a documented per-replicate variance coefficient that is not the method's default. CETIC publishes the ICT Households microdata with `0.0065365334145709` at R = 200, which bakes in a finite-population correction. Declaring it is now a parameter rather than an arithmetic exercise:
+
+  ```python
+  svy.RepWeights(method="bootstrap", prefix="REP", n_reps=200, scale=0.0065365334145709)
+  ```
+
+  A scalar is broadcast to every replicate; a sequence must match `n_reps` and is checked at construction. It replaces, rather than multiplies, the method default: `V = Σ_r scale_r · (θ_r − θ̄)²`. svy's `scale` is R `svrepdesign`'s `scale × rscales` folded into one field, so `svrepdesign(type = "bootstrap", scale = c, rscales = rep(1, R))` is `scale=c` here, with no conversion factor. `examples/ict_households.py` drops the `sqrt(scale * R)` workaround it used to demonstrate.
+
+- **Jackknife designs say which family they are.** `JackknifeWgts.kind` takes R's `svrepdesign(type=)` names — `"jk1"` (unstratified delete-one-PSU, `(R−1)/R`), `"jkn"` (stratified, `(n_h−1)/n_h` per replicate), `"jk2"` (paired, one replicate per stratum, `1.0`). `"paired"` is accepted as an alias for `"jk2"`: it describes the design, not the replication scheme, since a JKn on a paired design is still JKn.
+
+  The default is `None` — unspecified. `None` and `"jk1"` produce the same number but are different statements, and svy claims only what it knows or was told. A producer withholding design variables is not evidence that the weights are unstratified.
+
+- **JKn coefficients are derived when the design allows it.** `(n_h−1)/n_h` is the only standard coefficient that is not closed-form in `n_reps`, so it used to have to be supplied by hand. Given `kind="jkn"` plus `stratum` and `psu`, svy now works it out at `Sample` construction. Limited to balanced designs — every stratum the same `n_h` — where the coefficient is uniform and the replicate-to-stratum mapping does not matter; that covers the paired-PSU designs that dominate real JKn files. Unbalanced still needs `scale`.
+
+  A declared kind is also checked rather than merely trusted: `jk1` and `jkn` imply one replicate per PSU, `jk2` one per stratum. Mismatches warn rather than raise, since a legitimately subset frame has fewer PSUs than the weight columns were built from. An unspecified kind on a stratified design warns too — svy has evidence the JK1 global is probably wrong, but no claim to act on.
+
 ### Fixed
+
+- **A user-supplied replicate coefficient was silently discarded for bootstrap, BRR and SDR ([#7](https://github.com/samplics-org/svy/issues/7)).** Before [#131](https://github.com/samplics-org/svy/pull/131) the override was applied at one site in the kernel — `rscales.unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef))` — and was therefore method-agnostic by construction. #131 moved coefficient computation into Python and scattered it across four per-variant `coefficients()` methods, which gave every method its own chance to forget. Three of four forgot: the field was accepted, stored, length-checked, and then dropped, so a bootstrap declared with a producer's published scale silently returned the `1/R` answer.
+
+  `coefficients()` is now a template method on the shared base. The override is resolved there, at the single point of use, and the variants implement only their own default — they never see it, so a new variant cannot regress this again. **No published standard error changes:** #131 landed after `svy-v0.24.1` and was never released.
+
+- **Estimation and regression could scale the same design differently.** `GLM._rep_coefficients` re-derived the coefficients by substring-matching a stringified method tag (`if "boot" in m`), and honoured the user's override for every method while the estimation path did not. One `Design` therefore produced differently scaled standard errors from `sample.regression.glm(...)` and `sample.estimation.mean(...)`. It is gone; both call `rep_wgts.coefficients()`.
+
+- **A declared paired jackknife used the wrong coefficient.** JK2 has one delete-one replicate per stratum and a coefficient of `1.0`; the global `(R−1)/R` understates the variance by exactly that factor. Declaring `kind="jk2"` now gets `1.0`. Relatedly, `kind="jkn"` with nothing to compute the per-stratum coefficients from — no `scale`, no design variables — refuses rather than substituting the JK1 global, which on a 4-strata × 2-PSU design overstates standard errors by `sqrt(7/4)`, 32%. An unmet claim fails; an absent one (`kind=None`) still falls back to `(R−1)/R` exactly as before.
 
 - **Labelled variables were never `is_categorical` ([#130](https://github.com/samplics-org/svy/issues/130)).** `Sample(data=df)` infers `mtype` from the polars dtype, and `import_labels_from_svyio_meta` brought across labels while leaving that untouched — so every labelled variable in a survey recode stayed `Numerical Continuous` and `is_categorical` was `False`. Deriving a codebook from it classified an entire DHS-style file as continuous. The importer now revises `mtype` on import: it honours a measurement level the file declares, and otherwise asks whether the value labels cover every observed value. On a Stata census file this takes 16 labelled variables from 0 categorical to 16.
 - **Measurement type is inferred from label coverage, not label presence.** "Has labels" alone would misread a continuous variable that labels only a sentinel code — a "how many TVs?" count labelling just `0 = none` and `4 = 4 or more` is not a five-level factor. A variable becomes `NOMINAL` only when every observed non-null value carries a label; partial coverage, an all-null column, and a column absent from the frame all leave `mtype` alone, as does a type the user set by hand. `ORDINAL` is assigned only when the file says so, since coverage cannot distinguish it from `NOMINAL`.
 - **The polars deprecation filter never worked.** `filterwarnings = ["error::DeprecationWarning:polars"]` looked like a guard against calling deprecated polars APIs and was inert: the module field is compared against the frame the warning is attributed to, and polars sets `stacklevel` to point at the calling code, so `:polars` never matches. Verified with a probe — a deprecated call passed cleanly under it. The filter is now unqualified, and the suite passes under it.
 
 ### Changed
+
+- **Replicate-weight designs are a tagged union of four types, and `svy.RepWeights` is a function ([#131](https://github.com/samplics-org/svy/pull/131)).** They were a single struct carrying an estimation-method enum plus every method's parameters. They are now one type per method — `BootstrapWgts`, `JackknifeWgts`, `BrrWgts`, `SdrWgts` — each carrying exactly the parameters its algorithm has. A bootstrap cannot hold a Fay coefficient, because there is no field for one.
+
+  `svy.RepWeights(method=..., ...)` keeps working and returns the variant for the name, so call sites are unaffected. **But it is a factory function now, not a class**, which breaks two things it used to support:
+
+  ```python
+  isinstance(x, svy.RepWeights)   # TypeError: isinstance() arg 2 must be a type
+  x: svy.RepWeights               # no longer a valid annotation
+  ```
+
+  Use `svy.RepWgts`, the union of the four variants, for both. Code that knows the method at authoring time can construct the variant directly, which is the typed path: `BootstrapWgts(prefix="bsw", n_reps=1000, kind="poisson")`.
+
+- **`rscales` is now `scale` (user-supplied) or `rep_coefs` (svy-derived).** The single field held both, which made "the user asserted this" indistinguishable from "svy computed this". They split on who supplied the values — the one axis that is verifiable, since a user declaring stratified JKn supplies the *standard* coefficient rather than a custom one. `scale` is what you pass; `rep_coefs` is filled by `create_jk_wgts` and by the JKn derivation, and is shown as `(derived)` in the design output.
+
+  This renames a parameter on two released surfaces: `svy.RepWeights(rscales=...)` and `Design.update_rep_weights(rscales=...)`. Both now take `scale=` (or `rep_coefs=`), and `scale` additionally accepts a scalar.
+
+- **A parameter that belongs to another method is refused, even at its neutral value.** `RepWeights(method="bootstrap", fay_coef=0.0)` was accepted as a stored no-op when every method shared one flat signature. It now raises, naming the variant that owns the parameter. Callers that know the method should not be sending it; nothing in `svy` does any more.
+
+- **The `method` label is display-only, and now genuinely is.** Its docstring said nothing read it to choose a code path while eight sites did — seven in `weighting/` rebuilt a design by round-tripping the type through its own tag and hand-listing every field that had to survive, which is how `kind`, `scale` and `padding` could vanish across a poststratification. Copies now go through `msgspec.structs.replace`, which preserves the type and drops nothing.
+
+- **Non-default variance coefficients are visible.** `scale` and `rep_coefs` did not appear in `repr` or `print(design)` at all. A non-standard coefficient is what a reviewer or replicator most needs to see and is set rarely, so rare-and-silent was the wrong combination. A uniform vector prints as the scalar it is.
 
 - **`import_labels_from_svyio_meta` now requires the frame** the metadata describes as its third argument. Resolving a measurement type depends on how well the value labels cover the observed values, which cannot be judged without the data. It is required rather than optional on purpose: an omitted frame would silently fall back to the very behavior this release fixes. The function is internal (`svy.engine.io`, not exported from the top-level `svy` namespace) and had a single production call site.
 

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -817,9 +817,11 @@ class Design:
 
         if self.rep_wgts:
             rw = self.rep_wgts
-            method_name = getattr(rw.method, "name", str(rw.method))
+            # `.method` is the variant's tag and always a str. The getattr(...,
+            # "name", ...) dance here was for the estimation-method enum, which
+            # #131 removed.
             parts.append(
-                f"rep_wgts={method_name}(n_reps={rw.n_reps}, prefix='{rw.prefix}', df={rw.df})"
+                f"rep_wgts={rw.method}(n_reps={rw.n_reps}, prefix='{rw.prefix}', df={rw.df})"
             )
         else:
             parts.append("rep_wgts=None")

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -16,7 +16,9 @@ from typing import (
 )
 
 from svy.core.repwgts import (
+    BootstrapWgts,
     BrrWgts,
+    JackknifeWgts,
     RepWeights,
     RepWgts,
     _RepWgtsBase,
@@ -134,9 +136,11 @@ def make_rep_weights(
         method=method,
         prefix=prefix,
         n_reps=n_reps,
-        fay_coef=fay_coef,
         df=df,
         padding=padding,
+        # Only BRR has one; forwarding a 0.0 to any other method would be
+        # sending a Fay claim that is not being made.
+        **({"fay_coef": fay_coef} if fay_coef else {}),
     )
 
 
@@ -477,16 +481,25 @@ class Design:
         if isinstance(kind, _MissingType):
             kind = getattr(cur, "kind", None) if _same else None
 
+        # Pass only what this variant carries. Sending a foreign parameter at
+        # its neutral value -- fay_coef=0.0 to a bootstrap -- would need the
+        # receiving end to treat that as "unset", which is the flat struct's
+        # habit, not something the union should have to accommodate.
+        variant_only: dict[str, object] = {}
+        if _variant is BrrWgts:
+            variant_only["fay_coef"] = fay_coef
+        if _variant in (BootstrapWgts, JackknifeWgts) and kind is not None:
+            variant_only["kind"] = kind
+
         updated_rep_wgts = RepWeights(
             method=resolved_method,
             prefix=resolved_prefix,
             n_reps=resolved_n_reps,
-            fay_coef=fay_coef if _variant is BrrWgts else 0.0,
             df=df,
             padding=padding,
             scale=scale,
             rep_coefs=rep_coefs,
-            kind=kind,
+            **variant_only,
         )
 
         return self.update(rep_wgts=updated_rep_wgts)

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -406,7 +406,8 @@ class Design:
         fay_coef: float | _MissingType = _MISSING,
         df: int | None | _MissingType = _MISSING,
         padding: int | None | _MissingType = _MISSING,
-        rscales: tuple[float, ...] | None | _MissingType = _MISSING,
+        scale: float | Sequence[float] | None | _MissingType = _MISSING,
+        rep_coefs: tuple[float, ...] | None | _MissingType = _MISSING,
         kind: str | None | _MissingType = _MISSING,
         paired: bool | _MissingType = _MISSING,
     ) -> Self:
@@ -423,7 +424,8 @@ class Design:
             and isinstance(fay_coef, _MissingType)
             and isinstance(df, _MissingType)
             and isinstance(padding, _MissingType)
-            and isinstance(rscales, _MissingType)
+            and isinstance(scale, _MissingType)
+            and isinstance(rep_coefs, _MissingType)
             and isinstance(kind, _MissingType)
             and isinstance(paired, _MissingType)
         ):
@@ -462,8 +464,11 @@ class Design:
         if isinstance(padding, _MissingType):
             padding = cur.padding if cur else None
 
-        if isinstance(rscales, _MissingType):
-            rscales = cur.rscales if cur else None
+        if isinstance(scale, _MissingType):
+            scale = cur.scale if cur else None
+
+        if isinstance(rep_coefs, _MissingType):
+            rep_coefs = cur.rep_coefs if cur else None
 
         # 5. Create the new variant.
         _variant = resolve_rep_variant(resolved_method)
@@ -483,7 +488,8 @@ class Design:
             fay_coef=fay_coef if _variant is BrrWgts else 0.0,
             df=df,
             padding=padding,
-            rscales=rscales,
+            scale=scale,
+            rep_coefs=rep_coefs,
             kind=kind,
             paired=paired,
         )

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -409,7 +409,6 @@ class Design:
         scale: float | Sequence[float] | None | _MissingType = _MISSING,
         rep_coefs: tuple[float, ...] | None | _MissingType = _MISSING,
         kind: str | None | _MissingType = _MISSING,
-        paired: bool | _MissingType = _MISSING,
     ) -> Self:
         """
         Return a new Design with selected RepWeights fields updated.
@@ -427,7 +426,6 @@ class Design:
             and isinstance(scale, _MissingType)
             and isinstance(rep_coefs, _MissingType)
             and isinstance(kind, _MissingType)
-            and isinstance(paired, _MissingType)
         ):
             return self
 
@@ -478,8 +476,6 @@ class Design:
         _same = cur is not None and type(cur) is _variant
         if isinstance(kind, _MissingType):
             kind = getattr(cur, "kind", None) if _same else None
-        if isinstance(paired, _MissingType):
-            paired = getattr(cur, "paired", False) if _same else False
 
         updated_rep_wgts = RepWeights(
             method=resolved_method,
@@ -491,7 +487,6 @@ class Design:
             scale=scale,
             rep_coefs=rep_coefs,
             kind=kind,
-            paired=paired,
         )
 
         return self.update(rep_wgts=updated_rep_wgts)

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -2,7 +2,7 @@
 """Replicate-weight designs as a tagged union.
 
 One struct per variance-estimation method, each carrying exactly the parameters
-its algorithm has. See ``docs/design/rep-weights-tagged-union.md``.
+its algorithm has.
 
 The rule for adding a variant: **a type exists exactly when the data differs.**
 Behaviour differences are handled by a method on the variant, not a new type.
@@ -10,8 +10,15 @@ That is why Fay's BRR is a ``fay_coef`` value rather than a type —
 plain BRR *is* Fay's BRR at 0.0, so splitting it would make
 ``FayWgts(fay_coef=0.0)`` constructible and self-contradictory.
 
-The top level mirrors ``RepMethod`` in ``svy-rs/src/estimation/replication.rs``,
-which is what the variance kernel actually branches on.
+The names mirror ``RepMethod`` in ``svy-rs/src/estimation/replication.rs``, but
+the kernel no longer branches on them: Python resolves the per-replicate
+coefficients here and passes the resulting vector across the FFI. Nothing in
+``svy`` reads the ``method`` label to choose a code path — copies go through
+``msgspec.structs.replace``, which preserves the type, and variance goes through
+``coefficients()``.
+
+``RepWeights`` is a function, not a class. For annotations and ``isinstance``
+use ``RepWgts``, the union of the four variants.
 """
 
 from __future__ import annotations
@@ -29,15 +36,12 @@ from svy.errors import MethodError
 # Bootstrap kinds
 # =============================================================================
 #
-# A nested union rather than a plain string, because the kinds carry different
-# data. Behaviour that varies by kind (the replicate coefficient) lives here as
-# a method, so adding a kind whose scale differs -- svrep's generalized
-# bootstrap uses tau^2/B rather than 1/B -- needs no change anywhere else.
-
-
-# The two bootstrap kinds differ in how the replicates are drawn, not in what
-# they carry, so this is a field rather than a nested union. Calibrating the
-# replicates afterwards is a separate weighting step (see
+# The two kinds differ in how the replicates are drawn, not in what they carry
+# or how the variance is scaled -- both use 1/R -- so this is a field rather
+# than a nested union, and it is provenance rather than a coefficient input.
+# A kind whose scale *does* differ (svrep's generalized bootstrap, tau^2/B)
+# would branch in ``BootstrapWgts._default_coefficients`` and nowhere else.
+# Calibrating the replicates afterwards is a separate weighting step (see
 # ``Sample.weighting.poststratify``) and is not recorded here.
 #: The canonical values. Aliases normalize onto these, and the field stores
 #: only these, so the Literal describes what is actually held. Authored code

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -57,6 +57,27 @@ _BS_KIND_ALIASES: dict[str, str] = {
 # =============================================================================
 
 
+def _normalize_scale(value: float | Sequence[float], n_reps: int, param: str) -> tuple[float, ...]:
+    """Broadcast a scalar, or validate a sequence against ``n_reps``.
+
+    Stored normalized so that every reader downstream sees one shape and the
+    length is wrong at construction rather than at estimation.
+    """
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return (float(value),) * n_reps
+    if isinstance(value, (str, bytes, bytearray)) or not isinstance(value, Sequence):
+        raise TypeError(
+            f"'{param}' must be a float or a sequence of floats, got {type(value).__name__}."
+        )
+    values = tuple(float(v) for v in value)
+    if len(values) != n_reps:
+        raise ValueError(
+            f"'{param}' has {len(values)} entries but n_reps is {n_reps}. "
+            f"Pass a scalar to use the same coefficient for every replicate."
+        )
+    return values
+
+
 class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
     """Fields every replicate design has, whatever produced it.
 
@@ -70,11 +91,22 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
     # weight set and therefore the same for every domain.
     df: int | None = None
     padding: int | None = None  # None = auto-detect, 0 = none, >0 = zero-pad width
-    # Per-replicate variance coefficients (R's scale*rscales combined). Kept
-    # common rather than on JackknifeWgts: R's svrepdesign takes scale/rscales
-    # for every type=, and the default is correct for BRR/bootstrap/SDR/JK1 --
-    # stratified JKn merely needs a non-default.
-    rscales: tuple[float, ...] | None = None
+    # Per-replicate variance coefficients, split by who supplied them -- the one
+    # axis that is verifiable. "Is this a tweak or the standard value?" is not:
+    # a user declaring stratified JKn supplies the *standard* coefficient,
+    # because svy cannot derive it from replicate weights alone.
+    #
+    # scale: the user said so. R's svrepdesign takes scale/rscales for every
+    # type=, and svy folds the pair into this one field (svy's scale is R's
+    # scale * rscales). A scalar is broadcast to every replicate. Replaces,
+    # rather than multiplies, the method default.
+    scale: float | Sequence[float] | None = None
+    # rep_coefs: svy computed these and cannot recompute them later. Exists for
+    # one case -- JKn's (n_h-1)/n_h is the only standard coefficient that is not
+    # closed-form in n_reps: it needs per-stratum PSU counts, coefficients() has
+    # no frame, and the stratum column may be gone by estimation time. Filled by
+    # create_jk_wgts; users want ``scale``.
+    rep_coefs: tuple[float, ...] | None = None
 
     def __post_init__(self) -> None:
         if not self.prefix or not self.prefix.strip():
@@ -85,6 +117,14 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
             raise ValueError(f"df must be > 0. Got {self.df}.")
         if self.padding is not None and self.padding < 0:
             raise ValueError(f"padding must be >= 0. Got {self.padding}.")
+        if self.scale is not None:
+            msgspec.structs.force_setattr(
+                self, "scale", _normalize_scale(self.scale, self.n_reps, "scale")
+            )
+        if self.rep_coefs is not None:
+            msgspec.structs.force_setattr(
+                self, "rep_coefs", _normalize_scale(self.rep_coefs, self.n_reps, "rep_coefs")
+            )
 
     # ---- back-compat read surface ------------------------------------------
 
@@ -145,10 +185,26 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
     # ---- variance ------------------------------------------------------------
 
     def coefficients(self) -> list[float]:
-        """Per-replicate variance coefficients.
+        """Per-replicate variance coefficients, in precedence order.
 
-        Lives on the variant rather than in a distant ``match`` so that adding a
-        method, or a bootstrap kind whose scale differs, stays a local change.
+        The override is resolved *here*, at the single point of use, and the
+        variants never see it -- they implement only their own default. Before
+        the tagged union this lived at one site in the kernel
+        (``rscales.unwrap_or_else(|| replicate_coefficients(...))``); scattering
+        it into per-variant methods gave every method its own chance to forget,
+        and three of four did. A new variant cannot regress it.
+        """
+        if self.scale is not None:
+            return list(self.scale)  # the user asserted these
+        if self.rep_coefs is not None:
+            return list(self.rep_coefs)  # svy computed them and cannot redo it
+        return self._default_coefficients()
+
+    def _default_coefficients(self) -> list[float]:
+        """The method's standard coefficients, closed-form in ``n_reps``.
+
+        The only thing a variant implements. Adding a method, or a bootstrap
+        kind whose scale differs, stays a local change.
         """
         raise NotImplementedError
 
@@ -195,7 +251,10 @@ class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", ta
         super().__post_init__()
         msgspec.structs.force_setattr(self, "kind", normalize_bootstrap_kind(self.kind))
 
-    def coefficients(self) -> list[float]:
+    def _default_coefficients(self) -> list[float]:
+        # Both kinds: the kind decides how the replicates are drawn, not how the
+        # variance is scaled. A kind whose scale differs (svrep's generalized
+        # bootstrap, tau^2/B) branches here.
         return [1.0 / self.n_reps] * self.n_reps
 
     def _variant_parts(self) -> list[str]:
@@ -208,9 +267,10 @@ class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", ta
 class JackknifeWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Jackknife", tag_field="method"):
     paired: bool = False  # JK2 paired vs JK1/JKn
 
-    def coefficients(self) -> list[float]:
-        if self.rscales is not None:
-            return list(self.rscales)
+    def _default_coefficients(self) -> list[float]:
+        # JK1's global (R-1)/R. Stratified JKn's (n_h-1)/n_h is not closed-form
+        # in n_reps, so it arrives through rep_coefs (svy-generated) or scale
+        # (user-declared) and never reaches here.
         return [(self.n_reps - 1) / self.n_reps] * self.n_reps
 
     def _variant_parts(self) -> list[str]:
@@ -227,9 +287,9 @@ class BrrWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="BRR", tag_field="met
         if self.fay_coef < 0:
             raise ValueError(f"fay_coef cannot be negative. Got {self.fay_coef}.")
 
-    def coefficients(self) -> list[float]:
-        scale = 1.0 / (self.n_reps * (1.0 - self.fay_coef) ** 2)
-        return [scale] * self.n_reps
+    def _default_coefficients(self) -> list[float]:
+        coef = 1.0 / (self.n_reps * (1.0 - self.fay_coef) ** 2)
+        return [coef] * self.n_reps
 
     def _variant_parts(self) -> list[str]:
         return [f"fay={self.fay_coef}"]
@@ -239,7 +299,7 @@ class BrrWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="BRR", tag_field="met
 
 
 class SdrWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="SDR", tag_field="method"):
-    def coefficients(self) -> list[float]:
+    def _default_coefficients(self) -> list[float]:
         return [4.0 / self.n_reps] * self.n_reps
 
 
@@ -337,7 +397,8 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
     fay_coef: float = 0.0,
     df: int | None = None,
     padding: int | None = None,
-    rscales: tuple[float, ...] | None = None,
+    scale: float | Sequence[float] | None = None,
+    rep_coefs: tuple[float, ...] | None = None,
     *,
     kind: str | None = None,
     paired: bool = False,
@@ -362,7 +423,9 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
 
     variant = resolve_rep_variant(method)
 
-    common = dict(prefix=prefix, n_reps=n_reps, df=df, padding=padding, rscales=rscales)
+    common = dict(
+        prefix=prefix, n_reps=n_reps, df=df, padding=padding, scale=scale, rep_coefs=rep_coefs
+    )
 
     if variant is BootstrapWgts:
         _reject(variant, fay_coef=fay_coef, paired=paired)

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 import re
 
-from typing import Literal, Sequence, Union
+from typing import Literal, Sequence, Union, cast, get_args
 
 import msgspec
 
@@ -39,7 +39,12 @@ from svy.errors import MethodError
 # they carry, so this is a field rather than a nested union. Calibrating the
 # replicates afterwards is a separate weighting step (see
 # ``Sample.weighting.poststratify``) and is not recorded here.
-BOOTSTRAP_KINDS = ("rao-wu", "poisson")
+#: The canonical values. Aliases normalize onto these, and the field stores
+#: only these, so the Literal describes what is actually held. Authored code
+#: should use a canonical name and gets checked for it; a name arriving as data
+#: goes through ``RepWeights``, where no static type applies anyway.
+BootstrapKind = Literal["rao-wu", "poisson"]
+BOOTSTRAP_KINDS: tuple[str, ...] = get_args(BootstrapKind)
 
 _BS_KIND_ALIASES: dict[str, str] = {
     "rao-wu": "rao-wu",
@@ -65,7 +70,8 @@ _BS_KIND_ALIASES: dict[str, str] = {
 # "jk1"  unstratified delete-one-PSU          (R-1)/R
 # "jkn"  stratified delete-one-PSU            (n_h-1)/n_h, per replicate
 # "jk2"  one paired replicate per stratum     1.0
-JACKKNIFE_KINDS = ("jk1", "jkn", "jk2")
+JackknifeKind = Literal["jk1", "jkn", "jk2"]
+JACKKNIFE_KINDS: tuple[str, ...] = get_args(JackknifeKind)
 
 _JK_KIND_ALIASES: dict[str, str] = {
     "jk1": "jk1",
@@ -84,7 +90,7 @@ _JK_KIND_ALIASES: dict[str, str] = {
 }
 
 
-def normalize_jackknife_kind(kind: str) -> str:
+def normalize_jackknife_kind(kind: str) -> JackknifeKind:
     """Normalize a jackknife ``kind``. Case- and separator-insensitive."""
     if not isinstance(kind, str):
         raise TypeError(f"'kind' must be a string, got {type(kind).__name__}.")
@@ -102,7 +108,7 @@ def normalize_jackknife_kind(kind: str) -> str:
                 "scheme. Leave it unset if you do not know which the weights are."
             ),
         )
-    return resolved
+    return cast(JackknifeKind, resolved)
 
 
 # =============================================================================
@@ -328,7 +334,7 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
 
 
 class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", tag_field="method"):
-    kind: str = "rao-wu"
+    kind: BootstrapKind = "rao-wu"
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -355,7 +361,7 @@ class JackknifeWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Jackknife", ta
     # None = unspecified: nobody has said which family these weights are. That
     # is a different statement from "jk1", even though the two produce the same
     # number -- svy only claims what it knows or what it was told.
-    kind: str | None = None
+    kind: JackknifeKind | None = None
 
     def __post_init__(self) -> None:
         super().__post_init__()
@@ -477,7 +483,7 @@ def resolve_rep_variant(
     )
 
 
-def normalize_bootstrap_kind(kind: str) -> str:
+def normalize_bootstrap_kind(kind: str) -> BootstrapKind:
     """Normalize a bootstrap ``kind``.
 
     Case-insensitive and tolerant of hyphen, underscore or space separators,
@@ -491,7 +497,7 @@ def normalize_bootstrap_kind(kind: str) -> str:
             where="svy.RepWeights",
             param="kind",
             got=kind,
-            allowed=["rao-wu", "poisson"],
+            allowed=list(BOOTSTRAP_KINDS),
             docs_url=None,
             hint=(
                 "'rao-wu' is the stratified Rao-Wu-Yue rescaling bootstrap and needs "
@@ -499,7 +505,7 @@ def normalize_bootstrap_kind(kind: str) -> str:
                 "bootstrap and needs only a weight."
             ),
         )
-    return resolved
+    return cast(BootstrapKind, resolved)
 
 
 _MISSING_ARG: object = object()
@@ -548,7 +554,7 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
 
     variant = resolve_rep_variant(method)
     try:
-        return variant(prefix=prefix, n_reps=n_reps, **kwargs)  # type: ignore[return-value]
+        return cast(RepWgts, variant(prefix=prefix, n_reps=n_reps, **kwargs))
     except TypeError as exc:
         name = _unexpected_param(exc)
         if name is None:

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -506,14 +506,6 @@ _MISSING_ARG: object = object()
 
 # Parameters that only some variants carry, for turning msgspec's accurate but
 # terse "Unexpected keyword argument" into one that names the owner.
-# Value a foreign parameter can carry while still meaning "unset", because the
-# flat struct this replaced gave every method's parameters a shared default.
-_NEUTRAL: dict[str, tuple[object, ...]] = {
-    "fay_coef": (0.0, 0, None),
-    "kind": (None,),
-    "paired": (False, None),
-}
-
 _PARAM_OWNER = {
     "fay_coef": ("BrrWgts", "BRR"),
     # kind belongs to bootstrap and to jackknife, with different vocabularies;
@@ -555,22 +547,13 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
             raise TypeError(f"Missing required argument {_name!r}")
 
     variant = resolve_rep_variant(method)
-    fields = dict(kwargs)
-    # The flat signature this replaced carried every method's parameters, so
-    # callers pass a foreign one at its neutral value to mean "unset" --
-    # fay_coef=0.0 on a bootstrap is not a Fay claim. Those are dropped; a
-    # foreign parameter carrying an actual value still earns an error.
-    for _ in range(len(fields) + 1):
-        try:
-            return variant(prefix=prefix, n_reps=n_reps, **fields)  # type: ignore[return-value]
-        except TypeError as exc:
-            name = _unexpected_param(exc)
-            if name is None:
-                raise
-            if fields.get(name) not in _NEUTRAL.get(name, (None,)):
-                raise _foreign_param_error(variant, name) from exc
-            fields.pop(name)
-    raise AssertionError("unreachable: one parameter is dropped per iteration")
+    try:
+        return variant(prefix=prefix, n_reps=n_reps, **kwargs)  # type: ignore[return-value]
+    except TypeError as exc:
+        name = _unexpected_param(exc)
+        if name is None:
+            raise
+        raise _foreign_param_error(variant, name, kwargs.get(name)) from exc
 
 
 def _unexpected_param(exc: TypeError) -> str | None:
@@ -579,7 +562,7 @@ def _unexpected_param(exc: TypeError) -> str | None:
     return match.group(1) if match else None
 
 
-def _foreign_param_error(variant: type, name: str) -> Exception:
+def _foreign_param_error(variant: type, name: str, value: object = None) -> Exception:
     """Name the variant that owns a parameter msgspec has just refused.
 
     msgspec already rejects a foreign keyword on every path, including direct
@@ -593,7 +576,7 @@ def _foreign_param_error(variant: type, name: str) -> Exception:
     return MethodError.invalid_choice(
         where="svy.RepWeights",
         param=name,
-        got=True,
+        got=value,
         allowed=[None],
         hint=(
             f"'{name}' is a {owner_method} parameter and is not stored on a "

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -53,6 +53,59 @@ _BS_KIND_ALIASES: dict[str, str] = {
 
 
 # =============================================================================
+# Jackknife kinds
+# =============================================================================
+#
+# Three families, and unlike the bootstrap kinds they carry different variance
+# coefficients -- which is why this replaced a ``paired: bool``. The boolean
+# folded JK1 and JKn together into False, but those two have different
+# coefficients, so it could not express the distinction the coefficient logic
+# depends on. The names are R's ``svrepdesign(type=)`` strings.
+#
+# "jk1"  unstratified delete-one-PSU          (R-1)/R
+# "jkn"  stratified delete-one-PSU            (n_h-1)/n_h, per replicate
+# "jk2"  one paired replicate per stratum     1.0
+JACKKNIFE_KINDS = ("jk1", "jkn", "jk2")
+
+_JK_KIND_ALIASES: dict[str, str] = {
+    "jk1": "jk1",
+    "jk-1": "jk1",
+    "jk_1": "jk1",
+    "jkn": "jkn",
+    "jk-n": "jkn",
+    "jk_n": "jkn",
+    "jk2": "jk2",
+    "jk-2": "jk2",
+    "jk_2": "jk2",
+    # "paired" describes the design (two PSUs per stratum), not the replication
+    # scheme -- a JKn on a paired design is still JKn. Accepted because people
+    # reach for it, normalized to the scheme's actual name.
+    "paired": "jk2",
+}
+
+
+def normalize_jackknife_kind(kind: str) -> str:
+    """Normalize a jackknife ``kind``. Case- and separator-insensitive."""
+    if not isinstance(kind, str):
+        raise TypeError(f"'kind' must be a string, got {type(kind).__name__}.")
+    resolved = _JK_KIND_ALIASES.get(kind.strip().lower())
+    if resolved is None:
+        raise MethodError.invalid_choice(
+            where="svy.RepWeights",
+            param="kind",
+            got=kind,
+            allowed=list(JACKKNIFE_KINDS),
+            docs_url=None,
+            hint=(
+                "'jk1' is the unstratified delete-one-PSU jackknife, 'jkn' its "
+                "stratified form, and 'jk2' the paired one-replicate-per-stratum "
+                "scheme. Leave it unset if you do not know which the weights are."
+            ),
+        )
+    return resolved
+
+
+# =============================================================================
 # Shared fields and behaviour
 # =============================================================================
 
@@ -265,16 +318,44 @@ class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", ta
 
 
 class JackknifeWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Jackknife", tag_field="method"):
-    paired: bool = False  # JK2 paired vs JK1/JKn
+    # None = unspecified: nobody has said which family these weights are. That
+    # is a different statement from "jk1", even though the two produce the same
+    # number -- svy only claims what it knows or what it was told.
+    kind: str | None = None
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.kind is not None:
+            msgspec.structs.force_setattr(self, "kind", normalize_jackknife_kind(self.kind))
 
     def _default_coefficients(self) -> list[float]:
-        # JK1's global (R-1)/R. Stratified JKn's (n_h-1)/n_h is not closed-form
-        # in n_reps, so it arrives through rep_coefs (svy-generated) or scale
-        # (user-declared) and never reaches here.
+        if self.kind == "jk2":
+            # One delete-one replicate per stratum. A global (R-1)/R would
+            # understate the variance by exactly that factor.
+            return [1.0] * self.n_reps
+        if self.kind == "jkn":
+            # (n_h-1)/n_h is the only standard coefficient that is not
+            # closed-form in n_reps, and nothing supplied it. An unmet claim
+            # fails; an absent one (kind=None) falls back to the JK1 global.
+            raise MethodError.not_applicable(
+                where="RepWeights.coefficients",
+                method="jackknife",
+                reason=(
+                    "kind='jkn' needs the per-stratum (n_h-1)/n_h coefficients, "
+                    "which cannot be derived from replicate weights alone. Pass "
+                    "'scale' with the coefficients your file documents. Falling "
+                    "back to the JK1 global (R-1)/R would overstate the standard "
+                    "errors"
+                ),
+            )
+        # kind=None (unspecified) and "jk1" alike: the unstratified global.
         return [(self.n_reps - 1) / self.n_reps] * self.n_reps
 
     def _variant_parts(self) -> list[str]:
-        return ["paired=True"] if self.paired else []
+        return [] if self.kind is None else [f"kind={self.kind}"]
+
+    def _plain_variant_lines(self) -> list[str]:
+        return [] if self.kind is None else [f"Kind     : {self.kind}"]
 
 
 class BrrWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="BRR", tag_field="method"):
@@ -401,7 +482,6 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
     rep_coefs: tuple[float, ...] | None = None,
     *,
     kind: str | None = None,
-    paired: bool = False,
 ) -> RepWgts:
     """Build the replicate-weight variant for ``method``.
 
@@ -428,24 +508,25 @@ def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
     )
 
     if variant is BootstrapWgts:
-        _reject(variant, fay_coef=fay_coef, paired=paired)
+        _reject(variant, fay_coef=fay_coef)
         return BootstrapWgts(
             **common, kind=normalize_bootstrap_kind(kind) if kind is not None else "rao-wu"
         )
     if variant is JackknifeWgts:
-        _reject(variant, fay_coef=fay_coef, kind=kind)
-        return JackknifeWgts(**common, paired=paired)
+        _reject(variant, fay_coef=fay_coef)
+        return JackknifeWgts(**common, kind=kind)
     if variant is BrrWgts:
-        _reject(variant, kind=kind, paired=paired)
+        _reject(variant, kind=kind)
         return BrrWgts(**common, fay_coef=fay_coef)
-    _reject(variant, fay_coef=fay_coef, kind=kind, paired=paired)
+    _reject(variant, fay_coef=fay_coef, kind=kind)
     return SdrWgts(**common)
 
 
 _PARAM_OWNER = {
     "fay_coef": ("BrrWgts", "BRR"),
-    "kind": ("BootstrapWgts", "bootstrap"),
-    "paired": ("JackknifeWgts", "jackknife"),
+    # kind belongs to bootstrap and to jackknife, with different vocabularies;
+    # only BRR and SDR have none.
+    "kind": ("BootstrapWgts or JackknifeWgts", "bootstrap or jackknife"),
 }
 
 
@@ -456,7 +537,7 @@ def _reject(variant: type, **supplied) -> None:
     they are turned away, so nothing downstream holds a value that is wrong.
     """
     for name, value in supplied.items():
-        empty = 0.0 if name == "fay_coef" else (False if name == "paired" else None)
+        empty = 0.0 if name == "fay_coef" else None
         if value == empty or value is empty:
             continue
         owner, owner_method = _PARAM_OWNER[name]

--- a/packages/svy/src/svy/core/repwgts.py
+++ b/packages/svy/src/svy/core/repwgts.py
@@ -110,6 +110,14 @@ def normalize_jackknife_kind(kind: str) -> str:
 # =============================================================================
 
 
+def _fmt_coefs(values: Sequence[float]) -> str:
+    """A uniform coefficient prints as the scalar it is."""
+    uniq = set(values)
+    if len(uniq) == 1:
+        return repr(next(iter(uniq)))
+    return f"({values[0]!r}, ... , {values[-1]!r}) x{len(values)}"
+
+
 def _normalize_scale(value: float | Sequence[float], n_reps: int, param: str) -> tuple[float, ...]:
     """Broadcast a scalar, or validate a sequence against ``n_reps``.
 
@@ -185,9 +193,13 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
     def method(self) -> str:
         """The coarse method family, as a display label.
 
-        One of ``"Bootstrap"``, ``"Jackknife"``, ``"BRR"``, ``"SDR"``. A label
-        for display and reporting: the variant's own type is what decides
-        anything, so nothing reads this to choose a code path.
+        One of ``"Bootstrap"``, ``"Jackknife"``, ``"BRR"``, ``"SDR"``. For
+        display and reporting only -- nothing in ``svy`` reads this to choose a
+        code path. Internal code that needs to copy a design uses
+        ``msgspec.structs.replace``, which preserves the type; code that needs
+        the coefficients calls ``coefficients()``. Both used to go through this
+        label and back via the string factory, which is how a bootstrap and a
+        jackknife could end up scaled by different rules.
         """
         return self.__struct_config__.tag
 
@@ -267,11 +279,25 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
         """Variant-specific fragments for repr. Overridden where there are any."""
         return []
 
+    def _coef_parts(self) -> list[str]:
+        """Where the coefficients came from, when it is not the method default.
+
+        A non-standard variance coefficient is exactly what a reviewer or a
+        replicator needs to see, and it is set rarely enough that showing it
+        costs nothing.
+        """
+        if self.scale is not None:
+            return [f"scale={_fmt_coefs(self.scale)}"]
+        if self.rep_coefs is not None:
+            return [f"rep_coefs={_fmt_coefs(self.rep_coefs)} (derived)"]
+        return []
+
     def __repr__(self) -> str:
         parts = [f"method={self.method}", f"prefix='{self.prefix}'", f"n_reps={self.n_reps}"]
         if self.df is not None:
             parts.append(f"df={self.df}")
         parts.extend(self._variant_parts())
+        parts.extend(self._coef_parts())
         if self.padding is not None:
             parts.append(f"padding={self.padding}")
         return f"RepWeights({', '.join(parts)})"
@@ -286,6 +312,10 @@ class _RepWgtsBase(msgspec.Struct, frozen=True, kw_only=True):
             f"DF       : {self.df if self.df is not None else 'auto'}",
         ]
         lines.extend(self._plain_variant_lines())
+        if self.scale is not None:
+            lines.append(f"Scale    : {_fmt_coefs(self.scale)}")
+        elif self.rep_coefs is not None:
+            lines.append(f"Coefs    : {_fmt_coefs(self.rep_coefs)} (derived)")
         return "\n".join(lines)
 
     def _plain_variant_lines(self) -> list[str]:
@@ -302,7 +332,11 @@ class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", ta
 
     def __post_init__(self) -> None:
         super().__post_init__()
-        msgspec.structs.force_setattr(self, "kind", normalize_bootstrap_kind(self.kind))
+        # An explicit None means the same as omitting it: this field's default
+        # is a value, not an absence, because both kinds share the 1/R
+        # coefficient and rao-wu is the dominant convention.
+        resolved = "rao-wu" if self.kind is None else normalize_bootstrap_kind(self.kind)
+        msgspec.structs.force_setattr(self, "kind", resolved)
 
     def _default_coefficients(self) -> list[float]:
         # Both kinds: the kind decides how the replicates are drawn, not how the
@@ -311,7 +345,7 @@ class BootstrapWgts(_RepWgtsBase, frozen=True, kw_only=True, tag="Bootstrap", ta
         return [1.0 / self.n_reps] * self.n_reps
 
     def _variant_parts(self) -> list[str]:
-        return [] if self.kind == "rao-wu" else [f"kind={self.kind}"]
+        return [f"kind={self.kind}"]
 
     def _plain_variant_lines(self) -> list[str]:
         return [f"Kind     : {self.kind}"]
@@ -470,57 +504,15 @@ def normalize_bootstrap_kind(kind: str) -> str:
 
 _MISSING_ARG: object = object()
 
-
-def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
-    method: str = _MISSING_ARG,  # type: ignore[assignment]
-    prefix: str = _MISSING_ARG,  # type: ignore[assignment]
-    n_reps: int = _MISSING_ARG,  # type: ignore[assignment]
-    fay_coef: float = 0.0,
-    df: int | None = None,
-    padding: int | None = None,
-    scale: float | Sequence[float] | None = None,
-    rep_coefs: tuple[float, ...] | None = None,
-    *,
-    kind: str | None = None,
-) -> RepWgts:
-    """Build the replicate-weight variant for ``method``.
-
-    Kept as a factory with the pre-union signature so existing call sites keep
-    working. New code can construct the variant directly:
-
-    >>> BootstrapWgts(prefix="bsw", n_reps=1000, kind="poisson")
-    >>> BrrWgts(prefix="brr_", n_reps=32, fay_coef=0.5)
-
-    Parameters that do not belong to ``method`` are rejected rather than stored:
-    the union is what makes ``fay_coef`` on a bootstrap unrepresentable, and the
-    factory is the boundary that enforces it for string callers.
-    """
-    # Sentinels rather than bare required parameters so the message matches the
-    # struct this factory replaced.
-    for _name, _val in (("method", method), ("prefix", prefix), ("n_reps", n_reps)):
-        if _val is _MISSING_ARG:
-            raise TypeError(f"Missing required argument {_name!r}")
-
-    variant = resolve_rep_variant(method)
-
-    common = dict(
-        prefix=prefix, n_reps=n_reps, df=df, padding=padding, scale=scale, rep_coefs=rep_coefs
-    )
-
-    if variant is BootstrapWgts:
-        _reject(variant, fay_coef=fay_coef)
-        return BootstrapWgts(
-            **common, kind=normalize_bootstrap_kind(kind) if kind is not None else "rao-wu"
-        )
-    if variant is JackknifeWgts:
-        _reject(variant, fay_coef=fay_coef)
-        return JackknifeWgts(**common, kind=kind)
-    if variant is BrrWgts:
-        _reject(variant, kind=kind)
-        return BrrWgts(**common, fay_coef=fay_coef)
-    _reject(variant, fay_coef=fay_coef, kind=kind)
-    return SdrWgts(**common)
-
+# Parameters that only some variants carry, for turning msgspec's accurate but
+# terse "Unexpected keyword argument" into one that names the owner.
+# Value a foreign parameter can carry while still meaning "unset", because the
+# flat struct this replaced gave every method's parameters a shared default.
+_NEUTRAL: dict[str, tuple[object, ...]] = {
+    "fay_coef": (0.0, 0, None),
+    "kind": (None,),
+    "paired": (False, None),
+}
 
 _PARAM_OWNER = {
     "fay_coef": ("BrrWgts", "BRR"),
@@ -530,25 +522,82 @@ _PARAM_OWNER = {
 }
 
 
-def _reject(variant: type, **supplied) -> None:
-    """Reject parameters that belong to a different method.
+def RepWeights(  # noqa: N802 - a factory that replaced a class of this name
+    method: str = _MISSING_ARG,  # type: ignore[assignment]
+    prefix: str = _MISSING_ARG,  # type: ignore[assignment]
+    n_reps: int = _MISSING_ARG,  # type: ignore[assignment]
+    **kwargs: object,
+) -> RepWgts:
+    """Build the replicate-weight variant for ``method``.
 
-    The flat signature can express combinations the union cannot; this is where
-    they are turned away, so nothing downstream holds a value that is wrong.
+    The door for a method name that arrives as a string -- from a codebook, a
+    config file, or a producer's documentation. New code that knows the method
+    at authoring time should construct the variant directly, which is typed and
+    autocompletes:
+
+    >>> BootstrapWgts(prefix="bsw", n_reps=1000, kind="poisson")
+    >>> BrrWgts(prefix="brr_", n_reps=32, fay_coef=0.5)
+
+    This is a function, not a class: ``isinstance(x, svy.RepWeights)`` and the
+    annotation ``x: svy.RepWeights`` do not work. Use ``svy.RepWgts``, the union
+    of the four variants, for both.
+
+    Parameters that do not belong to ``method`` are refused rather than stored --
+    by the variant itself, since a struct has no field to put them in. This
+    wrapper only improves the message.
     """
-    for name, value in supplied.items():
-        empty = 0.0 if name == "fay_coef" else None
-        if value == empty or value is empty:
-            continue
-        owner, owner_method = _PARAM_OWNER[name]
-        raise MethodError.invalid_choice(
-            where="svy.RepWeights",
-            param=name,
-            got=value,
-            allowed=[empty],
-            hint=(
-                f"'{name}' is a {owner_method} parameter and is not stored on a "
-                f"{variant.__name__} design. Each method carries only its own "
-                f"parameters: {owner} has '{name}'."
-            ),
-        )
+    # Sentinels rather than bare required parameters so the message matches the
+    # struct this factory replaced. Only these three need it: everything else
+    # forwards to msgspec, whose own message is already verbatim
+    # "Missing required argument 'prefix'".
+    for _name, _val in (("method", method), ("prefix", prefix), ("n_reps", n_reps)):
+        if _val is _MISSING_ARG:
+            raise TypeError(f"Missing required argument {_name!r}")
+
+    variant = resolve_rep_variant(method)
+    fields = dict(kwargs)
+    # The flat signature this replaced carried every method's parameters, so
+    # callers pass a foreign one at its neutral value to mean "unset" --
+    # fay_coef=0.0 on a bootstrap is not a Fay claim. Those are dropped; a
+    # foreign parameter carrying an actual value still earns an error.
+    for _ in range(len(fields) + 1):
+        try:
+            return variant(prefix=prefix, n_reps=n_reps, **fields)  # type: ignore[return-value]
+        except TypeError as exc:
+            name = _unexpected_param(exc)
+            if name is None:
+                raise
+            if fields.get(name) not in _NEUTRAL.get(name, (None,)):
+                raise _foreign_param_error(variant, name) from exc
+            fields.pop(name)
+    raise AssertionError("unreachable: one parameter is dropped per iteration")
+
+
+def _unexpected_param(exc: TypeError) -> str | None:
+    """The parameter name msgspec refused, or None if this is another TypeError."""
+    match = re.search(r"Unexpected keyword argument '([^']+)'", str(exc))
+    return match.group(1) if match else None
+
+
+def _foreign_param_error(variant: type, name: str) -> Exception:
+    """Name the variant that owns a parameter msgspec has just refused.
+
+    msgspec already rejects a foreign keyword on every path, including direct
+    construction -- which the hand-rolled guard this replaced never covered. All
+    that is added here is the hint.
+    """
+    owned = _PARAM_OWNER.get(name)
+    if owned is None:
+        return TypeError(f"Unexpected keyword argument {name!r}")
+    owner, owner_method = owned
+    return MethodError.invalid_choice(
+        where="svy.RepWeights",
+        param=name,
+        got=True,
+        allowed=[None],
+        hint=(
+            f"'{name}' is a {owner_method} parameter and is not stored on a "
+            f"{variant.__name__} design. Each method carries only its own "
+            f"parameters: {owner} has '{name}'."
+        ),
+    )

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -7,6 +7,7 @@ import logging
 
 from typing import TYPE_CHECKING, Any, Iterable, Literal, Mapping, Self, Sequence, cast
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -19,6 +20,7 @@ from svy.core.describe_runtime import run_describe
 from svy.core.design import Design, PopSize, RepWeights
 from svy.core.enumerations import MeasurementType
 from svy.core.expr import to_polars_expr
+from svy.core.repwgts import JackknifeWgts
 from svy.core.types import (
     _MISSING,
     DF,
@@ -165,6 +167,114 @@ class Sample:
 
         self._check_for_singletons()
         self._validate_design()
+        self._resolve_jackknife_kind()
+
+    def _resolve_jackknife_kind(self) -> None:
+        """Check a declared jackknife ``kind`` against the design, and derive the
+        JKn coefficients when the design makes them derivable.
+
+        Only jackknife needs this. Every other method's standard coefficient is
+        closed-form in ``n_reps`` -- bootstrap 1/R, BRR 1/(R(1-f)^2), SDR 4/R,
+        JK1 (R-1)/R, JK2 1.0 -- so nothing else can learn anything from strata
+        and PSUs. JKn's (n_h-1)/n_h is the sole exception, and it is why this
+        lives here, where the frame is, rather than on the struct.
+
+        Producers who withhold design variables and publish replicate weights
+        instead usually ship bootstrap, BRR or SDR; the large jackknife files
+        that arrive without strata (NAEP, TIMSS) are JK2, whose coefficient is
+        closed-form. The common paths do not depend on any of this.
+        """
+        design = cast("Design", self._design)
+        rw = design.rep_wgts
+        if not isinstance(rw, JackknifeWgts):
+            return
+
+        stratum_col = self._internal_design.get("stratum")
+        psu_col = self._internal_design.get("psu")
+        data = cast(pl.DataFrame, self._data)
+        if psu_col is None or psu_col not in data.columns:
+            return  # nothing to check against and nothing to derive from
+
+        if stratum_col is not None and stratum_col in data.columns:
+            counts = (
+                data.select([stratum_col, psu_col])
+                .unique()
+                .group_by(stratum_col)
+                .len()
+                .get_column("len")
+                .to_list()
+            )
+        else:
+            counts = [data.get_column(psu_col).n_unique()]
+        n_strata = len(counts)
+        n_psus = sum(counts)
+
+        # A declared kind is otherwise an assertion svy has to trust; with design
+        # variables present it becomes checkable arithmetic. A warning rather
+        # than an error, because a legitimately subset frame has fewer PSUs than
+        # the weight columns were built from and that is not a mislabelling.
+        expected = {"jk1": n_psus, "jkn": n_psus, "jk2": n_strata}.get(rw.kind or "")
+        if expected is not None and expected != rw.n_reps:
+            self.warn(
+                code=WarnCode.JACKKNIFE_KIND_UNSPECIFIED,
+                title=f"Jackknife kind {rw.kind!r} does not match the design",
+                detail=(
+                    f"kind={rw.kind!r} implies {expected} replicates "
+                    f"({'one per stratum' if rw.kind == 'jk2' else 'one per PSU'}), "
+                    f"but n_reps is {rw.n_reps}. The frame has {n_psus} PSUs "
+                    f"across {n_strata} strata."
+                ),
+                where="Sample",
+                param="rep_wgts.kind",
+                expected=expected,
+                got=rw.n_reps,
+                hint=(
+                    "Expected when the frame is a subset of what the replicate "
+                    "weights were built from. Otherwise the kind is probably wrong."
+                ),
+            )
+            return
+
+        if rw.kind is None:
+            # Positive evidence that the JK1 global is probably wrong, but no
+            # claim from the user to act on: too weak to raise, too strong to
+            # pass over. Deriving a kind here would turn "the producer withheld
+            # the design" into "these weights are unstratified".
+            if n_strata > 1 and rw.scale is None and rw.rep_coefs is None:
+                self.warn(
+                    code=WarnCode.JACKKNIFE_KIND_UNSPECIFIED,
+                    title="Stratified design with an unspecified jackknife kind",
+                    detail=(
+                        f"The design has {n_strata} strata, but the replicate "
+                        f"weights do not say which jackknife they are, so the "
+                        f"unstratified JK1 coefficient (R-1)/R is being used."
+                    ),
+                    where="Sample",
+                    param="rep_wgts.kind",
+                    hint=(
+                        "Set kind='jkn' for the stratified delete-one-PSU "
+                        "jackknife, 'jk2' for the paired one-replicate-per-stratum "
+                        "scheme, or 'jk1' if these really are unstratified."
+                    ),
+                )
+            return
+
+        if rw.kind != "jkn":
+            return  # jk1 and jk2 are closed-form; nothing to derive
+        if rw.scale is not None or rw.rep_coefs is not None:
+            return  # already answered, by the user or by whoever generated these
+
+        # (n_h-1)/n_h is indexed by *replicate*, so the general case needs to know
+        # which replicate deletes a PSU from which stratum -- an ordering only
+        # whoever built the file knows. When every stratum has the same n_h the
+        # coefficient is uniform and the mapping is irrelevant, which covers the
+        # paired-PSU designs that dominate real JKn files. Unbalanced falls
+        # through, and coefficients() refuses and names `scale`.
+        if len(set(counts)) != 1 or counts[0] < 2:
+            return
+        n_h = counts[0]
+        derived = (float(n_h - 1) / float(n_h),) * rw.n_reps
+        self._design = design.update(rep_wgts=msgspec.structs.replace(rw, rep_coefs=derived))
 
     def __setattr__(self, name: str, value: Any) -> None:
         # Any rebind of the data or design invalidates every version-keyed

--- a/packages/svy/src/svy/core/warnings.py
+++ b/packages/svy/src/svy/core/warnings.py
@@ -36,6 +36,7 @@ class WarnCode(StrEnum):
     POSTSTRATA_EMPTY = "POSTSTRATA_EMPTY"
     CONTROL_MISMATCH = "CONTROL_MISMATCH"
     DESIGN_INCOMPLETE = "DESIGN_INCOMPLETE"
+    JACKKNIFE_KIND_UNSPECIFIED = "JACKKNIFE_KIND_UNSPECIFIED"
     # ── Weighting (generic — shared across trim, rake, calibrate, …) ──
     REPLICATE_SKIPPED = "REPLICATE_SKIPPED"  # rep weights present but not adjusted
     DOMAIN_SKIPPED = "DOMAIN_SKIPPED"  # domain skipped (e.g. below min_cell_size)

--- a/packages/svy/src/svy/estimation/replication.py
+++ b/packages/svy/src/svy/estimation/replication.py
@@ -98,18 +98,22 @@ def _get_rep_params(est: Estimation, fay_coef: float = 0.0):
         raise ValueError("No replicate weight columns found.")
     n_reps = len(rep_weight_cols)
     df_val = int(rw.df) if rw.df and rw.df > 0 else max(1, n_reps - 1)
-    rscales = list(rw.rscales) if rw.rscales is not None else None
-    if rscales is not None and len(rscales) != n_reps:
-        raise DimensionError(
-            title="rscales length mismatch",
-            detail=f"RepWeights.rscales has {len(rscales)} entries but "
-            f"{n_reps} replicate weight columns were resolved.",
-            code="RSCALES_LENGTH_MISMATCH",
-            where="estimation.replication",
-            param="rep_wgts.rscales",
-            expected=n_reps,
-            got=len(rscales),
-        )
+    # Both coefficient channels are length-checked at construction against the
+    # recorded n_reps; this catches the case that check cannot see -- a recorded
+    # n_reps that disagrees with the columns actually resolved from the data.
+    for _param in ("scale", "rep_coefs"):
+        _supplied = getattr(rw, _param, None)
+        if _supplied is not None and len(_supplied) != n_reps:
+            raise DimensionError(
+                title=f"{_param} length mismatch",
+                detail=f"RepWeights.{_param} has {len(_supplied)} entries but "
+                f"{n_reps} replicate weight columns were resolved.",
+                code=f"{_param.upper()}_LENGTH_MISMATCH",
+                where="estimation.replication",
+                param=f"rep_wgts.{_param}",
+                expected=n_reps,
+                got=len(_supplied),
+            )
     # Per-replicate variance coefficients, computed by the variant rather than
     # re-derived from a method label on the far side of the FFI boundary. The
     # resolved column count wins over the recorded n_reps, and an

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -596,9 +596,14 @@ class GLM:
                     ) from e
                 rep_betas.append(np.asarray(r_chosen[1], dtype=float))
             B = np.vstack(rep_betas)
-            coefs_r = np.asarray(
-                self._rep_coefficients(rep_wgts, B.shape[0]), dtype=float
-            )
+            # The variant computes its own coefficients, the same call the
+            # estimation path makes. Re-deriving them here from a method label
+            # is what let regression and estimation disagree about a design.
+            # The count of replicates actually fitted wins over the recorded one.
+            _rw = rep_wgts
+            if getattr(_rw, "n_reps", B.shape[0]) != B.shape[0]:
+                _rw = msgspec.structs.replace(_rw, n_reps=B.shape[0])
+            coefs_r = np.asarray(_rw.coefficients(), dtype=float)
             Bc = B - B.mean(axis=0)
             cov_mat = (Bc * coefs_r[:, None]).T @ Bc
             rep_df = getattr(rep_wgts, "df", None)
@@ -894,29 +899,6 @@ class GLM:
             raise ModelError.domain_violation(
                 where="GLM.fit", family=family, violation="Negative values"
             )
-
-    @staticmethod
-    def _rep_coefficients(rep_wgts, n_reps: int) -> list[float]:
-        """Per-replicate variance coefficients c_r (R svrVar's scale*rscales)."""
-        rscales = getattr(rep_wgts, "rscales", None)
-        if rscales is not None:
-            return [float(r) for r in rscales]
-        m = str(getattr(rep_wgts, "method", "")).lower()
-        if "boot" in m:
-            return [1.0 / n_reps] * n_reps
-        if "brr" in m or "balanced" in m:
-            fay = float(getattr(rep_wgts, "fay_coef", 0.0) or 0.0)
-            return [1.0 / (n_reps * (1.0 - fay) ** 2)] * n_reps
-        if "jack" in m:
-            return [(n_reps - 1.0) / n_reps] * n_reps
-        if "sdr" in m:
-            return [4.0 / n_reps] * n_reps
-        raise ModelError(
-            title="Unknown replication method",
-            detail=f"Cannot derive replicate variance coefficients for method {m!r}.",
-            code="UNKNOWN_REP_METHOD",
-            where="GLM.fit",
-        )
 
     @staticmethod
     def _effective_parameters(

--- a/packages/svy/src/svy/weighting/adjustment.py
+++ b/packages/svy/src/svy/weighting/adjustment.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -190,12 +191,8 @@ def adjust(
         df = sample._data
 
         if update_design_wgts:
-            sample._design = sample._design.update_rep_weights(
-                method=design.rep_wgts.method,
-                prefix=wgt_name,
-                n_reps=n_reps,
-                fay_coef=design.rep_wgts.fay_coef,
-                df=design.rep_wgts.df,
+            sample._design = sample._design.update(
+                rep_wgts=msgspec.structs.replace(design.rep_wgts, prefix=wgt_name, n_reps=n_reps)
             )
 
     sample._data = df
@@ -223,12 +220,12 @@ def adjust(
             original_design = sample._design
             tmp_design = original_design.update(wgt=wgt_name)
             if not ignore_reps and design.rep_wgts is not None:
-                tmp_design = tmp_design.update_rep_weights(
-                    method=design.rep_wgts.method,
-                    prefix=wgt_name,
-                    n_reps=len(design.rep_wgts.columns),
-                    fay_coef=design.rep_wgts.fay_coef,
-                    df=design.rep_wgts.df,
+                tmp_design = tmp_design.update(
+                    rep_wgts=msgspec.structs.replace(
+                        design.rep_wgts,
+                        prefix=wgt_name,
+                        n_reps=len(design.rep_wgts.columns),
+                    )
                 )
             sample._design = tmp_design
             sample = _apply_trim(

--- a/packages/svy/src/svy/weighting/base.py
+++ b/packages/svy/src/svy/weighting/base.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Literal, Mapping, Sequence
 
 import numpy as np
 
+from svy.core.repwgts import BootstrapKind
 from svy.core.terms import Feature
 from svy.core.types import Category, ControlsType, DomainScalarMap, Number
 from svy.utils.random_state import RandomState
@@ -106,7 +107,7 @@ class Weighting:
         self,
         n_reps: int = 500,
         *,
-        kind: Literal["rao-wu", "poisson"] = "rao-wu",
+        kind: BootstrapKind = "rao-wu",
         rep_prefix: str | None = None,
         drop_nulls: bool = False,
         rstate: RandomState = None,

--- a/packages/svy/src/svy/weighting/calibration.py
+++ b/packages/svy/src/svy/weighting/calibration.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Literal, Sequence
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -482,9 +483,7 @@ def calibrate_matrix(
         # Resolve trim domains (honor TrimConfig.by / min_cell_size, matching
         # the contract adjust()/trim() already implement)
         if trimming.by is not None:
-            t_by_cols = (
-                [trimming.by] if isinstance(trimming.by, str) else list(trimming.by)
-            )
+            t_by_cols = [trimming.by] if isinstance(trimming.by, str) else list(trimming.by)
             missing_by = [c for c in t_by_cols if c not in df.columns]
             if missing_by:
                 raise MethodError.invalid_choice(
@@ -518,16 +517,8 @@ def calibrate_matrix(
                     level=Severity.WARNING,
                 )
                 continue
-            _up = (
-                resolve_threshold(trimming.upper, _w_pos)
-                if trimming.upper is not None
-                else None
-            )
-            _lo = (
-                resolve_threshold(trimming.lower, _w_pos)
-                if trimming.lower is not None
-                else None
-            )
+            _up = resolve_threshold(trimming.upper, _w_pos) if trimming.upper is not None else None
+            _lo = resolve_threshold(trimming.lower, _w_pos) if trimming.lower is not None else None
             trim_groups.append((_mask, _up, _lo))
 
         assert rust_trim_weights is not None  # noqa: S101
@@ -670,12 +661,10 @@ def calibrate_matrix(
             df = df.hstack(wgts_df)
 
             if update_design_wgts:
-                sample._design = sample._design.update_rep_weights(
-                    method=design.rep_wgts.method,
-                    prefix=wgt_name,
-                    n_reps=n_reps,
-                    fay_coef=design.rep_wgts.fay_coef,
-                    df=design.rep_wgts.df,
+                sample._design = sample._design.update(
+                    rep_wgts=msgspec.structs.replace(
+                        design.rep_wgts, prefix=wgt_name, n_reps=n_reps
+                    )
                 )
 
     sample._data = df

--- a/packages/svy/src/svy/weighting/normalization.py
+++ b/packages/svy/src/svy/weighting/normalization.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -126,12 +127,10 @@ def normalize(
             sample._data = df.hstack(wgts_df)
             df = sample._data
             if update_design_wgts:
-                sample._design = sample._design.update_rep_weights(
-                    method=design.rep_wgts.method,
-                    prefix=wgt_name,
-                    n_reps=n_reps,
-                    fay_coef=design.rep_wgts.fay_coef,
-                    df=design.rep_wgts.df,
+                sample._design = sample._design.update(
+                    rep_wgts=msgspec.structs.replace(
+                        design.rep_wgts, prefix=wgt_name, n_reps=n_reps
+                    )
                 )
 
     sample._data = df

--- a/packages/svy/src/svy/weighting/poststratification.py
+++ b/packages/svy/src/svy/weighting/poststratification.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Sequence
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -247,12 +248,10 @@ def poststratify(
             df = sample._data
 
             if update_design_wgts:
-                sample._design = sample._design.update_rep_weights(
-                    method=design.rep_wgts.method,
-                    prefix=wgt_name,
-                    n_reps=n_reps,
-                    fay_coef=design.rep_wgts.fay_coef,
-                    df=design.rep_wgts.df,
+                sample._design = sample._design.update(
+                    rep_wgts=msgspec.structs.replace(
+                        design.rep_wgts, prefix=wgt_name, n_reps=n_reps
+                    )
                 )
 
     sample._data = df

--- a/packages/svy/src/svy/weighting/raking.py
+++ b/packages/svy/src/svy/weighting/raking.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Mapping, cast
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -36,7 +37,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 
-
 def _rake_or_raise(*args, where: str = "Sample.weighting.rake"):
     """Call the Rust raking kernel, translating bounds violations into a
     typed svy error. Bounds violations are errors on every exit path,
@@ -50,8 +50,7 @@ def _rake_or_raise(*args, where: str = "Sample.weighting.rake"):
             raise MethodError.not_applicable(
                 where=where,
                 method="rake",
-                reason="Weight ratios exceeded the specified bounds "
-                "(ll_bound/up_bound).",
+                reason="Weight ratios exceeded the specified bounds (ll_bound/up_bound).",
                 param="ll_bound/up_bound",
                 hint="Widen the bounds, relax the margins, or increase max_iter.",
             ) from None
@@ -568,12 +567,10 @@ def rake(
             df = sample._data
 
             if update_design_wgts:
-                sample._design = sample._design.update_rep_weights(
-                    method=design.rep_wgts.method,
-                    prefix=wgt_name,
-                    n_reps=n_reps,
-                    fay_coef=design.rep_wgts.fay_coef,
-                    df=design.rep_wgts.df,
+                sample._design = sample._design.update(
+                    rep_wgts=msgspec.structs.replace(
+                        design.rep_wgts, prefix=wgt_name, n_reps=n_reps
+                    )
                 )
 
     sample._data = df

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -40,8 +40,13 @@ except ImportError:  # pragma: no cover
     rust_create_jk_wgts = None
     rust_create_sdr_wgts = None
 
-from svy.core.design import RepWeights
-from svy.core.repwgts import normalize_bootstrap_kind
+from svy.core.repwgts import (
+    BootstrapWgts,
+    BrrWgts,
+    JackknifeWgts,
+    SdrWgts,
+    normalize_bootstrap_kind,
+)
 from svy.errors import DimensionError, MethodError
 from svy.utils.checks import drop_missing
 from svy.utils.random_state import RandomState, resolve_random_state
@@ -321,13 +326,7 @@ def create_brr_wgts(
     )
 
     sample._design = sample._design.fill_missing(
-        rep_wgts=RepWeights(
-            method="brr",
-            prefix=rep_prefix,
-            n_reps=n_reps_actual,
-            fay_coef=fay_coef,
-            df=df_val,
-        )
+        rep_wgts=BrrWgts(prefix=rep_prefix, n_reps=n_reps_actual, fay_coef=fay_coef, df=df_val)
     )
 
     return sample
@@ -390,8 +389,7 @@ def create_jk_wgts(
         jk_kind = "jkn"
 
     sample._design = sample._design.fill_missing(
-        rep_wgts=RepWeights(
-            method="jackknife",
+        rep_wgts=JackknifeWgts(
             prefix=rep_prefix,
             n_reps=n_reps,
             df=df_val,
@@ -515,12 +513,8 @@ def create_bs_wgts(
         [pl.Series(name=col, values=vals) for col, vals in rep_dicts.items()]
     )
 
-    sample._design = sample._design.update_rep_weights(
-        method="bootstrap",
-        prefix=rep_prefix,
-        n_reps=n_reps,
-        df=df_val,
-        kind=kind,
+    sample._design = sample._design.update(
+        rep_wgts=BootstrapWgts(prefix=rep_prefix, n_reps=n_reps, df=df_val, kind=kind)
     )
 
     return sample
@@ -576,11 +570,8 @@ def create_sdr_wgts(
         [pl.Series(name=col, values=vals) for col, vals in rep_dicts.items()]
     )
 
-    sample._design = sample._design.update_rep_weights(
-        method="sdr",
-        prefix=rep_prefix,
-        n_reps=n_reps,
-        df=df_val,
+    sample._design = sample._design.update(
+        rep_wgts=SdrWgts(prefix=rep_prefix, n_reps=n_reps, df=df_val)
     )
 
     return sample

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -41,6 +41,7 @@ except ImportError:  # pragma: no cover
     rust_create_sdr_wgts = None
 
 from svy.core.repwgts import (
+    BootstrapKind,
     BootstrapWgts,
     BrrWgts,
     JackknifeWgts,
@@ -409,7 +410,7 @@ def create_bs_wgts(
     sample: Sample,
     n_reps: int = 500,
     *,
-    kind: Literal["rao-wu", "poisson"] = "rao-wu",
+    kind: BootstrapKind = "rao-wu",
     rep_prefix: str | None = None,
     drop_nulls: bool = False,
     rstate: RandomState = None,

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -362,7 +362,7 @@ def create_jk_wgts(
     stratum_int = _to_int_array(data, design.stratum)
 
     assert rust_create_jk_wgts is not None  # noqa: S101
-    rep_mat, df_val, rscales = rust_create_jk_wgts(
+    rep_mat, df_val, rep_coefs = rust_create_jk_wgts(
         main_weights,
         psu_int,
         stratum_int,
@@ -386,8 +386,10 @@ def create_jk_wgts(
             df=df_val,
             paired=paired,
             # Per-replicate (n_h-1)/n_h coefficients: exact stratified-JKn
-            # variance instead of the global (R-1)/R approximation.
-            rscales=tuple(rscales),
+            # variance instead of the global (R-1)/R approximation. The computed
+            # channel, not `scale` -- svy derived these, the user did not assert
+            # them, and only svy can (it has the strata; coefficients() does not).
+            rep_coefs=tuple(rep_coefs),
         )
     )
 

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -378,13 +378,24 @@ def create_jk_wgts(
         [pl.Series(name=col, values=vals) for col, vals in rep_dicts.items()]
     )
 
+    # svy generated these, so the family is a fact rather than an assumption.
+    # A single stratum is not merely "close to" JK1: JKn's (n_h-1)/n_h with one
+    # stratum of n PSUs gives R = n replicates each at (n-1)/n, which is exactly
+    # the JK1 global. The collapse is identical, not approximate.
+    if paired:
+        jk_kind = "jk2"
+    elif design.stratum is None or len(np.unique(stratum_int)) <= 1:
+        jk_kind = "jk1"
+    else:
+        jk_kind = "jkn"
+
     sample._design = sample._design.fill_missing(
         rep_wgts=RepWeights(
             method="jackknife",
             prefix=rep_prefix,
             n_reps=n_reps,
             df=df_val,
-            paired=paired,
+            kind=jk_kind,
             # Per-replicate (n_h-1)/n_h coefficients: exact stratified-JKn
             # variance instead of the global (R-1)/R approximation. The computed
             # channel, not `scale` -- svy derived these, the user did not assert

--- a/packages/svy/src/svy/weighting/trimming.py
+++ b/packages/svy/src/svy/weighting/trimming.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import msgspec
 import numpy as np
 import polars as pl
 
@@ -304,12 +305,10 @@ def _run_trim(
                     ]
                 )
                 if update_design_wgts:
-                    sample._design = sample._design.update_rep_weights(
-                        method=design.rep_wgts.method,
-                        prefix=target_wgt,
-                        n_reps=n_reps,
-                        fay_coef=design.rep_wgts.fay_coef,
-                        df=design.rep_wgts.df,
+                    sample._design = sample._design.update(
+                        rep_wgts=msgspec.structs.replace(
+                            design.rep_wgts, prefix=target_wgt, n_reps=n_reps
+                        )
                     )
 
     # ── Flush to sample ───────────────────────────────────────────────────

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -368,3 +368,42 @@ def test_a_kind_that_disagrees_with_the_design_warns():
     s = _jk_sample([1, 1, 1, 1, 2, 2, 2, 2], n_reps=4, kind="jk2")
     codes = {w.code for w in s.warnings.list()}
     assert WarnCode.JACKKNIFE_KIND_UNSPECIFIED in codes
+
+
+# =============================================================================
+# The factory as a parse door
+# =============================================================================
+
+
+def test_factory_forwards_unknown_parameters_to_the_variant():
+    """It resolves the name and forwards; msgspec owns the field checking."""
+    rw = RepWeights(method="brr", prefix="b", n_reps=32, fay_coef=0.5, padding=3)
+    assert isinstance(rw, BrrWgts)
+    assert (rw.fay_coef, rw.padding) == (0.5, 3)
+
+
+def test_a_neutral_foreign_parameter_means_unset_not_a_claim():
+    """The flat struct gave every method's parameters a shared default, so
+    fay_coef=0.0 on a bootstrap is how callers spell "not applicable"."""
+    assert isinstance(
+        RepWeights(method="bootstrap", prefix="b", n_reps=10, fay_coef=0.0), BootstrapWgts
+    )
+
+
+def test_a_foreign_parameter_carrying_a_value_still_names_its_owner():
+    with pytest.raises(MethodError) as exc:
+        RepWeights(method="bootstrap", prefix="b", n_reps=10, fay_coef=0.5)
+    assert "BrrWgts" in str(exc.value)
+
+
+def test_direct_construction_is_guarded_too():
+    """The hand-rolled guard this replaced only covered the factory."""
+    with pytest.raises(TypeError):
+        BootstrapWgts(prefix="b", n_reps=10, fay_coef=0.5)
+
+
+def test_scale_is_visible_in_the_repr():
+    """Rare and silent is the bad combination for a variance coefficient."""
+    assert "scale=0.5" in repr(BootstrapWgts(prefix="b", n_reps=4, scale=0.5))
+    assert "(derived)" in repr(JackknifeWgts(prefix="b", n_reps=4, rep_coefs=(0.5,) * 4))
+    assert "scale" not in repr(BootstrapWgts(prefix="b", n_reps=4))

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -44,11 +44,8 @@ def test_method_property_is_the_display_label(variant, expected_method):
     "ctor, kwargs",
     [
         (BootstrapWgts, {"fay_coef": 0.5}),
-        (BootstrapWgts, {"paired": True}),
-        (JackknifeWgts, {"kind": "poisson"}),
         (JackknifeWgts, {"fay_coef": 0.5}),
         (BrrWgts, {"kind": "poisson"}),
-        (BrrWgts, {"paired": True}),
         (SdrWgts, {"fay_coef": 0.5}),
     ],
 )
@@ -56,6 +53,39 @@ def test_foreign_parameters_are_unrepresentable(ctor, kwargs):
     """The flat struct accepted all of these and never read them."""
     with pytest.raises(TypeError):
         ctor(prefix="w", n_reps=10, **kwargs)
+
+
+def test_jackknife_rejects_a_bootstrap_kind():
+    """Both variants have a ``kind``; the vocabularies are not interchangeable."""
+    with pytest.raises(MethodError) as exc:
+        JackknifeWgts(prefix="w", n_reps=10, kind="poisson")
+    assert "jk1" in str(exc.value)
+
+
+@pytest.mark.parametrize(
+    "given, expected",
+    [("jk1", "jk1"), ("JKN", "jkn"), ("jk_2", "jk2"), ("paired", "jk2")],
+)
+def test_jackknife_kind_aliases_normalize(given, expected):
+    assert JackknifeWgts(prefix="w", n_reps=10, kind=given).kind == expected
+
+
+def test_jackknife_kind_is_unspecified_by_default():
+    """None is not JK1: same number, different statement about who said so."""
+    rw = JackknifeWgts(prefix="w", n_reps=10)
+    assert rw.kind is None
+    assert rw.coefficients() == [0.9] * 10
+
+
+def test_declared_jkn_without_coefficients_refuses_to_guess():
+    """An unmet claim fails; an absent one falls back."""
+    with pytest.raises(MethodError) as exc:
+        JackknifeWgts(prefix="w", n_reps=10, kind="jkn").coefficients()
+    assert "scale" in str(exc.value)
+
+
+def test_declared_jk2_uses_one_not_the_global():
+    assert JackknifeWgts(prefix="w", n_reps=10, kind="jk2").coefficients() == [1.0] * 10
 
 
 def test_bootstrap_kind_is_a_value_not_a_type():
@@ -133,7 +163,6 @@ def test_bootstrap_kind_aliases_normalize(given):
     "kwargs, param",
     [
         ({"method": "bootstrap", "fay_coef": 0.5}, "fay_coef"),
-        ({"method": "bootstrap", "paired": True}, "paired"),
         ({"method": "brr", "kind": "poisson"}, "kind"),
         ({"method": "jackknife", "fay_coef": 0.5}, "fay_coef"),
         ({"method": "sdr", "kind": "poisson"}, "kind"),
@@ -246,11 +275,16 @@ def test_update_rep_weights_carries_kind_within_the_same_method():
 
 
 def test_update_rep_weights_drops_kind_when_the_method_changes():
-    """A bootstrap kind means nothing on a jackknife design."""
+    """A bootstrap kind means nothing on a jackknife design.
+
+    Both variants carry a ``kind`` now, with different vocabularies, so the
+    invariant is that the value does not survive the change of method -- not
+    that the field is absent.
+    """
     d = svy.Design(wgt="w", rep_wgts=BootstrapWgts(prefix="b", n_reps=10, kind="poisson"))
     updated = d.update_rep_weights(method="jackknife")
     assert isinstance(updated.rep_wgts, JackknifeWgts)
-    assert not hasattr(updated.rep_wgts, "kind")
+    assert updated.rep_wgts.kind is None
 
 
 def test_variants_are_publicly_exported():

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -1,5 +1,5 @@
 # tests/svy/core/test_repwgts_union.py
-"""RepWeights as a tagged union — see docs/design/rep-weights-tagged-union.md."""
+"""RepWeights as a tagged union."""
 
 from __future__ import annotations
 

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -382,12 +382,11 @@ def test_factory_forwards_unknown_parameters_to_the_variant():
     assert (rw.fay_coef, rw.padding) == (0.5, 3)
 
 
-def test_a_neutral_foreign_parameter_means_unset_not_a_claim():
-    """The flat struct gave every method's parameters a shared default, so
-    fay_coef=0.0 on a bootstrap is how callers spell "not applicable"."""
-    assert isinstance(
-        RepWeights(method="bootstrap", prefix="b", n_reps=10, fay_coef=0.0), BootstrapWgts
-    )
+def test_a_foreign_parameter_is_refused_even_at_its_neutral_value():
+    """fay_coef=0.0 on a bootstrap is still a Fay parameter on a design that has
+    none. Callers that know the variant should not be sending it at all."""
+    with pytest.raises(MethodError):
+        RepWeights(method="bootstrap", prefix="b", n_reps=10, fay_coef=0.0)
 
 
 def test_a_foreign_parameter_carrying_a_value_still_names_its_owner():

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import msgspec
+import polars as pl
 import pytest
 
 import svy
@@ -17,6 +18,7 @@ from svy.core.repwgts import (
     SdrWgts,
     resolve_rep_variant,
 )
+from svy.core.warnings import WarnCode
 from svy.errors import MethodError
 
 
@@ -298,3 +300,71 @@ def test_variants_are_publicly_exported():
         "SdrWgts",
     ):
         assert hasattr(svy, name), name
+
+
+# =============================================================================
+# Jackknife kind resolved against the design (Sample-level)
+# =============================================================================
+#
+# The struct cannot do this: (n_h-1)/n_h needs per-stratum PSU counts and
+# coefficients() has no frame. So it happens once at Sample construction.
+
+
+def _jk_frame(strata, n_reps=4):
+    n = len(strata)
+    return pl.DataFrame(
+        {
+            "stratum": strata,
+            "psu": [i // 2 + 1 for i in range(n)],
+            "w": [5.0] * n,
+            "y": [float(i) for i in range(n)],
+            **{f"jw{r}": [5.0] * n for r in range(1, n_reps + 1)},
+        }
+    )
+
+
+def _jk_sample(strata, *, n_reps=4, **rw_kwargs):
+    df = _jk_frame(strata, n_reps)
+    rw = JackknifeWgts(prefix="jw", n_reps=n_reps, **rw_kwargs)
+    return svy.Sample(df, svy.Design(wgt="w", stratum="stratum", psu="psu", rep_wgts=rw))
+
+
+def test_declared_jkn_derives_its_coefficients_from_a_balanced_design():
+    s = _jk_sample([1, 1, 1, 1, 2, 2, 2, 2], n_reps=4, kind="jkn")
+    assert s._design.rep_wgts.rep_coefs == (0.5,) * 4  # (n_h-1)/n_h, n_h=2
+    assert s._design.rep_wgts.scale is None  # derived, not asserted
+
+
+def test_unbalanced_jkn_is_not_derived_and_still_refuses():
+    """The replicate->stratum mapping is the producer's, not svy's to infer."""
+    s = _jk_sample([1, 1, 1, 1, 2, 2], n_reps=3, kind="jkn")
+    assert s._design.rep_wgts.rep_coefs is None
+    with pytest.raises(MethodError):
+        s._design.rep_wgts.coefficients()
+
+
+def test_user_scale_is_never_overwritten_by_derivation():
+    s = _jk_sample([1, 1, 1, 1, 2, 2, 2, 2], n_reps=4, kind="jkn", scale=0.9)
+    assert s._design.rep_wgts.rep_coefs is None
+    assert s._design.rep_wgts.coefficients() == [0.9] * 4
+
+
+def test_unspecified_kind_on_a_stratified_design_warns_but_does_not_guess():
+    s = _jk_sample([1, 1, 1, 1, 2, 2, 2, 2], n_reps=4)
+    assert s._design.rep_wgts.kind is None  # absence of a claim is not a claim
+    assert s._design.rep_wgts.coefficients() == [0.75] * 4  # JK1 global, unchanged
+    codes = {w.code for w in s.warnings.list()}
+    assert WarnCode.JACKKNIFE_KIND_UNSPECIFIED in codes
+
+
+def test_unspecified_kind_on_an_unstratified_design_is_silent():
+    s = _jk_sample([1, 1, 1, 1], n_reps=4)
+    codes = {w.code for w in s.warnings.list()}
+    assert WarnCode.JACKKNIFE_KIND_UNSPECIFIED not in codes
+
+
+def test_a_kind_that_disagrees_with_the_design_warns():
+    """jk2 implies one replicate per stratum; here there are 2 strata, not 4."""
+    s = _jk_sample([1, 1, 1, 1, 2, 2, 2, 2], n_reps=4, kind="jk2")
+    codes = {w.code for w in s.warnings.list()}
+    assert WarnCode.JACKKNIFE_KIND_UNSPECIFIED in codes

--- a/packages/svy/tests/svy/core/test_repwgts_union.py
+++ b/packages/svy/tests/svy/core/test_repwgts_union.py
@@ -95,9 +95,9 @@ def test_coefficients_match_the_rust_kernel():
     assert JackknifeWgts(prefix="w", n_reps=n).coefficients() == pytest.approx([(n - 1) / n] * n)
 
 
-def test_jackknife_rscales_override_the_default():
+def test_user_scale_overrides_the_default():
     rs = tuple(0.5 for _ in range(10))
-    assert JackknifeWgts(prefix="w", n_reps=10, rscales=rs).coefficients() == list(rs)
+    assert BootstrapWgts(prefix="w", n_reps=10, scale=rs).coefficients() == list(rs)
 
 
 # ---------------------------------------------------------------------------

--- a/packages/svy/tests/svy/estimation/data_golden.py
+++ b/packages/svy/tests/svy/estimation/data_golden.py
@@ -100,14 +100,14 @@ BOOTSTRAP = {
 # ==============================================================================
 # JACKKNIFE - 8 Replicates, df=7 — GLOBAL-SCALE convention, not JKn
 #
-# These goldens validate the documented no-rscales fallback: a RepWeights
-# without rscales uses the uniform (R-1)/R coefficient, and the R
+# These goldens validate the documented no-scale fallback: a RepWeights
+# without a scale uses the uniform (R-1)/R coefficient, and the R
 # reference was configured identically (svrepdesign(type="other",
 # scale=(R-1)/R, rscales=1)). For this fixture (4 strata x 2 PSUs) the
 # JKn-correct coefficients are (n_h-1)/n_h = 0.5, giving SEs exactly
 # sqrt(7/4) smaller — that convention is validated end-to-end in
 # test_jackknife_r_validation.py (svy-generated weights) and
-# test_jackknife_fixture_jkn.py (this fixture with explicit rscales
+# test_jackknife_fixture_jkn.py (this fixture with an explicit scale
 # against R svrepdesign(type="JKn")).
 # ==============================================================================
 JACKKNIFE = {
@@ -294,7 +294,7 @@ WHERE_BOOTSTRAP = {
     },
 }
 
-# Same global-scale (no-rscales) convention as JACKKNIFE above.
+# Same global-scale (no-scale) convention as JACKKNIFE above.
 WHERE_JACKKNIFE = {
     "mean_overall": {
         "est": 54944.21712125,

--- a/packages/svy/tests/svy/estimation/test_degrees_of_freedom.py
+++ b/packages/svy/tests/svy/estimation/test_degrees_of_freedom.py
@@ -260,7 +260,7 @@ def jkn() -> pl.DataFrame:
 
 def _rep_sample(data: pl.DataFrame, df: int | None = None) -> Sample:
     rep = RepWeights(
-        method="jackknife", prefix="rw", n_reps=N_REPS, df=df, rscales=tuple([0.75] * N_REPS)
+        method="jackknife", prefix="rw", n_reps=N_REPS, df=df, scale=0.75
     )
     return Sample(data, Design(wgt="w", stratum="stratum", psu="psu_id", rep_wgts=rep))
 

--- a/packages/svy/tests/svy/estimation/test_jackknife_fixture_jkn.py
+++ b/packages/svy/tests/svy/estimation/test_jackknife_fixture_jkn.py
@@ -5,7 +5,7 @@ Proper stratified-JKn validation of the jackknife golden fixture.
 The golden tests in test_replication.py run this fixture WITHOUT a scale
 (the documented global (R-1)/R fallback). Here the same delete-one-PSU
 weights are used with the JKn-correct per-replicate coefficients
-scale = (n_h-1)/n_h = 0.5 (4 strata x 2 PSUs), validated against
+(n_h-1)/n_h = 0.5 (4 strata x 2 PSUs), validated against
 R survey 4.5 (2026-07-23):
 
   api <- read.csv("fake_survey_jackknife_25122025.csv")
@@ -20,9 +20,9 @@ R survey 4.5 (2026-07-23):
 
 The no-scale SEs are exactly sqrt(7/4) larger (7/8 vs 1/2).
 
-The design here already carries stratum and psu, so once svy derives the
-per-stratum coefficients itself this becomes a test of that derivation and
-the explicit ``scale=0.5`` goes away. The R numbers below do not change.
+The design carries stratum and psu, so nothing is supplied by hand: svy
+derives (n_h-1)/n_h itself from the declared kind and the design. These are
+therefore tests of that derivation against R, not of a hand-fed coefficient.
 """
 
 import numpy as np
@@ -40,7 +40,7 @@ def jkn_sample(load_survey_data):
         prefix="jk_",
         n_reps=8,
         df=7,
-        scale=0.5,
+        kind="jkn",
     )
     design = Design(
         row_index="id", wgt="weight", stratum="stratum", psu="psu", rep_wgts=rep_weights
@@ -81,3 +81,10 @@ def test_jkn_se_is_sqrt_7_4_below_global_scale(load_survey_data, jkn_sample):
     se_j = jkn_sample.estimation.mean(y="income", method="replication", drop_nulls=True)
     ratio = se_g.estimates[0].se / se_j.estimates[0].se
     np.testing.assert_allclose(ratio, np.sqrt(7.0 / 4.0), rtol=1e-10)
+
+
+def test_coefficients_are_derived_from_the_design(jkn_sample):
+    """kind='jkn' plus stratum/psu is enough: nothing was supplied by hand."""
+    rw = jkn_sample._design.rep_wgts
+    assert rw.scale is None
+    assert rw.rep_coefs == (0.5,) * 8

--- a/packages/svy/tests/svy/estimation/test_jackknife_fixture_jkn.py
+++ b/packages/svy/tests/svy/estimation/test_jackknife_fixture_jkn.py
@@ -2,10 +2,10 @@
 """
 Proper stratified-JKn validation of the jackknife golden fixture.
 
-The golden tests in test_replication.py run this fixture WITHOUT rscales
+The golden tests in test_replication.py run this fixture WITHOUT a scale
 (the documented global (R-1)/R fallback). Here the same delete-one-PSU
 weights are used with the JKn-correct per-replicate coefficients
-rscales = (n_h-1)/n_h = 0.5 (4 strata x 2 PSUs), validated against
+scale = (n_h-1)/n_h = 0.5 (4 strata x 2 PSUs), validated against
 R survey 4.5 (2026-07-23):
 
   api <- read.csv("fake_survey_jackknife_25122025.csv")
@@ -18,7 +18,11 @@ R survey 4.5 (2026-07-23):
   svytotal(~low_income, rd)       # 23.1428636   (SE 2.8326446)
   svyratio(~income, ~hh_size, rd) # 21945.594958 (SE 489.9267289)
 
-The no-rscales SEs are exactly sqrt(7/4) larger (scale 7/8 vs 1/2).
+The no-scale SEs are exactly sqrt(7/4) larger (7/8 vs 1/2).
+
+The design here already carries stratum and psu, so once svy derives the
+per-stratum coefficients itself this becomes a test of that derivation and
+the explicit ``scale=0.5`` goes away. The R numbers below do not change.
 """
 
 import numpy as np
@@ -36,7 +40,7 @@ def jkn_sample(load_survey_data):
         prefix="jk_",
         n_reps=8,
         df=7,
-        rscales=(0.5,) * 8,
+        scale=0.5,
     )
     design = Design(
         row_index="id", wgt="weight", stratum="stratum", psu="psu", rep_wgts=rep_weights
@@ -68,7 +72,7 @@ def test_ratio_matches_r_jkn(jkn_sample):
 
 
 def test_jkn_se_is_sqrt_7_4_below_global_scale(load_survey_data, jkn_sample):
-    """The documented no-rscales fallback is exactly sqrt(7/4) larger."""
+    """The documented no-scale fallback is exactly sqrt(7/4) larger."""
     data = load_survey_data("fake_survey_jackknife_25122025.csv")
     rw_global = RepWeights(method="Jackknife", prefix="jk_", n_reps=8, df=7)
     design = Design(row_index="id", wgt="weight", stratum="stratum", psu="psu", rep_wgts=rw_global)

--- a/packages/svy/tests/svy/estimation/test_jackknife_r_validation.py
+++ b/packages/svy/tests/svy/estimation/test_jackknife_r_validation.py
@@ -46,13 +46,13 @@ def jk_sample() -> Sample:
 
 
 class TestGeneratedJknMatchesR:
-    def test_df_and_rscales(self, jk_sample):
+    def test_df_and_rep_coefs(self, jk_sample):
         rw = jk_sample.design.rep_wgts
         assert rw.n_reps == 8
         # Stratified jackknife df = #PSUs - #strata (R degf; was total PSUs)
         assert rw.df == 6
         # (n_h - 1)/n_h per deleted-PSU replicate; 4 clusters per stratum
-        assert rw.rscales == (0.75,) * 8
+        assert rw.rep_coefs == (0.75,) * 8
 
     def test_mean_matches_r(self, jk_sample):
         r = jk_sample.estimation.mean("income", method="replication", drop_nulls=True)
@@ -74,29 +74,3 @@ class TestGeneratedJknMatchesR:
         t = jk_sample.estimation.total("income", method="replication", drop_nulls=True)
         assert t.estimates[0].est == pytest.approx(114554002.6538, rel=1e-9)
         assert t.estimates[0].se == pytest.approx(18830996.1797964, rel=REL)
-
-    def test_user_rscales_override(self, jk_sample):
-        """User-supplied rscales flow through: doubling them scales the
-        variance by 2 (SE by sqrt 2)."""
-        import math
-
-        base = jk_sample.estimation.mean("income", method="replication", drop_nulls=True)
-        rw = jk_sample.design.rep_wgts
-        boosted = Sample(
-            jk_sample.data,
-            jk_sample.design.update_rep_weights(
-                method=rw.method,
-                prefix=rw.prefix,
-                n_reps=rw.n_reps,
-                df=rw.df,
-                rscales=tuple(2.0 * r for r in rw.rscales),
-            ),
-        )
-        r2 = boosted.estimation.mean("income", method="replication", drop_nulls=True)
-        assert r2.estimates[0].se == pytest.approx(
-            base.estimates[0].se * math.sqrt(2.0), rel=1e-12
-        )
-
-
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])

--- a/packages/svy/tests/svy/estimation/test_rep_domain_df.py
+++ b/packages/svy/tests/svy/estimation/test_rep_domain_df.py
@@ -55,7 +55,7 @@ def _taylor_sample(data):
 
 
 def _rep_sample(data, df=None):
-    rep = RepWeights(method="jackknife", prefix="rw", n_reps=N_REPS, df=df, rscales=RSCALES)
+    rep = RepWeights(method="jackknife", prefix="rw", n_reps=N_REPS, df=df, scale=RSCALES)
     return Sample(data, Design(wgt="w", stratum="stratum", psu="psu_id", rep_wgts=rep))
 
 

--- a/packages/svy/tests/svy/estimation/test_replicate_coefficients.py
+++ b/packages/svy/tests/svy/estimation/test_replicate_coefficients.py
@@ -79,9 +79,9 @@ def test_variant_coefficients_match_the_kernel_formulas(variant, expected):
     assert variant.coefficients() == pytest.approx(expected, rel=1e-15)
 
 
-def test_user_rscales_take_precedence_over_the_method_default():
+def test_user_scale_takes_precedence_over_the_method_default():
     rs = tuple(np.linspace(0.5, 1.5, 10))
-    assert JackknifeWgts(prefix="w", n_reps=10, rscales=rs).coefficients() == pytest.approx(
+    assert BootstrapWgts(prefix="w", n_reps=10, scale=rs).coefficients() == pytest.approx(
         list(rs)
     )
 

--- a/packages/svy/tests/svy/regression/test_glm_design_gaps.py
+++ b/packages/svy/tests/svy/regression/test_glm_design_gaps.py
@@ -124,8 +124,8 @@ class TestReplicateGLM:
         from collections import Counter
 
         n_h = Counter(strata)
-        rscales = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
-        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, rscales=rscales)
+        coefs = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
+        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, scale=coefs)
         s = Sample(df, Design(stratum="stype", wgt="pw", rep_wgts=rw))
         m = s.glm.fit(y="api00", x=["ell", "meals"])
         got = [c.se for c in m.fitted.coefs]
@@ -141,8 +141,8 @@ class TestReplicateGLM:
         from collections import Counter
 
         n_h = Counter(strata)
-        rscales = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
-        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, rscales=rscales)
+        coefs = tuple((n_h[h] - 1.0) / n_h[h] for h in strata)
+        rw = RepWeights(method="jackknife", prefix="jw", n_reps=n, scale=coefs)
         s_rep = Sample(df, Design(stratum="stype", wgt="pw", rep_wgts=rw))
         s_tay = Sample(api_strat, Design(stratum="stype", wgt="pw"))
         se_rep = [c.se for c in s_rep.glm.fit(y="api00", x=["ell", "meals"]).fitted.coefs]


### PR DESCRIPTION
Closes #7.

## The regression

Before #131 the user-supplied replicate coefficient was applied at one site in the kernel:

```rust
let rep_coefs = rscales.map(<[f64]>::to_vec)
    .unwrap_or_else(|| replicate_coefficients(method, n_reps, fay_coef));
```

Method-agnostic by construction. #131 moved that computation into Python and scattered it across four per-variant `coefficients()` methods, which gave every method its own chance to forget. Three of four forgot — `bootstrap`, `BRR` and `SDR` accepted the field, stored it, length-checked it, then discarded it, so a bootstrap declared with a producer's published scale silently returned the `1/R` answer.

`coefficients()` is now a template method on the shared base. The override is resolved there, and the variants implement only `_default_coefficients()` — they never see it, so a new variant cannot regress this again.

**No published standard error changes.** #131 landed after `svy-v0.24.1` and was never released.

## What #7 asked for

```python
svy.RepWeights(method="bootstrap", prefix="REP", n_reps=200, scale=0.0065365334145709)
```

Scalar or sequence, validated at construction. svy's `scale` is R `svrepdesign`'s `scale × rscales` folded into one field. `examples/ict_households.py` drops the `sqrt(scale * R)` workaround — that file also could not run as committed, since `ict_design` was used while its definition sat commented out.

The issue's own implementation notes are obsolete and its "out of scope: BRR, SDR, Jackknife" line is backwards; jackknife is where the override was already implemented and most load-bearing. Its body should be rewritten or closed rather than followed.

## Finishing the migration

`#131` replaced the estimation-method enum with real types, but the string discriminant survived and the code that mattered kept reading it. `_RepWgtsBase.method` documented itself as display-only while eight sites used it for dispatch.

- Seven sites in `weighting/` rebuilt a design by round-tripping the type through its own tag, re-listing by hand every field that had to survive — which is how `kind`, `scale` and `padding` could vanish across a poststratification. Now `msgspec.structs.replace`.
- `GLM._rep_coefficients` re-derived coefficients by substring-matching a stringified tag (`if "boot" in m`) and honoured the override for every method while the estimation path did not, so one `Design` produced differently scaled SEs from `glm()` and from `estimation.mean()`. Deleted.
- `RepWeights` is now a forwarding parse door. `_reject` and the four-branch dispatch are gone: msgspec already refuses a foreign keyword on every path, including direct construction, which the hand-rolled guard never covered.

## Two coefficient channels

They split on **who supplied the values** — the one axis that is verifiable. "Custom versus standard" is not: a user declaring stratified JKn supplies the *standard* coefficient, because svy cannot derive it from replicate weights alone.

| field | meaning | written by |
| --- | --- | --- |
| `scale` | the user asserted these | users only |
| `rep_coefs` | svy computed them and cannot recompute them | `create_jk_wgts`, the JKn derivation |

## Jackknife `kind`

`paired: bool` folded JK1 and JKn together into `False`, but those two have different coefficients, so the boolean could not express the distinction the coefficient logic depends on. It is now `"jk1" | "jkn" | "jk2" | None`, using R's `svrepdesign(type=)` names.

| declared | design info | outcome |
| --- | --- | --- |
| `None` | none | `(R−1)/R`, silent — unchanged |
| `None` | stratified | `(R−1)/R` + warn |
| `"jk1"` | any | `(R−1)/R` |
| `"jk2"` | any | `1.0` — closed form |
| `"jkn"` | stratum/psu | derived |
| `"jkn"` | none, no `scale` | raises |

An unmet claim fails; an absent one falls back. `None` is not `"jk1"` — same number, different statement, and svy claims only what it knows or was told. A producer withholding design variables is not evidence that the weights are unstratified.

Derivation is limited to balanced designs, where the coefficient is uniform and the replicate-to-stratum mapping does not matter; that covers the paired-PSU designs that dominate real JKn files. `create_jk_wgts(paired=...)` keeps its released name and resolves the three-way kind itself — and the collapse is exact, not heuristic: JKn's `(n_h−1)/n_h` over a single stratum of *n* PSUs gives *R = n* replicates each at `(n−1)/n`, which **is** the JK1 global.

## Verification

R goldens are unchanged throughout. `test_jackknife_fixture_jkn.py` now reaches them through the derivation instead of hand-fed coefficients:

```
derived rep_coefs : (0.5, ..., 0.5)
scale             : None
mean   54687.648908800125    R survey 4.5: 54687.648909
se      1008.4721692881396   R survey 4.5:  1008.4721693
```

Estimation and regression agree, at `sqrt(0.05 / (1/40))`:

```
expected ratio      1.4142135623730951
estimation ratio    1.4142135623730951
regression ratios   [1.4142135623730951, 1.4142135623730951]
```

3067 passed, 1 skipped. ruff clean. mypy on `repwgts.py` 25 → 23.

## Breaking changes

Each checked against `svy-v0.24.1` rather than assumed:

- `isinstance(x, svy.RepWeights)` and `x: svy.RepWeights` — broken by #131 and unrecorded until now. Use `svy.RepWgts`.
- `RepWeights(rscales=...)` **and** `Design.update_rep_weights(rscales=...)` — `rscales` was released on both surfaces; now `scale=` or `rep_coefs=`.
- `RepWeights(method="bootstrap", fay_coef=0.0)` — a stored no-op on the flat struct, now refused with the owning variant named.

No released user's numbers change. The one path that could have — a jackknife with design variables and no declared kind — still gets `(R−1)/R`, because derivation fires only on an explicit `kind="jkn"`.

## Left for a follow-up

- `Design.update_rep_weights` and `make_rep_weights` have no callers left in `src/`, but both are released API and `update_rep_weights` is documented, so they stay until that is a deliberate decision. 38 test sites use it as setup convenience.
- Unbalanced JKn coefficients are not derived — the replicate-to-stratum mapping is the producer's ordering. `scale` covers it.
- `BootstrapWgts.kind` is provenance only; a kind whose scale differs (svrep's generalized bootstrap, `tau^2/B`) would branch in `_default_coefficients()`.
- `Literal` kinds do **not** catch typos under this repo's mypy — it does not model msgspec Structs (the file's baseline includes `Unexpected keyword argument "tag_field"`). They buy one definition instead of two, and `decode`/`convert` validation. Getting the static check would need a msgspec plugin or pyright.
