### PR TITLE
release(svy): 0.26.0

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,7 +8,29 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+## [0.26.0] — 2026-08-28
+
+A breaking change to the weighting API, and a substantial cut to import time.
+
 ### Changed
+
+- **BREAKING: `Sample.weighting` no longer mutates the sample you call it on.** All eleven transforming methods — the four `create_*_wgts`, `adjust`, `normalize`, `poststratify`, `rake`, `calibrate`, `calibrate_matrix`, `trim` — now return a new `Sample` and take `inplace: bool = False` to ask for the old behaviour. Both branches return a `Sample`, so chaining is unchanged and `s = s.weighting.…()` keeps working exactly as before.
+
+  This is not a new convention: all 19 `wrangling` methods already take `inplace: bool = False` and default to copying, and `singleton`'s five transforms always return a new `Sample`. `weighting` was the only namespace that mutated unconditionally, and the only one with no way to ask for a copy — `grep -rn inplace src/svy/` hit nothing outside `wrangling/`.
+
+  The reassignment idiom hid it, so it surfaced only when two variants branched off one sample — which is what a method comparison, a sensitivity check, or a docs page does:
+
+  ```python
+  boot = base.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
+  jack = base.weighting.create_jk_wgts(rep_prefix="jk")
+  # before: boot is jack is base. 33 jk* columns in the frame, and a design
+  #         still reading method=Bootstrap prefix='bs' -- so an estimate off
+  #         `jack` silently used the bootstrap columns and coefficients.
+  ```
+
+  **What breaks:** code that called a weighting method and then read the receiver without capturing the return. Add `inplace=True`, or capture the result. Code already written as `s = s.weighting.…()` needs no change.
+
+  The isolation covers diagnostics as well as data: an operation that raises under the default leaves the caller's warning store untouched, because "this call had no effect on my sample" is only true if it covers everything. The error is still raised and still emitted to the log; `inplace=True` is how you ask for the warning to land on your sample.
 
 - **`import svy` was paying for scipy before you asked it anything.** Importing the package cost ~0.80 s, and 383 ms of that was `scipy.stats`, pulled in along the chain `svy.serialize` → `svy.categorical` → `svy.estimation.base`. Nothing about that import was needed to *reach* svy — it was needed only by whichever call eventually wanted a quantile.
 
@@ -54,26 +76,6 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
   ```
 
   Unlike the mutation defect fixed alongside it, this one fired on the plain `s = s.weighting.…()` idiom, in both orders, and switching methods mid-analysis is exactly when someone does it — comparing a jackknife against a bootstrap, or moving to JK2 after seeing the replicate count. Both now use `update`: the design describes the columns that were just written, and a declaration that no longer matches them is replaced rather than preserved.
-
-### Changed
-
-- **BREAKING: `Sample.weighting` no longer mutates the sample you call it on.** All eleven transforming methods — the four `create_*_wgts`, `adjust`, `normalize`, `poststratify`, `rake`, `calibrate`, `calibrate_matrix`, `trim` — now return a new `Sample` and take `inplace: bool = False` to ask for the old behaviour. Both branches return a `Sample`, so chaining is unchanged and `s = s.weighting.…()` keeps working exactly as before.
-
-  This is not a new convention: all 19 `wrangling` methods already take `inplace: bool = False` and default to copying, and `singleton`'s five transforms always return a new `Sample`. `weighting` was the only namespace that mutated unconditionally, and the only one with no way to ask for a copy — `grep -rn inplace src/svy/` hit nothing outside `wrangling/`.
-
-  The reassignment idiom hid it, so it surfaced only when two variants branched off one sample — which is what a method comparison, a sensitivity check, or a docs page does:
-
-  ```python
-  boot = base.weighting.create_bs_wgts(n_reps=10, rep_prefix="bs")
-  jack = base.weighting.create_jk_wgts(rep_prefix="jk")
-  # before: boot is jack is base. 33 jk* columns in the frame, and a design
-  #         still reading method=Bootstrap prefix='bs' -- so an estimate off
-  #         `jack` silently used the bootstrap columns and coefficients.
-  ```
-
-  **What breaks:** code that called a weighting method and then read the receiver without capturing the return. Add `inplace=True`, or capture the result. Code already written as `s = s.weighting.…()` needs no change.
-
-  The isolation covers diagnostics as well as data: an operation that raises under the default leaves the caller's warning store untouched, because "this call had no effect on my sample" is only true if it covers everything. The error is still raised and still emitted to the log; `inplace=True` is how you ask for the warning to land on your sample.
 
 ## [0.25.0] — 2026-08-26
 
@@ -637,7 +639,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.25.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.26.0...HEAD
+[0.26.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.26.0
 [0.25.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.25.0
 [0.24.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.1
 [0.24.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.0

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.25.0"
+version = "0.26.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -134,7 +134,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.25.0"
+__version__ = "0.26.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.25.0"
+version = "0.26.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts 0.26.0 from the two changes on `main` since 0.25.0.

## Why 0.26.0 and not 0.25.1

`#142` is breaking — `Sample.weighting` no longer mutates the sample you call it on — and it landed after the 0.25.0 release, so any release cut from `main` carries it.

`packages/svy/CHANGELOG.md` states that releases follow Semantic Versioning, with no pre-1.0 exemption. A patch release promises backward compatibility, so shipping a documented breaking change as 0.25.1 would break that promise silently for anyone pinning `~=0.25.0`.

The alternative was a cherry-pick of `#143` alone onto the `0.25.0` tag, giving downstream users a safe patch upgrade for the import-time work. That's worth doing if consumers are stuck on 0.25.x — but it creates a second release branch to reason about, and the main known consumer (`svy-sae`) pins `<0.25.0` today and needs a pin bump either way.

## Contents

- **BREAKING** — `Sample.weighting` returns a new `Sample` rather than mutating in place; `inplace=True` restores the old behaviour (#142)
- Three weighting fixes: BRR stratum validation, a stale error hint, and replicate-weight designs being dropped on regeneration (#142)
- `import svy` 0.80s → 0.24s, and `svy.datasets` now loads on first use (#143)

## Changelog housekeeping

The two merges each opened their own `### Changed` heading, so the section arrived split in two with the breaking change last. Merged into one, breaking change first — it's what a reader deciding whether to upgrade needs to see before anything else.

## Verification

- `3535 passed, 11 skipped, 10 xfailed`
- `svy.__version__` reports `0.26.0`; `uv.lock` regenerated
- Version bumped in `pyproject.toml` and `src/svy/__init__.py`, matching how 0.25.0 was cut

Tag and publish left to a maintainer.

## Downstream

`svy-sae` pins `svy[report]>=0.24.0,<0.25.0` and runs 0.24.0, so it sees none of this yet. Once released, bumping that pin takes its first-estimator cost from ~0.98s to ~0.42s — but it also picks up the weighting change, which is worth checking against rather than assuming.