### PR TITLE
fix(weighting)!: stop mutating the caller's Sample, and two defects it was hiding

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -10,6 +10,25 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Fixed
 
+- **BRR validated its strata in two passes, and sent one of them to the wrong subsystem.** `create_brr_wgts` checked `< 2` PSUs first, raising `INSUFFICIENT_PSU`, and only then checked for odd counts. A frame carrying both therefore reported the lone-PSU stratum, and revealed the odd ones on the next run — one class of problem per attempt, on a validation that could have been answered in full the first time.
+
+  The split also borrowed a question that is not BRR's. A stratum with one PSU is a **singleton**, which matters to Taylor linearization and has its own subsystem — `Sample.singleton`, with `collapse`, `combine`, `pool`, `certainty` — none of which the hint mentioned; it said "Combine small strata or check design specification." For BRR the count is not a singleton question at all: a stratum of 1 and a stratum of 3 fail for exactly the same reason, a PSU with no partner.
+
+  BRR now asks one question — is the PSU count a multiple of 2 — and reports every stratum that fails it in a single error, naming each with its count:
+
+  ```
+  ❌ BRR needs 2 PSUs per variance stratum [ODD_PSU_COUNT]
+  BRR pairs PSUs into variance strata of exactly 2. Found 3 strata whose PSU
+  count is not a multiple of 2, leaving a PSU with no partner.
+  - got: a=1, b=3, c=5
+  ```
+
+  "Multiple of 2" rather than "equal to 2" because `create_brr_wgts` pairs: a 4-PSU stratum becomes two variance strata of 2 and is valid. `INSUFFICIENT_PSU` is now the paired jackknife's alone, which is the one method that genuinely distinguishes the two — it absorbs an odd count into a triplet but still cannot pair a lone PSU.
+
+- **The odd-PSU BRR error pointed at an API that no longer exists.** Its hint read `Use method='jk2' which allows 2-3 PSUs per stratum`. `method='jk2'` was `create_variance_strata`'s parameter — a function removed in 0.25.0 — and `method` is not a parameter of `create_brr_wgts` either, so the one line telling you what to do instead named a parameter of a gone function on a function that never had it. "2-3 PSUs per stratum" was equally stale: `create_jk_wgts(paired=True)` pairs any count ≥ 2 and absorbs an odd one into a triplet.
+
+  The hint now names `create_jk_wgts(paired=True)`, says why BRR cannot do the same, and tells anyone who needs BRR specifically to fix *every* stratum listed rather than one. Its test asserted `pytest.raises(Exception)` and nothing more, which is how the text drifted unnoticed; it now pins the code, the `where`, and that the remedy names a real API.
+
 - **Regenerating replicate weights left the previous method's design in place.** `create_brr_wgts` and `create_jk_wgts` recorded their result with `Design.fill_missing(rep_wgts=…)`, which by definition only fills a field that is currently `None` — so once any replicate design existed, the record of what had just been built was silently dropped. `create_bs_wgts` and `create_sdr_wgts` used `Design.update` and were unaffected, which is the whole of the difference: it was an inconsistency inherited from the monorepo migration, never a decision.
 
   Building a second set of replicates therefore wrote the new columns and kept the first method's metadata — and estimation reads the metadata, not the columns:

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,22 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Fixed
+
+- **Regenerating replicate weights left the previous method's design in place.** `create_brr_wgts` and `create_jk_wgts` recorded their result with `Design.fill_missing(rep_wgts=…)`, which by definition only fills a field that is currently `None` — so once any replicate design existed, the record of what had just been built was silently dropped. `create_bs_wgts` and `create_sdr_wgts` used `Design.update` and were unaffected, which is the whole of the difference: it was an inconsistency inherited from the monorepo migration, never a decision.
+
+  Building a second set of replicates therefore wrote the new columns and kept the first method's metadata — and estimation reads the metadata, not the columns:
+
+  ```python
+  s = s.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
+  s = s.weighting.create_jk_wgts(rep_prefix="jk")
+  # before: 33 jk* columns in the frame, design.rep_wgts reading
+  #         method=Bootstrap prefix='bs' n_reps=10.
+  #         mean(method="replication") -> Estimate: MEAN (BOOTSTRAP), off `bs*`.
+  ```
+
+  Unlike the mutation defect fixed alongside it, this one fired on the plain `s = s.weighting.…()` idiom, in both orders, and switching methods mid-analysis is exactly when someone does it — comparing a jackknife against a bootstrap, or moving to JK2 after seeing the replicate count. Both now use `update`: the design describes the columns that were just written, and a declaration that no longer matches them is replaced rather than preserved.
+
 ### Changed
 
 - **BREAKING: `Sample.weighting` no longer mutates the sample you call it on.** All eleven transforming methods — the four `create_*_wgts`, `adjust`, `normalize`, `poststratify`, `rake`, `calibrate`, `calibrate_matrix`, `trim` — now return a new `Sample` and take `inplace: bool = False` to ask for the old behaviour. Both branches return a `Sample`, so chaining is unchanged and `s = s.weighting.…()` keeps working exactly as before.

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,26 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **BREAKING: `Sample.weighting` no longer mutates the sample you call it on.** All eleven transforming methods — the four `create_*_wgts`, `adjust`, `normalize`, `poststratify`, `rake`, `calibrate`, `calibrate_matrix`, `trim` — now return a new `Sample` and take `inplace: bool = False` to ask for the old behaviour. Both branches return a `Sample`, so chaining is unchanged and `s = s.weighting.…()` keeps working exactly as before.
+
+  This is not a new convention: all 19 `wrangling` methods already take `inplace: bool = False` and default to copying, and `singleton`'s five transforms always return a new `Sample`. `weighting` was the only namespace that mutated unconditionally, and the only one with no way to ask for a copy — `grep -rn inplace src/svy/` hit nothing outside `wrangling/`.
+
+  The reassignment idiom hid it, so it surfaced only when two variants branched off one sample — which is what a method comparison, a sensitivity check, or a docs page does:
+
+  ```python
+  boot = base.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
+  jack = base.weighting.create_jk_wgts(rep_prefix="jk")
+  # before: boot is jack is base. 33 jk* columns in the frame, and a design
+  #         still reading method=Bootstrap prefix='bs' -- so an estimate off
+  #         `jack` silently used the bootstrap columns and coefficients.
+  ```
+
+  **What breaks:** code that called a weighting method and then read the receiver without capturing the return. Add `inplace=True`, or capture the result. Code already written as `s = s.weighting.…()` needs no change.
+
+  The isolation covers diagnostics as well as data: an operation that raises under the default leaves the caller's warning store untouched, because "this call had no effect on my sample" is only true if it covers everything. The error is still raised and still emitted to the log; `inplace=True` is how you ask for the warning to land on your sample.
+
 ## [0.25.0] — 2026-08-26
 
 ### Added

--- a/packages/svy/src/svy/core/sample.py
+++ b/packages/svy/src/svy/core/sample.py
@@ -1126,6 +1126,21 @@ class Sample:
         new._warnings = copy.deepcopy(self._warnings)
         return new
 
+    def _fork(self) -> "Sample":
+        """Return an independent copy carrying the same data, for callers that
+        build their result by rebinding ``_data``/``_design`` as they go.
+
+        ``_replace_data`` covers the case where the new frame is already in
+        hand. The weighting operations are the other shape: each one rebinds
+        ``sample._data`` and ``sample._design`` several times over the course of
+        a single call, so the copy has to exist *before* the work starts for
+        those rebinds to land somewhere private. Sharing the frame object is
+        safe because nothing in ``weighting/`` mutates a frame in place -- every
+        step goes through ``with_columns``/``hstack``/``filter``, which return
+        new frames -- and the Design is frozen.
+        """
+        return self._replace_data(self._data)
+
     def _remove_invalid_weight(
         self, *, df: pl.DataFrame | None = None, wgt_col: str | None = None
     ) -> tuple[pl.DataFrame, dict[str, int]]:

--- a/packages/svy/src/svy/weighting/base.py
+++ b/packages/svy/src/svy/weighting/base.py
@@ -46,6 +46,18 @@ class Weighting:
     def __init__(self, sample: Any) -> None:
         self._sample = sample
 
+    def _target(self, inplace: bool) -> Any:
+        """The sample this operation works on: the caller's, or a private fork.
+
+        Every function in ``weighting/`` builds its result by rebinding
+        ``sample._data`` and ``sample._design`` as it goes, so the fork has to be
+        made here, before the work starts, rather than at the end the way
+        ``wrangling._helpers._resolve_target`` does it. Same contract either way:
+        ``inplace=False`` leaves the caller's sample untouched, ``inplace=True``
+        rewrites it, and both return a ``Sample`` so chaining is unaffected.
+        """
+        return self._sample if inplace else self._sample._fork()
+
     # ------------------------------------------------------------------ #
     # Variance strata / replicate weights
     # ------------------------------------------------------------------ #
@@ -63,9 +75,10 @@ class Weighting:
         fay_coef: float = 0.0,
         rstate: int | None = None,
         drop_nulls: bool = False,
+        inplace: bool = False,
     ) -> Any:
         return _create_brr_wgts(
-            self._sample,
+            self._target(inplace),
             n_reps,
             stratum=stratum,
             psu=psu,
@@ -90,9 +103,10 @@ class Weighting:
         rep_prefix: str | None = None,
         rstate: int | None = None,
         drop_nulls: bool = False,
+        inplace: bool = False,
     ) -> Any:
         return _create_jk_wgts(
-            self._sample,
+            self._target(inplace),
             paired=paired,
             stratum=stratum,
             psu=psu,
@@ -114,9 +128,10 @@ class Weighting:
         rep_prefix: str | None = None,
         drop_nulls: bool = False,
         rstate: RandomState = None,
+        inplace: bool = False,
     ) -> Any:
         return _create_bs_wgts(
-            self._sample,
+            self._target(inplace),
             n_reps,
             kind=kind,
             stratum=stratum,
@@ -134,9 +149,10 @@ class Weighting:
         rep_prefix: str | None = None,
         order_col: str | None = None,
         drop_nulls: bool = False,
+        inplace: bool = False,
     ) -> Any:
         return _create_sdr_wgts(
-            self._sample,
+            self._target(inplace),
             n_reps,
             psu=psu,
             rep_prefix=rep_prefix,
@@ -160,9 +176,10 @@ class Weighting:
         update_design_wgts: bool = True,
         respondents_only: bool = True,
         trimming: TrimConfig | None = None,
+        inplace: bool = False,
     ) -> Any:
         return _adjust(
-            self._sample,
+            self._target(inplace),
             resp_status,
             by,
             resp_mapping=resp_mapping,
@@ -186,9 +203,10 @@ class Weighting:
         wgt_name: str = "norm_wgt",
         ignore_reps: bool = False,
         update_design_wgts: bool = True,
+        inplace: bool = False,
     ) -> Any:
         return _normalize(
-            self._sample,
+            self._target(inplace),
             controls,
             by=by,
             wgt_name=wgt_name,
@@ -211,9 +229,10 @@ class Weighting:
         update_design_wgts: bool = True,
         strict: bool = True,
         trimming: TrimConfig | None = None,
+        inplace: bool = False,
     ) -> Any:
         return _poststratify(
-            self._sample,
+            self._target(inplace),
             controls,
             factors=factors,
             by=by,
@@ -257,9 +276,10 @@ class Weighting:
         update_design_wgts: bool = True,
         strict: bool = True,
         trimming: TrimConfig | None = None,
+        inplace: bool = False,
     ) -> Sample:
         return _rake(
-            self._sample,
+            self._target(inplace),
             controls=controls,
             factors=factors,
             wgt_name=wgt_name,
@@ -322,9 +342,10 @@ class Weighting:
         ignore_reps: bool = False,
         strict: bool = True,
         trimming: TrimConfig | None = None,
+        inplace: bool = False,
     ) -> Any:
         return _calibrate(
-            self._sample,
+            self._target(inplace),
             controls=controls,
             by=by,
             scale=scale,
@@ -351,9 +372,10 @@ class Weighting:
         ignore_reps: bool = False,
         strict: bool = True,
         trimming: TrimConfig | None = None,
+        inplace: bool = False,
     ) -> Any:
         return _calibrate_matrix(
-            self._sample,
+            self._target(inplace),
             aux_vars=aux_vars,
             control=control,
             by=by,
@@ -383,9 +405,11 @@ class Weighting:
         tol: float = 1e-6,
         wgt_name: str | None = "trim_wgt",
         update_design_wgts: bool = True,
+        *,
+        inplace: bool = False,
     ) -> "Sample":
         return _trim(
-            self._sample,
+            self._target(inplace),
             upper=upper,
             lower=lower,
             by=by,

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -84,6 +84,26 @@ def _as_recorded(col: str | tuple[str, ...] | None) -> str | tuple[str, ...] | N
     return col if isinstance(col, (str, tuple)) else None
 
 
+def _n_strata(n: int) -> str:
+    """``n stratum`` / ``n strata``.
+
+    The package spells this ``singleton PSU(s)`` elsewhere, but ``stratum`` is
+    irregular so the ``(s)`` suffix does not apply.
+    """
+    return f"{n} stratum" if n == 1 else f"{n} strata"
+
+
+def _fmt_strata(items: list, limit: int = 5) -> str:
+    """The offending strata, saying how many were withheld rather than ``...``.
+
+    Every one of these has to be fixed individually, so a bare ellipsis hides
+    the part of the job the reader still has to go and find.
+    """
+    shown = ", ".join(f"{name}={count}" for name, count in items[:limit])
+    extra = len(items) - limit
+    return shown if extra <= 0 else f"{shown} (+{extra} more)"
+
+
 def _pair_variance_strata(
     sample: Sample,
     *,
@@ -202,37 +222,55 @@ def _pair_variance_strata(
     unique_orig, counts = np.unique(orig_strata, return_counts=True)
     stratum_counts = dict(zip(unique_orig.tolist(), counts.tolist()))
 
-    small_strata = [(s, c) for s, c in stratum_counts.items() if c < 2]
-    if small_strata:
-        raise DimensionError(
-            title="Insufficient PSUs per stratum",
-            detail=(
-                f"All strata must have at least 2 PSUs. "
-                f"Found {len(small_strata)} strata with fewer."
-            ),
-            code="INSUFFICIENT_PSU",
-            where=where,
-            param="stratum",
-            expected="≥2 PSUs per stratum",
-            got=f"{small_strata[:5]}{'...' if len(small_strata) > 5 else ''}",
-            hint="Combine small strata or check design specification.",
-        )
-
     if _method == "brr":
-        odd_strata = [(s, c) for s, c in stratum_counts.items() if c % 2 == 1]
-        if odd_strata:
+        # BRR's unit is the variance stratum, and it must hold exactly 2 PSUs --
+        # that is what a balanced half-sample selects from. So a stratum is
+        # usable iff its PSU count is a multiple of 2, and a stratum of 1 fails
+        # for the same reason a stratum of 3 does: a PSU with no partner.
+        #
+        # They used to be two guards, the `< 2` one raising first, so a frame
+        # with both reported only the singleton and revealed the odd strata on
+        # the next run. Treating 1 as a different kind of problem also borrowed
+        # a question that is not BRR's: a lone PSU in a stratum is a singleton,
+        # which matters to Taylor linearization and belongs to
+        # ``Sample.singleton``. Here it is simply not 2.
+        unpairable = [(s, c) for s, c in stratum_counts.items() if c % 2 != 0]
+        if unpairable:
             raise DimensionError(
-                title="Odd PSU counts for BRR",
+                title="BRR needs 2 PSUs per variance stratum",
                 detail=(
-                    f"BRR requires even number of PSUs per stratum. "
-                    f"Found {len(odd_strata)} strata with odd counts."
+                    f"BRR pairs PSUs into variance strata of exactly 2. "
+                    f"Found {_n_strata(len(unpairable))} whose PSU count is not "
+                    f"a multiple of 2, leaving a PSU with no partner."
                 ),
                 code="ODD_PSU_COUNT",
                 where=where,
                 param="stratum",
-                expected="Even PSU count per stratum",
-                got=f"{odd_strata[:5]}{'...' if len(odd_strata) > 5 else ''}",
-                hint="Use method='jk2' which allows 2-3 PSUs per stratum.",
+                expected="A multiple of 2 PSUs per stratum",
+                got=_fmt_strata(unpairable),
+                hint=(
+                    "create_jk_wgts(paired=True) pairs these strata itself and "
+                    "absorbs an odd count into a triplet. BRR cannot: its "
+                    "balanced half-samples need exactly 2 PSUs per variance "
+                    "stratum. If BRR is required, fix every stratum listed, not "
+                    "just one -- drop or combine a PSU so each count is even."
+                ),
+            )
+    else:  # jk2: absorbs an odd count into a triplet, but cannot pair a lone PSU
+        small_strata = [(s, c) for s, c in stratum_counts.items() if c < 2]
+        if small_strata:
+            raise DimensionError(
+                title="Insufficient PSUs per stratum",
+                detail=(
+                    f"All strata must have at least 2 PSUs. "
+                    f"Found {len(small_strata)} strata with fewer."
+                ),
+                code="INSUFFICIENT_PSU",
+                where=where,
+                param="stratum",
+                expected="≥2 PSUs per stratum",
+                got=f"{small_strata[:5]}{'...' if len(small_strata) > 5 else ''}",
+                hint="Combine small strata or check design specification.",
             )
 
     var_strata = np.empty(n_psus, dtype=np.int64)

--- a/packages/svy/src/svy/weighting/replication.py
+++ b/packages/svy/src/svy/weighting/replication.py
@@ -462,7 +462,11 @@ def create_brr_wgts(
     )
 
     _rec_stratum, _rec_psu = _as_recorded(strat_col), _as_recorded(psu_col)
-    sample._design = sample._design.fill_missing(
+    # `update`, not `fill_missing`: these columns were just written, so the
+    # design has to describe *them*. fill_missing is a no-op once rep_wgts is
+    # set, which left a second generator's columns in the frame under the first
+    # one's metadata -- and estimation reads the metadata.
+    sample._design = sample._design.update(
         rep_wgts=BrrWgts(
             prefix=rep_prefix,
             n_reps=n_reps_actual,
@@ -568,7 +572,8 @@ def create_jk_wgts(
         jk_kind = "jkn"
 
     _rec_stratum, _rec_psu = _as_recorded(strat_col), _as_recorded(psu_col)
-    sample._design = sample._design.fill_missing(
+    # `update`, not `fill_missing` -- see the note in create_brr_wgts.
+    sample._design = sample._design.update(
         rep_wgts=JackknifeWgts(
             prefix=rep_prefix,
             n_reps=n_reps,

--- a/packages/svy/tests/svy/weighting/test_replication_weights.py
+++ b/packages/svy/tests/svy/weighting/test_replication_weights.py
@@ -983,3 +983,81 @@ def test_bootstrap_kind_is_recorded_on_the_design(multi_psu_sample, pumf_like_sa
         n_reps=8, kind="poisson", rep_prefix="r", rstate=41
     )
     assert po._design.rep_wgts.kind == "poisson"
+
+
+# ===========================================================================
+# Regenerating replicate weights replaces the recorded design
+# ===========================================================================
+
+
+class TestRegeneratedDesignIsRecorded:
+    """A generator records the columns it just wrote.
+
+    ``create_brr_wgts`` and ``create_jk_wgts`` used ``Design.fill_missing``,
+    which is a no-op once ``rep_wgts`` is set, while ``create_bs_wgts`` and
+    ``create_sdr_wgts`` used ``Design.update``. So building a second set of
+    replicates wrote the new columns and kept the *first* method's metadata --
+    and estimation reads the metadata, not the columns.
+    """
+
+    def test_bootstrap_then_jackknife(self, simple_stratified_sample):
+        s = simple_stratified_sample.weighting.create_bs_wgts(n_reps=8, rep_prefix="bs", rstate=1)
+        s = s.weighting.create_jk_wgts(rep_prefix="jk")
+
+        rw = s._design.rep_wgts
+        assert rw.method == "Jackknife"
+        assert rw.prefix == "jk"
+        assert rw.n_reps == 6  # one per PSU
+        assert "jk1" in s._data.columns
+
+    def test_jackknife_then_bootstrap(self, simple_stratified_sample):
+        s = simple_stratified_sample.weighting.create_jk_wgts(rep_prefix="jk")
+        s = s.weighting.create_bs_wgts(n_reps=8, rep_prefix="bs", rstate=1)
+
+        rw = s._design.rep_wgts
+        assert rw.method == "Bootstrap"
+        assert rw.prefix == "bs"
+        assert rw.n_reps == 8
+
+    def test_jackknife_then_brr(self, simple_stratified_sample):
+        s = simple_stratified_sample.weighting.create_jk_wgts(rep_prefix="jk")
+        s = s.weighting.create_brr_wgts(rep_prefix="brr")
+
+        rw = s._design.rep_wgts
+        assert rw.method == "BRR"
+        assert rw.prefix == "brr"
+
+    def test_regenerating_the_same_method_updates_its_parameters(self, simple_stratified_sample):
+        s = simple_stratified_sample.weighting.create_jk_wgts(rep_prefix="jk")
+        s = s.weighting.create_jk_wgts(paired=True, rep_prefix="jk2")
+
+        rw = s._design.rep_wgts
+        assert rw.prefix == "jk2"
+        assert rw.kind == "jk2"
+        assert rw.n_reps == 3  # one per variance stratum, not per PSU
+
+    def test_estimation_uses_the_regenerated_design(self, simple_stratified_sample):
+        """The symptom: an estimate off the second design read the first's columns."""
+        s = simple_stratified_sample.weighting.create_bs_wgts(n_reps=8, rep_prefix="bs", rstate=1)
+        s = s.weighting.create_jk_wgts(rep_prefix="jk")
+
+        est = s.estimation.mean(y="y", method="replication")
+        assert "JACKKNIFE" in str(est)
+
+    def test_a_declared_design_is_replaced_by_what_was_generated(self, simple_stratified_sample):
+        """Generating weights overrides a declaration that no longer describes them."""
+        from svy.core.repwgts import BootstrapWgts
+
+        declared = simple_stratified_sample._design.update(
+            rep_wgts=BootstrapWgts(prefix="declared", n_reps=4)
+        )
+        s = Sample(
+            data=simple_stratified_sample._data.with_columns(
+                [pl.lit(1.0).alias(f"declared{i}") for i in range(1, 5)]
+            ),
+            design=declared,
+        )
+        s = s.weighting.create_jk_wgts(rep_prefix="jk")
+
+        assert s._design.rep_wgts.method == "Jackknife"
+        assert s._design.rep_wgts.prefix == "jk"

--- a/packages/svy/tests/svy/weighting/test_replication_weights.py
+++ b/packages/svy/tests/svy/weighting/test_replication_weights.py
@@ -165,8 +165,116 @@ class TestBRRWeights:
             sample.weighting.create_brr_wgts()
 
     def test_brr_rejects_odd_psu_count(self, odd_psu_sample):
-        with pytest.raises(Exception):
+        with pytest.raises(DimensionError) as exc:
             odd_psu_sample.weighting.create_brr_wgts()
+
+        err = exc.value
+        assert err.code == "ODD_PSU_COUNT"
+        assert err.where == "Sample.weighting.create_brr_wgts"
+
+        # The remedy has to name an API that exists. This hint used to read
+        # "Use method='jk2'", which was create_variance_strata's parameter --
+        # a function removed in 0.25.0, and `method` is not a parameter of
+        # create_brr_wgts either.
+        assert "create_jk_wgts(paired=True)" in err.hint
+        assert "method=" not in err.hint
+        assert "create_variance_strata" not in err.hint
+
+        # More than one stratum can be at fault, and each needs its own fix,
+        # so the remedy must not read as one PSU overall.
+        assert "every stratum" in err.hint
+
+    @pytest.mark.parametrize(
+        "n_odd_strata, expected_count_phrase",
+        [(1, "Found 1 stratum whose"), (3, "Found 3 strata whose")],
+    )
+    def test_odd_psu_message_agrees_in_number(self, n_odd_strata, expected_count_phrase):
+        """`stratum`/`strata` is irregular, so the package's `(s)` suffix fails here."""
+        strata, psus, psu_id = [], [], 1
+        for i in range(n_odd_strata):
+            for _ in range(3):  # 3 PSUs -> odd
+                strata += [f"s{i}"] * 2
+                psus += [psu_id, psu_id]
+                psu_id += 1
+        data = pl.DataFrame({"stratum": strata, "psu": psus, "wgt": [1.0] * len(psus)})
+        sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
+
+        with pytest.raises(DimensionError) as exc:
+            sample.weighting.create_brr_wgts()
+        assert expected_count_phrase in exc.value.detail
+
+    def test_one_error_lists_every_stratum_that_is_not_a_multiple_of_2(self):
+        """1 and 3 are the same failure, so they arrive in one error, not two runs.
+
+        These used to be separate guards with the `< 2` one raising first, so a
+        frame carrying both reported only the lone-PSU stratum and revealed the
+        odd ones on the next run.
+        """
+        counts = {"a": 1, "b": 3, "c": 5, "d": 4}  # d pairs cleanly, must not appear
+        strata, psus, psu_id = [], [], 1
+        for name, n in counts.items():
+            for _ in range(n):
+                strata += [name] * 2
+                psus += [psu_id, psu_id]
+                psu_id += 1
+        data = pl.DataFrame({"stratum": strata, "psu": psus, "wgt": [1.0] * len(psus)})
+        sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
+
+        with pytest.raises(DimensionError) as exc:
+            sample.weighting.create_brr_wgts()
+
+        err = exc.value
+        assert err.code == "ODD_PSU_COUNT"
+        assert "3 strata" in err.detail
+        for offender in ("a=1", "b=3", "c=5"):
+            assert offender in err.got
+        assert "d=" not in err.got, "a stratum that pairs cleanly must not be reported"
+
+    @pytest.mark.parametrize("n_psus", [2, 4, 6])
+    def test_any_multiple_of_two_is_accepted(self, n_psus):
+        """Pairing is why the test is 'multiple of 2', not 'equal to 2'."""
+        strata, psus, psu_id = [], [], 1
+        for name in ("a", "b", "c"):
+            for _ in range(n_psus):
+                strata += [name] * 2
+                psus += [psu_id, psu_id]
+                psu_id += 1
+        data = pl.DataFrame({"stratum": strata, "psu": psus, "wgt": [1.0] * len(psus)})
+        sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
+
+        out = sample.weighting.create_brr_wgts(rep_prefix="r")
+        assert out._design.rep_wgts.method == "BRR"
+
+    def test_jk2_still_rejects_a_lone_psu(self):
+        """The `< 2` guard is now jk2's alone -- it can triple, but not pair one."""
+        data = pl.DataFrame({"stratum": [1, 2, 2, 2, 2], "psu": [1, 2, 2, 3, 3], "wgt": [1.0] * 5})
+        sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
+        with pytest.raises(DimensionError) as exc:
+            sample.weighting.create_jk_wgts(paired=True)
+        assert exc.value.code == "INSUFFICIENT_PSU"
+
+    def test_odd_psu_got_says_how_many_it_withheld(self):
+        """Each offending stratum needs fixing, so a bare `...` hides the job."""
+        strata, psus, psu_id = [], [], 1
+        for i in range(7):
+            for _ in range(3):
+                strata += [f"s{i}"] * 2
+                psus += [psu_id, psu_id]
+                psu_id += 1
+        data = pl.DataFrame({"stratum": strata, "psu": psus, "wgt": [1.0] * len(psus)})
+        sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
+
+        with pytest.raises(DimensionError) as exc:
+            sample.weighting.create_brr_wgts()
+        got = exc.value.got
+        assert "(+2 more)" in got  # 7 offenders, 5 shown
+        assert "..." not in got
+
+    def test_the_odd_psu_hint_actually_works(self, odd_psu_sample):
+        """Follow the hint and it succeeds on the frame that raised."""
+        out = odd_psu_sample.weighting.create_jk_wgts(paired=True, rep_prefix="jk")
+        assert out._design.rep_wgts.method == "Jackknife"
+        assert out._design.rep_wgts.kind == "jk2"
 
     def test_brr_string_psu_stratum(self):
         data = pl.DataFrame(
@@ -441,10 +549,18 @@ class TestVarianceStrataPairing:
         assert sample.design.stratum == "stratum"
 
     def test_singleton_stratum_raises(self):
+        """BRR rejects a lone PSU as "not a multiple of 2", not as a singleton.
+
+        A stratum of 1 and a stratum of 3 fail for the same reason -- a PSU with
+        no partner -- so BRR reports them the same way. Whether a lone PSU is a
+        *singleton* is a Taylor question, and `Sample.singleton` owns it.
+        """
         data = pl.DataFrame({"stratum": [1, 2, 2, 2, 2], "psu": [1, 2, 2, 3, 3], "wgt": [1.0] * 5})
         sample = Sample(data=data, design=Design(wgt="wgt", stratum="stratum", psu="psu"))
-        with pytest.raises(DimensionError, match="at least 2 PSUs"):
+        with pytest.raises(DimensionError) as exc:
             sample.weighting.create_brr_wgts()
+        assert exc.value.code == "ODD_PSU_COUNT"
+        assert "1=1" in exc.value.got
 
     def test_no_psu_raises(self):
         data = pl.DataFrame({"stratum": [1, 1, 2, 2], "wgt": [1.0] * 4})

--- a/packages/svy/tests/svy/weighting/test_weighting_inplace.py
+++ b/packages/svy/tests/svy/weighting/test_weighting_inplace.py
@@ -1,0 +1,201 @@
+# tests/svy/weighting/test_weighting_inplace.py
+"""The weighting namespace's copy-on-write contract.
+
+``inplace=False`` (the default) leaves the caller's Sample untouched;
+``inplace=True`` rewrites it and returns it. Both return a Sample, so chaining
+is identical under either. This mirrors ``wrangling``, where all 19 methods
+already take ``inplace: bool = False``.
+
+Before this contract every weighting method mutated its receiver and returned
+self, so two generators branching off one Sample produced an object whose
+columns came from one method and whose design came from the other.
+"""
+
+import inspect
+
+import polars as pl
+import pytest
+
+from svy import Design, Sample
+from svy.core.warnings import WarnCode
+from svy.weighting import Weighting
+
+
+# Methods that transform a Sample, and therefore carry `inplace`. The three
+# that do not -- controls_margins_template, control_aux_template,
+# build_aux_matrix -- return templates and matrices, not a Sample.
+TRANSFORMS = [
+    "create_brr_wgts",
+    "create_jk_wgts",
+    "create_bs_wgts",
+    "create_sdr_wgts",
+    "adjust",
+    "normalize",
+    "poststratify",
+    "rake",
+    "calibrate",
+    "calibrate_matrix",
+    "trim",
+]
+
+NON_TRANSFORMS = [
+    "controls_margins_template",
+    "control_aux_template",
+    "build_aux_matrix",
+]
+
+
+@pytest.fixture
+def frame():
+    # 4 strata x 2 PSUs, so BRR/JK2 pairing and the Rao-Wu bootstrap all run.
+    return pl.DataFrame(
+        {
+            "stratum": ["a"] * 4 + ["b"] * 4 + ["c"] * 4 + ["d"] * 4,
+            "psu": [1, 1, 2, 2, 3, 3, 4, 4, 5, 5, 6, 6, 7, 7, 8, 8],
+            "wgt": [10.0] * 16,
+            "y": [1.0, 2.0, 3.0, 4.0] * 4,
+            "urb": ["U", "R"] * 8,
+            "status": ["rr"] * 16,
+        }
+    )
+
+
+@pytest.fixture
+def sample(frame):
+    return Sample(data=frame, design=Design(stratum="stratum", psu="psu", wgt="wgt"))
+
+
+def _snapshot(s: Sample) -> tuple:
+    return (s._data.width, s._data.height, repr(s._design))
+
+
+# ---------------------------------------------------------------------------
+# Signature contract
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("name", TRANSFORMS)
+def test_transform_has_keyword_only_inplace_defaulting_false(name):
+    param = inspect.signature(getattr(Weighting, name)).parameters.get("inplace")
+    assert param is not None, f"{name} is missing the inplace parameter"
+    assert param.kind is inspect.Parameter.KEYWORD_ONLY, f"{name}.inplace must be keyword-only"
+    assert param.default is False, f"{name}.inplace must default to False"
+
+
+@pytest.mark.parametrize("name", NON_TRANSFORMS)
+def test_non_transform_has_no_inplace(name):
+    """These return templates/matrices, so there is no Sample to place."""
+    assert "inplace" not in inspect.signature(getattr(Weighting, name)).parameters
+
+
+# ---------------------------------------------------------------------------
+# Default (inplace=False) leaves the caller alone
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda s: s.weighting.create_bs_wgts(n_reps=4, rstate=1), id="bootstrap"),
+        pytest.param(lambda s: s.weighting.create_jk_wgts(), id="jackknife"),
+        pytest.param(lambda s: s.weighting.create_jk_wgts(paired=True), id="jackknife-paired"),
+        pytest.param(lambda s: s.weighting.create_brr_wgts(), id="brr"),
+        pytest.param(lambda s: s.weighting.create_sdr_wgts(n_reps=4), id="sdr"),
+        pytest.param(lambda s: s.weighting.adjust(resp_status="status", by="urb"), id="adjust"),
+        pytest.param(lambda s: s.weighting.normalize(controls=100.0), id="normalize"),
+        pytest.param(
+            lambda s: s.weighting.rake(controls={"urb": {"U": 90.0, "R": 90.0}}), id="rake"
+        ),
+        pytest.param(lambda s: s.weighting.trim(upper=15.0), id="trim"),
+    ],
+)
+def test_default_does_not_touch_the_caller(sample, call):
+    before = _snapshot(sample)
+    out = call(sample)
+    assert _snapshot(sample) == before, "the caller's Sample was modified"
+    assert out is not sample, "the default must return a distinct Sample"
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(
+            lambda s: s.weighting.create_bs_wgts(n_reps=4, rstate=1, inplace=True), id="bootstrap"
+        ),
+        pytest.param(lambda s: s.weighting.create_jk_wgts(inplace=True), id="jackknife"),
+        pytest.param(
+            lambda s: s.weighting.normalize(controls=100.0, inplace=True), id="normalize"
+        ),
+    ],
+)
+def test_inplace_true_rewrites_the_caller_and_returns_it(sample, call):
+    before = _snapshot(sample)
+    out = call(sample)
+    assert out is sample
+    assert _snapshot(sample) != before
+
+
+# ---------------------------------------------------------------------------
+# The bug this contract exists to prevent
+# ---------------------------------------------------------------------------
+
+
+def test_two_generators_can_branch_off_one_sample(sample):
+    boot = sample.weighting.create_bs_wgts(n_reps=4, rep_prefix="bs", rstate=1)
+    jack = sample.weighting.create_jk_wgts(rep_prefix="jk")
+
+    assert sample.design.rep_wgts is None
+    assert len({id(sample), id(boot), id(jack)}) == 3
+
+    # each branch's design describes its own columns
+    assert boot.design.rep_wgts.method == "Bootstrap"
+    assert boot.design.rep_wgts.prefix == "bs"
+    assert jack.design.rep_wgts.method == "Jackknife"
+    assert jack.design.rep_wgts.prefix == "jk"
+
+    assert {"bs1", "bs4"} <= set(boot._data.columns)
+    assert "jk1" not in boot._data.columns
+    assert {"jk1", "jk8"} <= set(jack._data.columns)
+    assert "bs1" not in jack._data.columns
+
+
+def test_chaining_is_unaffected_by_the_mode(sample):
+    controls = {"urb": {"U": 90.0, "R": 90.0}}
+
+    forked = (
+        sample.weighting.create_bs_wgts(n_reps=4, rep_prefix="bw", rstate=1)
+        .weighting.adjust(resp_status="status", by="urb", wgt_name="nr_wgt")
+        .weighting.rake(controls=controls, wgt_name="final_wgt")
+    )
+    mutated = (
+        Sample(data=sample._data, design=sample._design)
+        .weighting.create_bs_wgts(n_reps=4, rep_prefix="bw", rstate=1, inplace=True)
+        .weighting.adjust(resp_status="status", by="urb", wgt_name="nr_wgt", inplace=True)
+        .weighting.rake(controls=controls, wgt_name="final_wgt", inplace=True)
+    )
+
+    assert forked.design.wgt == mutated.design.wgt == "final_wgt"
+    assert sample.design.wgt == "wgt", "the forked chain leaked back to its source"
+    assert forked._data["final_wgt"].to_list() == pytest.approx(
+        mutated._data["final_wgt"].to_list()
+    )
+
+
+def test_fork_isolates_the_warning_store(sample):
+    """A failed default-mode call leaves the caller's warnings alone too.
+
+    The isolation has to cover diagnostics, not just data: "this call had no
+    effect on my Sample" is only true if the warning store is untouched as
+    well. The error is still raised, and still emitted to the log.
+    """
+    negative = sample.wrangling.mutate({"wgt": pl.lit(-1.0)})
+    before = len(negative._warnings.list(code=WarnCode.NEGATIVE_WEIGHT))
+
+    with pytest.raises(Exception, match="negative weight|Negative weights"):
+        negative.weighting.trim(upper=15.0)
+    assert len(negative._warnings.list(code=WarnCode.NEGATIVE_WEIGHT)) == before
+
+    # inplace=True is how you ask for the diagnostic to land on your Sample
+    with pytest.raises(Exception, match="negative weight|Negative weights"):
+        negative.weighting.trim(upper=15.0, inplace=True)
+    assert len(negative._warnings.list(code=WarnCode.NEGATIVE_WEIGHT)) == before + 1

--- a/packages/svy/tests/svy/weighting/test_wgt_adj_nonresponse.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_adj_nonresponse.py
@@ -86,7 +86,7 @@ def sample_data_single_class():
 
 def test_adjust_single_class_standard_codes(sample_data_single_class):
     sample = Sample(data=sample_data_single_class, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="single_class", resp_status="status", unknown_to_inelig=True, respondents_only=False
     )
     adjusted = sample.data[NR_WGT].to_numpy()
@@ -100,7 +100,7 @@ def test_adjust_single_class_standard_codes(sample_data_single_class):
 def test_adjust_stratified_custom_codes(sample_data_custom_codes):
     sample = Sample(data=sample_data_custom_codes, design=Design(wgt="weight"))
     mapping = {"rr": "R", "nr": "N", "in": "I", "uk": "U"}
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class_num",
         resp_status="status_code",
         resp_mapping=mapping,
@@ -114,7 +114,7 @@ def test_adjust_stratified_custom_codes(sample_data_custom_codes):
 
 def test_adjust_stratified_unknown_to_inelig_true(sample_data_basic):
     sample = Sample(data=sample_data_basic, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class", resp_status="status", unknown_to_inelig=True, respondents_only=False
     )
     adjusted = sample.data[NR_WGT].to_numpy()
@@ -137,7 +137,7 @@ def test_adjust_stratified_unknown_to_inelig_true(sample_data_basic):
 
 def test_adjust_stratified_unknown_to_inelig_false(sample_data_basic):
     sample = Sample(data=sample_data_basic, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class", resp_status="status", unknown_to_inelig=False, respondents_only=False
     )
     adjusted = sample.data[NR_WGT].to_numpy()
@@ -160,7 +160,7 @@ def test_adjust_stratified_unknown_to_inelig_false(sample_data_basic):
 
 def test_adjust_zero_respondents_in_class(sample_data_no_respondents):
     sample = Sample(data=sample_data_no_respondents, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class", resp_status="status", unknown_to_inelig=True, respondents_only=False
     )
     adjusted = sample.data[NR_WGT].to_numpy()
@@ -170,7 +170,7 @@ def test_adjust_zero_respondents_in_class(sample_data_no_respondents):
 
 def test_adjust_all_respondents(sample_data_all_respondents):
     sample = Sample(data=sample_data_all_respondents, design=Design(wgt="weight"))
-    sample.weighting.adjust(by="adj_class", resp_status="status", unknown_to_inelig=True)
+    sample = sample.weighting.adjust(by="adj_class", resp_status="status", unknown_to_inelig=True)
     adjusted = sample.data[NR_WGT].to_numpy()
     expected = np.array([10.0, 10.0, 10.0])
     np.testing.assert_allclose(adjusted, expected, atol=1e-9)
@@ -184,7 +184,7 @@ def test_adjust_all_respondents(sample_data_all_respondents):
 def test_adjust_auto_col_name_uses_nr_wgt(sample_data_basic):
     """Auto-generated adjusted weight column must be nr_wgt."""
     sample = Sample(data=sample_data_basic, design=Design(wgt="weight"))
-    sample.weighting.adjust(by="adj_class", resp_status="status")
+    sample = sample.weighting.adjust(by="adj_class", resp_status="status")
     assert NR_WGT in sample.data.columns
     assert "svy_adj_weight" not in sample.data.columns
 
@@ -192,7 +192,7 @@ def test_adjust_auto_col_name_uses_nr_wgt(sample_data_basic):
 def test_adjust_wgt_name_overrides_default(sample_data_basic):
     """Explicit wgt_name overrides auto-generated name."""
     sample = Sample(data=sample_data_basic, design=Design(wgt="weight"))
-    sample.weighting.adjust(by="adj_class", resp_status="status", wgt_name="my_adj_wgt")
+    sample = sample.weighting.adjust(by="adj_class", resp_status="status", wgt_name="my_adj_wgt")
     assert "my_adj_wgt" in sample.data.columns
     assert NR_WGT not in sample.data.columns
     assert sample.design.wgt == "my_adj_wgt"
@@ -231,7 +231,7 @@ def test_adjust_replicate_weights_auto_prefix(sample_data_basic):
         prefix="rw",
         n_reps=2,
     )
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class",
         resp_status="status",
         update_design_wgts=True,
@@ -256,7 +256,7 @@ def test_adjust_replicate_weights_custom_wgt_name(sample_data_basic):
         prefix="rw",
         n_reps=2,
     )
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class",
         resp_status="status",
         wgt_name="my_wgt",
@@ -279,7 +279,7 @@ def test_adjust_replicate_weights_ignored_when_flag_set(sample_data_basic):
         prefix="rw",
         n_reps=2,
     )
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class",
         resp_status="status",
         ignore_reps=True,
@@ -300,7 +300,7 @@ def test_adjust_no_design_update(sample_data_basic):
         prefix="rw",
         n_reps=2,
     )
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         by="adj_class",
         resp_status="status",
         update_design_wgts=False,
@@ -336,7 +336,7 @@ def test_adjust_by_tuple():
     """Tuple of strings crosses the columns into adjustment classes."""
     df, expected = _make_twoway_sample()
     sample = Sample(data=df, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         resp_status="status",
         by=("region", "sex"),
         unknown_to_inelig=True,
@@ -350,7 +350,7 @@ def test_adjust_by_list_accepted():
     """Lists of strings are now accepted (equivalent to tuple)."""
     df, expected = _make_twoway_sample()
     sample = Sample(data=df, design=Design(wgt="weight"))
-    sample.weighting.adjust(
+    sample = sample.weighting.adjust(
         resp_status="status",
         by=["region", "sex"],
         unknown_to_inelig=True,

--- a/packages/svy/tests/svy/weighting/test_wgt_normalization.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_normalization.py
@@ -42,7 +42,7 @@ def sample_data():
 def test_normalize_no_domain_or_control(sample_data, mock_design):
     """Weights normalized to sum to number of samples (n=6)."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.normalize()
+    sample = sample.weighting.normalize()
 
     expected = np.array([0.5, 0.5, 1.0, 1.0, 1.5, 1.5])
     result = sample.data.get_column(NORM_WGT).to_numpy()
@@ -56,7 +56,7 @@ def test_normalize_with_numeric_control(sample_data, mock_design):
     """With a scalar control total, weights sum to that total."""
     sample = Sample(data=sample_data, design=mock_design)
     control_total = 240
-    sample.weighting.normalize(controls=control_total)
+    sample = sample.weighting.normalize(controls=control_total)
 
     expected = np.array([20.0, 20.0, 40.0, 40.0, 60.0, 60.0])
     result = sample.data.get_column(NORM_WGT).to_numpy()
@@ -69,7 +69,7 @@ def test_normalize_with_domain_and_dict_control(sample_data, mock_design):
     """Normalization within domains using a dict of control totals."""
     sample = Sample(data=sample_data, design=mock_design)
     controls = {"A": 60, "B": 180}
-    sample.weighting.normalize(controls=controls, by="domain")
+    sample = sample.weighting.normalize(controls=controls, by="domain")
 
     expected = np.array([15.0, 15.0, 30.0, 45.0, 67.5, 67.5])
     result = sample.data.get_column(NORM_WGT).to_numpy()
@@ -84,7 +84,7 @@ def test_normalize_with_domain_and_dict_control(sample_data, mock_design):
 def test_normalize_with_domain_no_control(sample_data, mock_design):
     """Normalization within domains, each domain sums to its count."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.normalize(by="domain")
+    sample = sample.weighting.normalize(by="domain")
 
     expected = np.array([0.75, 0.75, 1.5, 0.75, 1.125, 1.125])
     result = sample.data.get_column(NORM_WGT).to_numpy()
@@ -104,7 +104,7 @@ def test_normalize_with_domain_no_control(sample_data, mock_design):
 def test_normalize_auto_col_name_uses_norm_wgt(sample_data, mock_design):
     """Auto-generated normalized weight column must be norm_wgt."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.normalize()
+    sample = sample.weighting.normalize()
     assert NORM_WGT in sample.data.columns
     assert "svy_norm_samp_weight" not in sample.data.columns
 
@@ -112,7 +112,7 @@ def test_normalize_auto_col_name_uses_norm_wgt(sample_data, mock_design):
 def test_normalize_wgt_name_overrides_default(sample_data, mock_design):
     """Explicit wgt_name overrides auto-generated name."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.normalize(wgt_name="my_norm_wgt")
+    sample = sample.weighting.normalize(wgt_name="my_norm_wgt")
     assert "my_norm_wgt" in sample.data.columns
     assert NORM_WGT not in sample.data.columns
     assert sample.design.wgt == "my_norm_wgt"
@@ -143,7 +143,7 @@ def test_normalize_replicate_weights_auto_prefix(sample_data, mock_design):
     )
     sample = Sample(data=df, design=mock_design)
     sample._design = sample.design.update_rep_weights(method="BRR", prefix="rw", n_reps=2)
-    sample.weighting.normalize(update_design_wgts=True)
+    sample = sample.weighting.normalize(update_design_wgts=True)
     assert f"{NORM_WGT}1" in sample.data.columns
     assert f"{NORM_WGT}2" in sample.data.columns
     assert sample.design.rep_wgts.columns == [f"{NORM_WGT}1", f"{NORM_WGT}2"]
@@ -158,7 +158,7 @@ def test_normalize_replicate_weights_custom_wgt_name(sample_data, mock_design):
     )
     sample = Sample(data=df, design=mock_design)
     sample._design = sample.design.update_rep_weights(method="BRR", prefix="rw", n_reps=2)
-    sample.weighting.normalize(wgt_name="my_norm")
+    sample = sample.weighting.normalize(wgt_name="my_norm")
     assert "my_norm" in sample.data.columns
     assert "my_norm1" in sample.data.columns
     assert "my_norm2" in sample.data.columns
@@ -172,7 +172,7 @@ def test_normalize_replicate_weights_ignored_when_flag_set(sample_data, mock_des
     )
     sample = Sample(data=df, design=mock_design)
     sample._design = sample.design.update_rep_weights(method="BRR", prefix="rw", n_reps=2)
-    sample.weighting.normalize(ignore_reps=True)
+    sample = sample.weighting.normalize(ignore_reps=True)
     assert f"{NORM_WGT}1" not in sample.data.columns
     assert sample.design.rep_wgts.columns == ["rw1", "rw2"]
 
@@ -184,7 +184,7 @@ def test_normalize_no_design_update(sample_data, mock_design):
     )
     sample = Sample(data=df, design=mock_design)
     sample._design = sample.design.update_rep_weights(method="BRR", prefix="rw", n_reps=2)
-    sample.weighting.normalize(update_design_wgts=False)
+    sample = sample.weighting.normalize(update_design_wgts=False)
     assert NORM_WGT in sample.data.columns
     assert f"{NORM_WGT}1" in sample.data.columns
     assert sample.design.wgt == "samp_weight"

--- a/packages/svy/tests/svy/weighting/test_wgt_poststratification.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_poststratification.py
@@ -104,7 +104,7 @@ def test_postratify_raises_value_error_for_mismatched_keys(sample_data, mock_des
 def test_poststratify_auto_col_name_uses_ps_wgt(sample_data, mock_design):
     """Auto-generated column must be ps_wgt."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.poststratify(controls=300)
+    sample = sample.weighting.poststratify(controls=300)
     assert PS_WGT in sample.data.columns
     assert "svy_ps_samp_weight" not in sample.data.columns
 
@@ -112,7 +112,7 @@ def test_poststratify_auto_col_name_uses_ps_wgt(sample_data, mock_design):
 def test_poststratify_wgt_name_overrides_default(sample_data, mock_design):
     """Explicit wgt_name overrides auto-generated name."""
     sample = Sample(data=sample_data, design=mock_design)
-    sample.weighting.poststratify(controls=300, wgt_name="my_ps_wgt")
+    sample = sample.weighting.poststratify(controls=300, wgt_name="my_ps_wgt")
     assert "my_ps_wgt" in sample.data.columns
     assert PS_WGT not in sample.data.columns
     assert sample.design.wgt == "my_ps_wgt"

--- a/packages/svy/tests/svy/weighting/test_wgt_raking.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_raking.py
@@ -65,7 +65,7 @@ def test_rake_successful_convergence_with_factors_empty_dict(sample_data_for_rak
         "age_group": {"18-34": 0.8, "35-54": 1.0, "55+": 1.3},
         "region": {"North": 1.25, "South": 0.75},
     }
-    sample.weighting.rake(controls={}, factors=factors)
+    sample = sample.weighting.rake(controls={}, factors=factors)
     col = RK_WGT
     raked = sample.data
 
@@ -82,7 +82,7 @@ def test_rake_successful_convergence_with_factors(sample_data_for_raking, mock_d
         "age_group": {"18-34": 0.8, "35-54": 1.0, "55+": 1.3},
         "region": {"North": 1.25, "South": 0.75},
     }
-    sample.weighting.rake(controls=None, factors=factors)
+    sample = sample.weighting.rake(controls=None, factors=factors)
     col = RK_WGT
     raked = sample.data
 
@@ -187,7 +187,7 @@ def test_rake_stops_at_max_iter_on_no_convergence(sample_data_for_raking, mock_d
     assert sample.design.wgt == original_wgt  # design not mutated
 
     # strict=False: stores partial weights, prints warning
-    sample.weighting.rake(controls=controls, max_iter=3, tol=1e-20, strict=False)
+    sample = sample.weighting.rake(controls=controls, max_iter=3, tol=1e-20, strict=False)
     captured = capsys.readouterr()
     assert "Warning: Raking did not converge after 3 iterations" in captured.out
 

--- a/packages/svy/tests/svy/weighting/test_wgt_trimming.py
+++ b/packages/svy/tests/svy/weighting/test_wgt_trimming.py
@@ -698,8 +698,13 @@ class TestTrimByDomain:
 class TestTrimWarnings:
     def test_negative_weight_raises_and_emits_error_warning(self):
         sample = _make_sample([-1.0, 10.0, 10.0])
+        # inplace=True on purpose: the assertion below is about the warning
+        # landing on *this* sample. Under the default (inplace=False) the
+        # operation works on a fork, so a raise leaves the caller's sample
+        # untouched -- warning store included, which is the point of the
+        # isolation. The error is still raised and still emitted to the log.
         with pytest.raises(Exception, match="negative weight|Negative weights"):
-            sample.weighting.trim(upper=50.0)
+            sample.weighting.trim(upper=50.0, inplace=True)
         warns = _warnings_of(sample, WarnCode.NEGATIVE_WEIGHT)
         assert len(warns) == 1
         assert warns[0].level == Severity.ERROR


### PR DESCRIPTION
Three defects in `Sample.weighting`, found while updating the docs against 0.25.0. The first was hiding the second.

## 1. `weighting` mutated the sample you called it on — `ec38188`

Every method rewrote its receiver and returned that same object, while all 19 `wrangling` methods take `inplace: bool = False` and default to copying, and `singleton`'s five transforms always return a new `Sample`. `weighting` was the only namespace that mutated unconditionally, and the only one with no way to ask for a copy — `grep -rn inplace src/svy/` hit nothing outside `wrangling/`.

The `s = s.weighting.…()` idiom hides it, so it surfaced only when two variants branched off one sample — a method comparison, a sensitivity check, a docs page:

```python
boot = base.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
jack = base.weighting.create_jk_wgts(rep_prefix="jk")
# boot is jack is base -- 33 jk* columns in the frame against a design still
# reading method=Bootstrap prefix='bs', so an estimate off `jack` silently
# used the bootstrap columns and coefficients.
```

The 11 transforming methods now take keyword-only `inplace: bool = False` and work on a fork by default. The three that return templates or matrices rather than a `Sample` — `controls_margins_template`, `control_aux_template`, `build_aux_matrix` — do not take it.

`Weighting` is a thin dispatcher, so this is one `_target(inplace)` call per method plus `Sample._fork()`. The 4,200 lines across the nine implementation modules are untouched: they keep rebinding `sample._data`/`sample._design` as they go, which is correct once they are handed a private copy.

**Chaining is unaffected** — both branches return a `Sample`, and the two modes produce identical numbers:

```
inplace=False:  final wgt=final_wgt, reps=final_wgt1..10, source untouched
inplace=True :  final wgt=final_wgt, chained is s -> True
both: est=12373.089190 se=650.681983
```

One judgement call worth review: the isolation covers diagnostics too. A default-mode call that **raises** leaves the caller's warning store untouched, on the grounds that "this call had no effect on my sample" is only true if it covers everything. The error is still raised and still logged; `inplace=True` is how you ask for it to land on your sample.

> [!WARNING]
> **Breaking.** Code that called a weighting method and then read the receiver without capturing the return must add `inplace=True` or capture the result. Code already written as `s = s.weighting.…()` needs no change.

## 2. Regenerating replicate weights kept the previous method's design — `4c6de80`

`create_brr_wgts` and `create_jk_wgts` recorded their result with `Design.fill_missing(rep_wgts=…)`, which only fills a field that is currently `None`. `create_bs_wgts` and `create_sdr_wgts` used `Design.update` — an inconsistency inherited from the monorepo migration (`eccae17`), never a decision.

```python
s = s.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
s = s.weighting.create_jk_wgts(rep_prefix="jk")
# 33 jk* columns in the frame; design.rep_wgts reads method=Bootstrap
# prefix='bs' n_reps=10, and mean(method="replication") returns
# Estimate: MEAN (BOOTSTRAP), computed off bs*.
```

Unlike #1 this fires on the plain reassignment idiom, in both orders. Switching methods mid-analysis is exactly when it happens. Both sites now use `update`.

## 3. BRR validated its strata in two passes, and sent one to the wrong subsystem — `d966f00`

`< 2` PSUs raised `INSUFFICIENT_PSU` first; only then did the odd-count check run. A frame carrying both reported the lone-PSU stratum and revealed the odd ones on the next attempt.

The split also borrowed a question that is not BRR's. A stratum with one PSU is a **singleton** — a Taylor concern with its own subsystem (`Sample.singleton`: `collapse`, `combine`, `pool`, `certainty`), none of which the hint mentioned; it said *"Combine small strata or check design specification."* For BRR a stratum of 1 and a stratum of 3 fail for the same reason: a PSU with no partner.

BRR now asks one question and answers it in full:

```
❌ BRR needs 2 PSUs per variance stratum [ODD_PSU_COUNT]
BRR pairs PSUs into variance strata of exactly 2. Found 3 strata whose PSU
count is not a multiple of 2, leaving a PSU with no partner.
- got: a=1, b=3, c=5
Hint: create_jk_wgts(paired=True) pairs these strata itself and absorbs an odd
count into a triplet. BRR cannot: its balanced half-samples need exactly 2 PSUs
per variance stratum. If BRR is required, fix every stratum listed, not just
one -- drop or combine a PSU so each count is even.
```

"Multiple of 2" rather than "equal to 2" because `create_brr_wgts` pairs: a 4-PSU stratum becomes two variance strata of 2 and is valid (verified for 2, 4 and 6). `INSUFFICIENT_PSU` is now the paired jackknife's alone — the one method that distinguishes the cases, absorbing an odd count into a triplet while still unable to pair a lone PSU.

The old hint read `Use method='jk2' which allows 2-3 PSUs per stratum`. `method='jk2'` was `create_variance_strata`'s parameter — removed in 0.25.0 — and `method` is not a parameter of `create_brr_wgts` either, so the remedy named a parameter of a gone function on a function that never had it.

## Verification

- **3164 passed, 1 skipped** (baseline on `main`: 3120).
- 29 call sites in existing weighting tests relied on mutation and now capture the return; one trimming test asserted the warning side-effect and now passes `inplace=True`, which makes it test something real.
- New `test_weighting_inplace.py` (29 tests) pins signatures, both modes, the branching case, chaining equivalence and warning-store isolation. `TestRegeneratedDesignIsRecorded` (6) covers both orders, BRR, regenerating the same method, the estimation symptom and overriding a stale declaration — **5 of the 6 fail without the fix**; the sixth is the case `update` already made correct.
- BRR guard tests: one error lists every offender while a cleanly-pairing 4-PSU stratum is absent, 2/4/6 accepted, jk2 still rejects a lone PSU, singular/plural agreement, and the hint names a real API.
- `ruff check` and `ruff format` clean on all touched files. (`core/sample.py` has a pre-existing format diff on `main`, left alone — 21 files repo-wide are in that state.)
- The svy-docs site re-renders against all three commits: exit 0, no tracebacks, raking propagation intact.

## Release note

`ec38188` carries a `BREAKING CHANGE:` trailer, so this wants a minor bump rather than a patch. All three have `[Unreleased]` CHANGELOG entries.
