### PR TITLE
Drop make_rep_weights, thin update_rep_weights

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -67,7 +67,13 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 - **Non-default variance coefficients are visible.** `scale` and `rep_coefs` did not appear in `repr` or `print(design)` at all. A non-standard coefficient is what a reviewer or replicator most needs to see and is set rarely, so rare-and-silent was the wrong combination. A uniform vector prints as the scalar it is.
 
+- **`Design.update_rep_weights` is a third the size, with the same behaviour.** It resolved nine sentinel parameters by hand and rebuilt the variant from a method name, because seven internal callers needed exactly that. They now use `msgspec.structs.replace`, so it keeps only the two jobs `replace` cannot do — changing the method, and creating weights where there are none. Unchanged for callers: the same signature, the same first-time error, and a variant-specific field still carries only within the same method.
+
 - **`import_labels_from_svyio_meta` now requires the frame** the metadata describes as its third argument. Resolving a measurement type depends on how well the value labels cover the observed values, which cannot be judged without the data. It is required rather than optional on purpose: an omitted frame would silently fall back to the very behavior this release fixes. The function is internal (`svy.engine.io`, not exported from the top-level `svy` namespace) and had a single production call site.
+
+### Removed
+
+- **`svy.core.design.make_rep_weights`.** A strictly weaker duplicate of `svy.RepWeights` — same job, but only four of the parameters, so it silently dropped `scale`, `rep_coefs` and `kind`. It was never exported from `svy` or `svy.core`, so it was reachable only as `from svy.core.design import make_rep_weights`, and had no callers in the package. Use `svy.RepWeights(method=..., prefix=..., n_reps=...)`, which takes the same three positionally.
 
 ## [0.24.1] — 2026-08-11
 

--- a/packages/svy/src/svy/core/design.py
+++ b/packages/svy/src/svy/core/design.py
@@ -15,10 +15,9 @@ from typing import (
     overload,
 )
 
+import msgspec
+
 from svy.core.repwgts import (
-    BootstrapWgts,
-    BrrWgts,
-    JackknifeWgts,
     RepWeights,
     RepWgts,
     _RepWgtsBase,
@@ -93,55 +92,6 @@ class PopSize(NamedTuple):
 # =============================================================================
 # Replicate Weights (Strict Configuration)
 # =============================================================================
-
-
-def make_rep_weights(
-    method: Literal["brr", "bootstrap", "jackknife", "sdr"],
-    prefix: str,
-    n_reps: int,
-    *,
-    fay_coef: float = 0.0,
-    df: int | None = None,
-    padding: int | None = None,
-) -> RepWgts:
-    """
-    Create a RepWeights object using a plain string method name.
-
-    Parameters
-    ----------
-    method : str
-        Replication method: ``'brr'``, ``'bootstrap'``, ``'jackknife'`` (or ``'jk'``),
-        or ``'sdr'``.
-    prefix : str
-        Column prefix for replicate weight columns (e.g. ``'btwt'`` for btwt1, btwt2, ...).
-    n_reps : int
-        Number of replicate weights (>= 2).
-    fay_coef : float, default 0.0
-        Fay coefficient for BRR with Fay's method.
-    df : int | None, default None
-        Degrees of freedom override. None = auto-calculate from data.
-    padding : int | None, default None
-        Zero-padding width for column names. None = auto-detect.
-
-    Returns
-    -------
-    RepWeights
-
-    Examples
-    --------
-    >>> rw = make_rep_weights("jackknife", prefix="jk_", n_reps=80)
-    >>> rw = make_rep_weights("brr", prefix="brr_", n_reps=32, fay_coef=0.5)
-    """
-    return RepWeights(
-        method=method,
-        prefix=prefix,
-        n_reps=n_reps,
-        df=df,
-        padding=padding,
-        # Only BRR has one; forwarding a 0.0 to any other method would be
-        # sending a Fay claim that is not being made.
-        **({"fay_coef": fay_coef} if fay_coef else {}),
-    )
 
 
 # =============================================================================
@@ -414,95 +364,62 @@ class Design:
         rep_coefs: tuple[float, ...] | None | _MissingType = _MISSING,
         kind: str | None | _MissingType = _MISSING,
     ) -> Self:
-        """
-        Return a new Design with selected RepWeights fields updated.
-        Ensures strict validity: if creating weights for the first time,
-        mandatory fields (method, prefix, n_reps) must be provided.
-        """
-        # 1. Quick exit if no arguments provided
-        if (
-            isinstance(prefix, _MissingType)
-            and isinstance(method, _MissingType)
-            and isinstance(n_reps, _MissingType)
-            and isinstance(fay_coef, _MissingType)
-            and isinstance(df, _MissingType)
-            and isinstance(padding, _MissingType)
-            and isinstance(scale, _MissingType)
-            and isinstance(rep_coefs, _MissingType)
-            and isinstance(kind, _MissingType)
-        ):
-            return self
+        """Return a new Design with selected RepWeights fields updated.
 
-        # 2. Explicitly handle method=None to clear weights
-        if method is None:
+        ``method=None`` clears the replicate weights. Creating them for the
+        first time requires ``method``, ``prefix`` and ``n_reps``; afterwards
+        each is taken from the current design unless named.
+
+        Internal code prefers
+        ``design.update(rep_wgts=msgspec.structs.replace(rw, ...))``, which is
+        the same operation without the string round-trip. This exists for
+        callers holding a method *name* rather than a variant.
+        """
+        supplied: dict[str, Any] = {
+            name: value
+            for name, value in (
+                ("method", method),
+                ("prefix", prefix),
+                ("n_reps", n_reps),
+                ("fay_coef", fay_coef),
+                ("df", df),
+                ("padding", padding),
+                ("scale", scale),
+                ("rep_coefs", rep_coefs),
+                ("kind", kind),
+            )
+            if not isinstance(value, _MissingType)
+        }
+        if not supplied:
+            return self
+        if "method" in supplied and supplied["method"] is None:
             return self.update(rep_wgts=None)
 
-        # 3. Get current state
         cur = self.rep_wgts
+        for name in ("method", "prefix", "n_reps"):
+            if name not in supplied:
+                if cur is None:
+                    raise ValueError(
+                        f"When initializing RepWeights for the first time, '{name}' is mandatory."
+                    )
+                supplied[name] = getattr(cur, name)
 
-        # 4. Resolve Values
+        method_name = supplied.pop("method")
 
-        def resolve_mandatory(arg_val: T | _MissingType, arg_name: str) -> T:
-            if not isinstance(arg_val, _MissingType):
-                return arg_val
-            if cur is not None:
-                return getattr(cur, arg_name)
-            raise ValueError(
-                f"When initializing RepWeights for the first time, '{arg_name}' is mandatory."
-            )
+        # Same method: `replace` preserves every field the caller did not name,
+        # including the variant's own, and re-runs the struct's validation.
+        if cur is not None and type(cur) is resolve_rep_variant(method_name):
+            return self.update(rep_wgts=msgspec.structs.replace(cur, **supplied))
 
-        # Resolve Mandatory Fields
-        resolved_method = resolve_mandatory(method, "method")
-        resolved_prefix = resolve_mandatory(prefix, "prefix")
-        resolved_n_reps = resolve_mandatory(n_reps, "n_reps")
-
-        # Resolve Optional Fields
-        if isinstance(fay_coef, _MissingType):
-            fay_coef = cur.fay_coef if cur else 0.0
-
-        if isinstance(df, _MissingType):
-            df = cur.df if cur else None
-
-        if isinstance(padding, _MissingType):
-            padding = cur.padding if cur else None
-
-        if isinstance(scale, _MissingType):
-            scale = cur.scale if cur else None
-
-        if isinstance(rep_coefs, _MissingType):
-            rep_coefs = cur.rep_coefs if cur else None
-
-        # 5. Create the new variant.
-        _variant = resolve_rep_variant(resolved_method)
-
-        # Variant-specific parameters carry over only within the same method:
-        # a bootstrap kind means nothing on a jackknife design.
-        _same = cur is not None and type(cur) is _variant
-        if isinstance(kind, _MissingType):
-            kind = getattr(cur, "kind", None) if _same else None
-
-        # Pass only what this variant carries. Sending a foreign parameter at
-        # its neutral value -- fay_coef=0.0 to a bootstrap -- would need the
-        # receiving end to treat that as "unset", which is the flat struct's
-        # habit, not something the union should have to accommodate.
-        variant_only: dict[str, object] = {}
-        if _variant is BrrWgts:
-            variant_only["fay_coef"] = fay_coef
-        if _variant in (BootstrapWgts, JackknifeWgts) and kind is not None:
-            variant_only["kind"] = kind
-
-        updated_rep_wgts = RepWeights(
-            method=resolved_method,
-            prefix=resolved_prefix,
-            n_reps=resolved_n_reps,
-            df=df,
-            padding=padding,
-            scale=scale,
-            rep_coefs=rep_coefs,
-            **variant_only,
-        )
-
-        return self.update(rep_wgts=updated_rep_wgts)
+        # A different method, or none yet. The shared fields carry over; the
+        # outgoing variant's own do not, because a bootstrap kind means nothing
+        # on a jackknife. Anything named explicitly still applies to the new
+        # variant, and a parameter the new variant does not carry is refused
+        # rather than dropped.
+        if cur is not None:
+            for name in ("df", "padding", "scale", "rep_coefs"):
+                supplied.setdefault(name, getattr(cur, name))
+        return self.update(rep_wgts=RepWeights(method=method_name, **supplied))
 
     # -----------------------------
     # Internal Merge Logic

--- a/packages/svy/tests/svy/core/test_design2.py
+++ b/packages/svy/tests/svy/core/test_design2.py
@@ -1,7 +1,6 @@
 import polars as pl
 import pytest
 
-from svy.core.design import make_rep_weights
 from svy.core.sample import SVY_ROW_INDEX, Design, RepWeights, Sample
 
 
@@ -45,7 +44,7 @@ def design_ok() -> Design:
         ssu=None,
         pop_size=None,
         wr=False,
-        rep_wgts=make_rep_weights("brr", prefix="rep", n_reps=3),
+        rep_wgts=RepWeights("brr", prefix="rep", n_reps=3),
     )
 
 
@@ -106,17 +105,17 @@ def test_rep_weights_invalid_method():
 def test_rep_weights_n_reps_too_small():
     # n_reps must be >= 2
     with pytest.raises(ValueError, match="n_reps must be >= 2"):
-        make_rep_weights("brr", prefix="rep", n_reps=1)
+        RepWeights("brr", prefix="rep", n_reps=1)
 
 
 def test_rep_weights_invalid_fay_coef():
     with pytest.raises(ValueError, match="fay_coef cannot be negative"):
-        make_rep_weights("brr", prefix="rep", n_reps=10, fay_coef=-0.5)
+        RepWeights("brr", prefix="rep", n_reps=10, fay_coef=-0.5)
 
 
 def test_rep_weights_invalid_df():
     with pytest.raises(ValueError, match="df must be > 0"):
-        make_rep_weights("brr", prefix="rep", n_reps=10, df=0)
+        RepWeights("brr", prefix="rep", n_reps=10, df=0)
 
 
 def test_rep_weights_accepts_string_method():
@@ -143,7 +142,7 @@ def test_update_rep_weights_fresh_init_missing_args():
 
 def test_update_rep_weights_clearing():
     # Setting method=None should remove the weights
-    d = Design(rep_wgts=make_rep_weights("brr", prefix="r", n_reps=10))
+    d = Design(rep_wgts=RepWeights("brr", prefix="r", n_reps=10))
     d_cleared = d.update_rep_weights(method=None)
     assert d_cleared.rep_wgts is None
 

--- a/packages/svy/tests/svy/core/test_repweights_construction.py
+++ b/packages/svy/tests/svy/core/test_repweights_construction.py
@@ -30,7 +30,7 @@ import pytest
 
 import svy
 
-from svy.core.design import RepWeights, make_rep_weights
+from svy.core.design import RepWeights
 
 
 # -----------------------------------------------------------------------------
@@ -169,13 +169,13 @@ def test_repweights_remains_frozen_for_method():
 # -----------------------------------------------------------------------------
 
 
-def test_make_rep_weights_factory_with_string():
-    rw = make_rep_weights("bootstrap", prefix="bsrw", n_reps=1000)
+def test_factory_resolves_a_method_name():
+    rw = RepWeights("bootstrap", prefix="bsrw", n_reps=1000)
     assert rw.method == "Bootstrap"
 
 
-def test_make_rep_weights_factory_with_alias():
-    rw = make_rep_weights("jk", prefix="jkw_", n_reps=62)
+def test_factory_resolves_a_method_alias():
+    rw = RepWeights("jk", prefix="jkw_", n_reps=62)
     assert rw.method == "Jackknife"
 
 

--- a/packages/svy/tests/svy/core/test_repweights_integration.py
+++ b/packages/svy/tests/svy/core/test_repweights_integration.py
@@ -13,7 +13,7 @@ import pytest
 
 import svy
 
-from svy.core.design import make_rep_weights
+from svy.core.design import RepWeights
 from svy.errors import MethodError
 
 
@@ -37,7 +37,7 @@ def rep_sample():
             "rw4": [1.0] * 5,
         }
     )
-    rw = make_rep_weights("jackknife", prefix="rw", n_reps=4)
+    rw = RepWeights("jackknife", prefix="rw", n_reps=4)
     design = svy.Design(stratum="strat", psu="psu", wgt="w", rep_wgts=rw)
     return svy.Sample(df, design)
 

--- a/packages/svy/tests/svy/wrangling/test_wrangling_round8_fixes.py
+++ b/packages/svy/tests/svy/wrangling/test_wrangling_round8_fixes.py
@@ -17,7 +17,7 @@ import pytest
 
 import svy
 
-from svy.core.design import make_rep_weights
+from svy.core.design import RepWeights
 from svy.core.sample import Design, Sample
 from svy.errors import MethodError
 
@@ -87,7 +87,7 @@ def rep_sample():
             "rw3": [1.0] * 4,
         }
     )
-    rw = make_rep_weights("jackknife", prefix="rw", n_reps=3)
+    rw = RepWeights("jackknife", prefix="rw", n_reps=3)
     return Sample(df, Design(stratum="strat", psu="psu", wgt="w", rep_wgts=rw))
 
 
@@ -99,9 +99,7 @@ def test_partial_replicate_rename_raises(rep_sample):
 
 
 def test_full_replicate_rename_still_works(rep_sample):
-    out = rep_sample.wrangling.rename_columns(
-        {"rw1": "boot1", "rw2": "boot2", "rw3": "boot3"}
-    )
+    out = rep_sample.wrangling.rename_columns({"rw1": "boot1", "rw2": "boot2", "rw3": "boot3"})
     assert out.design.rep_wgts.prefix == "boot"
     assert set(out.design.rep_wgts.columns) <= set(out._data.columns)
 
@@ -186,16 +184,12 @@ class TestFilterNullPredicates:
         s = Sample(pl.DataFrame({"x": [1.0, None, 3.0]}))
         out = s.wrangling.filter_records(svy.col("x") > 2, negate=True)
         assert out._data.height == 1
-        assert any(
-            w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list()
-        )
+        assert any(w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list())
 
     def test_no_warning_without_nulls(self):
         s = Sample(pl.DataFrame({"x": [1.0, 3.0]}))
         out = s.wrangling.filter_records(svy.col("x") > 2)
-        assert not any(
-            w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list()
-        )
+        assert not any(w.code == "NULL_PREDICATE_ROWS_DROPPED" for w in out._warnings.list())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #137, which left both functions in place as a deliberate decision rather than a silent deletion. With the seven `weighting/` round-trips now using `msgspec.structs.replace`, neither had a caller left in the package.

## `make_rep_weights` — removed

A strictly weaker duplicate of `RepWeights`: same job, four of the parameters, so it silently dropped `scale`, `rep_coefs` and `kind` — the exact failure mode the tagged union exists to prevent.

It was never exported from `svy` or `svy.core`, so it was reachable only as `from svy.core.design import make_rep_weights`. Zero callers in the package; the 15 test call sites take `RepWeights` unchanged, since it accepts the same three arguments positionally.

## `Design.update_rep_weights` — kept, reimplemented

It stays. It is a public method on `Design`, and a caller holding a method *name* rather than a variant genuinely needs it — that is a permanent situation, not a transitional one.

What it did not need was 106 lines. Most of that was sentinel unwrapping across nine parameters, a `resolve_mandatory` closure, and a variant carry-over dance — all of which existed to serve the internal callers that #137 removed. It now keeps only the two jobs `replace` cannot do, and delegates the rest:

| case | handling |
| --- | --- |
| same method | `msgspec.structs.replace` — preserves every field the caller did not name, re-runs the struct's validation |
| different method, or none yet | shared fields carry; the outgoing variant's own do not |

**106 → 71 lines**, and `design.py` 852 → 769 overall.

## Behaviour is unchanged

Verified branch by branch against the old implementation:

```
same method  -> RepWeights(method=Bootstrap, prefix='x', n_reps=10, kind=poisson, scale=0.5, padding=3)
method swap  -> RepWeights(method=Jackknife, prefix='b', n_reps=10, scale=0.5, padding=3)
clear        -> None
no args      -> True                      # returns self
first-time   -> When initializing RepWeights for the first time, 'method' is mandatory.
create fresh -> RepWeights(method=BRR, prefix='r', n_reps=8, fay=0.5)
```

A same-method update keeps `kind`, `scale` and `padding` while changing `prefix`; a method swap drops the bootstrap `kind` — it means nothing on a jackknife — and keeps the shared fields; the first-time error is unchanged word for word.

**No test edits were needed for it.** All 38 call sites pass exactly as they were, which is the point: this is a reimplementation, not a redesign.

3067 passed, 1 skipped. ruff clean.
