### PR TITLE
release(svy): 0.25.0

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.25.0] — 2026-08-26
+
 ### Added
 
 - **Replicate weights carry the units they were built from.** `stratum` and `psu` on every variant name the columns the replicates were drawn over — a separate question from `Design.stratum`/`Design.psu`, which describe the analysis design and are what Taylor linearizes over. Producers collapse strata and suppress PSUs for disclosure, publishing a distinct pair (`VARSTRAT`/`VARUNIT` and its many spellings) alongside — or instead of — the design variables:
@@ -568,7 +570,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.24.1...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.25.0...HEAD
+[0.25.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.25.0
 [0.24.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.1
 [0.24.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.0
 [0.23.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.23.0

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.24.1"
+version = "0.25.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -28,8 +28,8 @@ dependencies = [
   "msgspec>=0.21.0",
   "polars[pyarrow]>=1.33.1",
   "scipy>=1.13",
-  "svy-io>=0.2.0,<0.3.0",
-  "svy-rs>=0.14.0,<0.15.0",
+  "svy-io>=0.3.0,<0.4.0",
+  "svy-rs>=0.15.0,<0.16.0",
 ]
 
 [project.urls]

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -133,7 +133,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.24.1"
+__version__ = "0.25.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.24.1"
+version = "0.25.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Release wrapper for `svy` 0.25.0. No behaviour changes — the replication work it documents is already on `main`.

## Contents

- Version bumped in both places: `pyproject.toml` and the hardcoded `src/svy/__init__.py` `__version__`.
- `[Unreleased]` promoted to `## [0.25.0] — 2026-08-26`, fresh empty Unreleased, footer compare links updated. All **36 entries carry over unchanged** — the block already had one section per type, so nothing is restructured.
- Companion pins raised.

## The pin raise is required, not housekeeping

```
svy-rs>=0.15.0,<0.16.0    (was >=0.14.0,<0.15.0)
svy-io>=0.3.0,<0.4.0      (was >=0.2.0,<0.3.0)
```

The Poisson bootstrap calls `svy_rs._internal.create_poisson_bootstrap_wgts`, which does not exist in svy-rs 0.14.0. Worse, the import guard in `weighting/replication.py` wraps six symbols in one `try` and nulls **all** of them on any `ImportError` — so one missing symbol disables every Rust-backed replicate-weight generator, and the user gets a bare `AssertionError` with no message, no version, and no mention of svy-rs.

Measured against the published companions:

| Companions | Result |
|---|---|
| svy-rs 0.14.0 / svy-io 0.2.0 | **201 failed, 12 errors** |
| svy-rs 0.15.0 / svy-io 0.3.0 | **3120 passed, 1 skipped** |

The editable workspace override hides this entirely during local development, which is why it did not surface until the wheel was installed into a clean venv.

## Verification

Built the wheel and installed it into a clean venv: the pins resolve to svy-rs 0.15.0 and svy-io 0.3.0 from PyPI, `svy.__version__` reports `0.25.0`, and `create_bs_wgts(kind="poisson")` runs end to end — the exact path that was broken.

## Two things deliberately left out

**Formatting.** `make fmt` fails on 19 files, three of which (`core/repwgts.py`, `core/sample.py`, `tests/.../test_rust_import_fallback.py`) came in with the replication work. They are already on `main`, so the drift is not introduced here, and reflowing them would put unrelated churn in a release commit. `fmt` is not a CI gate. Worth a separate cleanup pass over all 19.

**Two environment-dependent test failures**, neither a product bug, both found while verifying against published companions:

- `test_expr.py::test_explode` fails on **polars 1.44.1** (what a fresh install gets; the lock pins 1.39.3). Polars warns that `empty_as_null` flips its default in Polars 2.0, and the strict `filterwarnings` promotes it to an error. A real forward-compat signal — `polars>=1.33.1` has no upper bound — but a warning today, not a break.
- `test_describe.py::test_describe_str_and_repr_dont_crash` requires `rich`, which lives in the optional `report` extra, but is not marked `@pytest.mark.optional` despite the repo defining that marker. It fails for anyone installing plain `svy` and running the suite.