### PR TITLE
perf(svy): take scipy off the import path

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,18 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Changed
+
+- **`import svy` was paying for scipy before you asked it anything.** Importing the package cost ~0.80 s, and 383 ms of that was `scipy.stats`, pulled in along the chain `svy.serialize` → `svy.categorical` → `svy.estimation.base`. Nothing about that import was needed to *reach* svy — it was needed only by whichever call eventually wanted a quantile.
+
+  Six modules imported scipy at module scope: `estimation/base.py`, `regression/base.py`, `regression/margins.py`, `engine/size_and_power/size.py`, `engine/size_and_power/power.py`, and `utils/hadamard.py`. What made this stubborn is that fixing any one of them alone changes nothing — scipy loads once and the other five ride `sys.modules`, so the cost simply moves. All six had to go together.
+
+  The uses turned out to be narrow: estimation, regression and margins want the t and F quantiles, size and power the normal, hadamard a single `scipy.linalg` call. Each import now sits in the function that needs it, matching what `categorical/base.py` had already been doing in four places — this finishes a refactor that had stalled partway.
+
+  `import svy` now costs ~0.27 s and `scipy.stats` is off the import path entirely; it loads on the first call that actually needs a distribution. Nothing about the numerical results changes.
+
+- **`svy.datasets` now loads on first use rather than on import.** The root package imported it purely so it would be reachable as an attribute, which is what a module-level `__getattr__` handles. Worth ~30 ms — not the ~180 ms an import profiler credits to it, since most of that is polars and numpy, which `datasets` merely imported first and which the rest of svy needs anyway. `svy.datasets.load(...)`, `from svy import datasets` and `import svy.datasets` all behave exactly as before.
+
 ### Fixed
 
 - **BRR validated its strata in two passes, and sent one of them to the wrong subsystem.** `create_brr_wgts` checked `< 2` PSUs first, raising `INSUFFICIENT_PSU`, and only then checked for odd counts. A frame carrying both therefore reported the lone-PSU stratum, and revealed the odd ones on the next run — one class of problem per attempt, on a validation that could have been answered in full the first time.

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 
 import logging
 
+from typing import TYPE_CHECKING
+
 from svy import (
-    datasets,  # noqa: F401
     serialize,  # noqa: F401
 )
 from svy.categorical import (
@@ -340,3 +341,25 @@ def _maybe_install_rich() -> None:
 
 
 _maybe_install_rich()
+
+
+if TYPE_CHECKING:
+    from svy import datasets  # noqa: F401
+
+
+# Subpackages exposed as attributes but imported only when first touched.
+# ``svy.datasets`` adds ~30 ms of catalog/bundled-data machinery on top of the
+# polars and numpy it shares with the rest of svy, and most callers never load a
+# dataset. Deferring it does not change the public API: ``svy.datasets.load(...)``,
+# ``from svy import datasets`` and ``import svy.datasets`` all still work.
+_LAZY_SUBMODULES = frozenset({"datasets"})
+
+
+def __getattr__(name: str):
+    if name in _LAZY_SUBMODULES:
+        from importlib import import_module
+
+        module = import_module(f"svy.{name}")
+        globals()[name] = module  # later lookups skip __getattr__
+        return module
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/packages/svy/src/svy/engine/size_and_power/power.py
+++ b/packages/svy/src/svy/engine/size_and_power/power.py
@@ -6,8 +6,6 @@ from typing import Literal, cast, overload
 
 import numpy as np
 
-from scipy.stats import norm as normal
-
 from svy.core.types import Array, Category, DomainScalarMap, FloatArray, Number
 
 
@@ -20,6 +18,8 @@ _EPS = 1e-12  # numeric guard for sqrt/arcsin
 
 
 def _zcrit(alpha: float, two_sides: bool) -> float:
+    from scipy.stats import norm as normal
+
     if not (0.0 < alpha < 1.0):
         raise ValueError("alpha must be in (0,1)")
     return float(normal.isf(alpha / 2.0 if two_sides else alpha))
@@ -30,6 +30,8 @@ def _zcrit_from_type(
     testing_type: Literal["two-sided", "less", "greater"],
 ) -> float | FloatArray:
     """Return z critical value(s) as float (scalar alpha) or FloatArray (array alpha)."""
+    from scipy.stats import norm as normal
+
     two_sided = testing_type == "two-sided"
 
     if isinstance(alpha, (int, float)):
@@ -71,6 +73,8 @@ def _se_two_props_array(pa: Array, pb: Array, na: Array, nb: Array) -> FloatArra
 def _power_from_lam_array(
     lam: Array, zc: float | Array, testing_type: Literal["two-sided", "less", "greater"]
 ) -> FloatArray:
+    from scipy.stats import norm as normal
+
     lam = np.asarray(lam, dtype=np.float64)
     zc_arr = np.asarray(zc, dtype=np.float64)
     if testing_type == "two-sided":
@@ -94,6 +98,8 @@ def _scalar_power(
     ttype: Literal["two-sided", "less", "greater"],
 ) -> float:
     """Compute clipped scalar power from non-centrality parameter lam and critical value zc."""
+    from scipy.stats import norm as normal
+
     if ttype == "two-sided":
         val = float(normal.cdf(lam - zc) + normal.cdf(-lam - zc))
     elif ttype == "greater":
@@ -119,6 +125,8 @@ def calculate_power_array(
     Typed array variant with explicit float64 arrays and a cast on return to
     satisfy mypy/pyright (some numpy overloads are typed as Any).
     """
+    from scipy.stats import norm as normal
+
     zc = _zcrit(alpha, two_sides)
 
     d = np.asarray(delta, dtype=np.float64)
@@ -291,6 +299,8 @@ def power_for_one_proportion_array(
     testing_type: Literal["two-sided", "less", "greater"] = "two-sided",
     alpha: float | Array = 0.05,
 ) -> FloatArray:
+    from scipy.stats import norm as normal
+
     p0 = np.asarray(prop_0, dtype=np.float64)
     p1 = np.asarray(prop_1, dtype=np.float64)
     n = np.asarray(samp_size, dtype=np.float64)

--- a/packages/svy/src/svy/engine/size_and_power/size.py
+++ b/packages/svy/src/svy/engine/size_and_power/size.py
@@ -8,8 +8,6 @@ from typing import Literal, cast
 
 import numpy as np
 
-from scipy.stats import norm
-
 from svy.core.enumerations import MeanVarMode, PropVarMode
 from svy.core.types import (
     Array,
@@ -338,6 +336,8 @@ def _as_like(x: float | Array, ref: FloatArray) -> FloatArray:
 
 
 def _zcrit(alpha: float, two_sides: bool) -> float:
+    from scipy.stats import norm
+
     if not (0.0 < alpha < 1.0):
         raise ValueError("alpha must be in (0,1)")
     return float(norm.ppf(1 - alpha / 2.0 if two_sides else 1 - alpha))
@@ -346,6 +346,8 @@ def _zcrit(alpha: float, two_sides: bool) -> float:
 def _zcrit_from_type(
     alpha: float | Array, ttype: Literal["two-sided", "less", "greater"]
 ) -> float | FloatArray:
+    from scipy.stats import norm
+
     two_sides = ttype == "two-sided"
     if isinstance(alpha, (int, float)):
         return _zcrit(float(alpha), two_sides)
@@ -962,6 +964,8 @@ def _apply_fpc_srswor_pair(
 def _zcrit_pair(
     *, two_sides: bool, alpha: float, power: float, delta: float
 ) -> tuple[float, float]:
+    from scipy.stats import norm
+
     if two_sides and delta == 0.0:
         z_a = _zcrit(alpha, True)
         z_b = float(norm.ppf(power))

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -10,8 +10,6 @@ import numpy as np
 import polars as pl
 import svy_rs as rs
 
-from scipy import stats
-
 from svy.core.constants import _BY_SEP, _INTERNAL_CONCAT_SUFFIX
 from svy.core.data_prep import prepare_data
 from svy.core.enumerations import PopParam
@@ -531,11 +529,15 @@ class Estimation:
         report NaN bounds, matching survey, instead of a zero-width CI that
         reads as a point estimate known with certainty (issue #96).
         """
+        from scipy import stats
+
         return float(stats.t.ppf(1 - alpha / 2, df)) if df > 0 else float("nan")
 
     @staticmethod
     def _t_crit_arr(alpha: float, df_arr: np.ndarray) -> np.ndarray:
         """Vectorised :meth:`_t_crit`; NaN wherever df <= 0."""
+        from scipy import stats
+
         pos = df_arr > 0
         return np.where(pos, stats.t.ppf(1 - alpha / 2, np.where(pos, df_arr, 1.0)), np.nan)
 
@@ -592,6 +594,8 @@ class Estimation:
         Data Presentation Standards for Proportions.
         *Vital Health Stat* 2(175).
         """
+        from scipy import stats
+
         method = self._normalize_ci_method(method)
 
         if method == "logit":

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -14,8 +14,6 @@ import msgspec
 import numpy as np
 import polars as pl
 
-from scipy import stats
-
 
 # Rust backend
 try:
@@ -265,6 +263,8 @@ class GLM:
         GLM
             Self, with fitted results in `.fitted`.
         """
+        from scipy import stats
+
         # Resolve family/link
         fam_str = _normalize_family(family)
         link_str = resolve_link(fam_str, _normalize_link(link))
@@ -347,9 +347,7 @@ class GLM:
         # validation all use exactly the rows the fit will use.
         _in_dom_expr = pl.col(w_col) > 0
         if by_col_name is not None:
-            _in_dom_expr = _in_dom_expr & (
-                pl.col(by_col_name).str.to_lowercase() == "true"
-            )
+            _in_dom_expr = _in_dom_expr & (pl.col(by_col_name).str.to_lowercase() == "true")
         level_df = df.filter(_in_dom_expr)
 
         # ── Build feature matrix ──────────────────────────────────────────
@@ -444,9 +442,7 @@ class GLM:
         if pop_cols and pop_cols[0] in df.columns:
             from svy.estimation._fpc import build_fpc_psu_column
 
-            df, fpc_name = build_fpc_psu_column(
-                df, pop_cols[0], s_col, p_col, "__svy_fpc_psu__"
-            )
+            df, fpc_name = build_fpc_psu_column(df, pop_cols[0], s_col, p_col, "__svy_fpc_psu__")
 
         # Build final selection — include the by_col when domain is set
         final_selects = (
@@ -706,6 +702,8 @@ class GLM:
         alpha: float = 0.05,
         y_col: str | None = None,
     ) -> GLMPred:
+        from scipy import stats
+
         fit = self._ensure_fitted()
 
         # Build design matrix
@@ -1012,6 +1010,8 @@ class GLM:
         provides no plain BIC for svyglm (its dBIC requires an explicit
         maximal model).
         """
+        from scipy import stats
+
         bic = None
 
         r2 = 1.0 - dev / null_dev if null_dev > 1e-12 else None

--- a/packages/svy/src/svy/regression/margins.py
+++ b/packages/svy/src/svy/regression/margins.py
@@ -13,8 +13,6 @@ import msgspec
 import numpy as np
 import polars as pl
 
-from scipy import stats
-
 from svy.regression.links import link_inverse, link_mu_eta, link_mu_eta2
 from svy.ui.printing import make_panel, render_plain_table, render_rich_to_str, resolve_width
 
@@ -405,6 +403,8 @@ def compute_predictive_margins(
     g = sum_i w_i mu'(eta_i) x_i / sum_i w_i  (Stata ``margins``
     convention; covariates treated as fixed).
     """
+    from scipy import stats
+
     fit = glm.fitted
     if fit is None:
         raise ValueError("Model not fitted")
@@ -487,6 +487,8 @@ def compute_average_marginal_effects(
     delta method over the design-based V(beta):
     g_j = mean_w(mu''(eta) X_j deta_dx + mu'(eta) D_j), se^2 = g' V g.
     """
+    from scipy import stats
+
     fit = glm.fitted
     if fit is None:
         raise ValueError("Model not fitted")

--- a/packages/svy/src/svy/utils/hadamard.py
+++ b/packages/svy/src/svy/utils/hadamard.py
@@ -18,8 +18,6 @@ import logging
 
 import numpy as np
 
-from scipy.linalg import hadamard as hdd
-
 
 log = logging.getLogger(__name__)
 
@@ -191,6 +189,8 @@ _HADAMARD_FUNCS = {
 
 
 def hadamard(n: int) -> np.ndarray:
+    from scipy.linalg import hadamard as hdd
+
     # Power-of-2 check using integer arithmetic — avoids float precision issues
     if n > 0 and (n & (n - 1)) == 0:
         return np.asarray(hdd(n))


### PR DESCRIPTION
## What

`import svy` cost **~0.80 s**. It now costs **~0.24 s**, with no change to any numerical result and no public API change.

| | before | after |
|---|---|---|
| `import svy` | 0.80 s | 0.24 s |
| `scipy.stats` on import path | yes (383 ms) | no |

## Why it needed all six modules at once

`scipy.stats` was reached through `svy.serialize` → `svy.categorical` → `svy.estimation.base`, but six modules imported scipy at module scope:

- `estimation/base.py`, `regression/base.py`, `regression/margins.py` — t and F quantiles
- `engine/size_and_power/size.py`, `engine/size_and_power/power.py` — normal quantiles
- `utils/hadamard.py` — one `scipy.linalg` call

Fixing any single one buys nothing: scipy loads once and the remaining five ride `sys.modules`. They had to move together, which is probably why this sat unfixed.

This **finishes a refactor already in the codebase** — `categorical/base.py` has done exactly this in four places for some time. The new imports match that pattern.

## One thing I ruled out

A module-level `__getattr__` (PEP 562) looks like the tidier fix, but it does not work here: it fires on attribute access from *outside* a module, not on global lookups inside that module's own functions. `stats.t.ppf(...)` in a method body would have raised `NameError`. Function-local imports are the correct tool, and they match existing style.

It *is* the right tool for `svy.datasets`, which the root package imported only to expose as an attribute — that is the second commit.

## Being straight about the second commit

The `svy.datasets` deferral is worth **~30 ms**, not the ~180 ms an import profiler credits to it. Most of that 180 ms is polars and numpy, which `datasets` merely imported first and which the rest of svy needs regardless. Happy to drop that commit if the `__getattr__` on the root package isn't worth 12% to you — the scipy work stands on its own.

## Where the floor is

The remaining ~240 ms is polars (~73 ms), numpy (~33 ms) and svy's own module tree (~90 ms). Those are what svy *is*. Going further would mean restructuring the root's flat re-export surface, which I don't think is worth it.

## Verification

- `3535 passed, 11 skipped, 10 xfailed` — same as base, rebased onto `origin/main` (includes #142)
- `ruff check` and `ruff format` clean on all changed files
- Numerical results unchanged: these commits move *when* scipy is imported, never what is computed
- CHANGELOG entry added under `[Unreleased]` per CONTRIBUTING

62 lines of source diff across 7 files.