### PR TITLE
ci: create the GitHub Release from the CHANGELOG on tag push

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -1,0 +1,84 @@
+"""Extract a package's release notes from its CHANGELOG, for `gh release create`.
+
+Run from a wheels workflow after a tag push. Writes the matching CHANGELOG
+section to a file and exits non-zero if it cannot, which is deliberate: a release
+with no notes, or one whose tag disagrees with the committed version, is a
+mistake worth stopping on rather than papering over.
+
+Usage:
+    python .github/scripts/release_notes.py --package svy --tag svy-v0.26.0 \
+        --out release-notes.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import re
+import sys
+
+
+def fail(message: str) -> None:
+    # `::error::` surfaces this in the Actions log and the job summary.
+    sys.exit(f"::error::{message}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--package", required=True, help="directory under packages/")
+    ap.add_argument("--tag", required=True, help="e.g. svy-v0.26.0")
+    ap.add_argument("--out", default="release-notes.md")
+    args = ap.parse_args()
+
+    root = pathlib.Path("packages") / args.package
+    prefix = f"{args.package}-v"
+    if not args.tag.startswith(prefix):
+        fail(f"tag {args.tag!r} does not start with {prefix!r}")
+    version = args.tag[len(prefix) :]
+
+    # The tagged commit must already carry this version. Tagging before the
+    # release PR lands would publish a wheel whose version disagrees with its
+    # tag — catchable here, and not on PyPI, where it cannot be undone.
+    pyproject = root / "pyproject.toml"
+    declared = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.M)
+    if not declared:
+        fail(f"no version found in {pyproject}")
+    if declared.group(1) != version:
+        fail(
+            f"tag {args.tag} does not match {pyproject} version {declared.group(1)}. "
+            "The version bump must be committed before the tag is pushed."
+        )
+
+    # Headings look like: '## [0.26.0] — 2026-08-26' (em dash).
+    changelog = root / "CHANGELOG.md"
+    text = changelog.read_text()
+    heading = re.search(rf"^## \[{re.escape(version)}\][^\n]*$", text, re.M)
+    if not heading:
+        fail(
+            f"no '## [{version}]' section in {changelog}. A release without notes is "
+            "almost certainly a mistake — stamp the CHANGELOG before tagging."
+        )
+
+    rest = text[heading.end() :]
+    following = re.search(r"^## \[", rest, re.M)
+    body = (rest[: following.start()] if following else rest).strip()
+    if not body:
+        fail(f"the '## [{version}]' section in {changelog} is empty")
+
+    pypi = f"https://pypi.org/project/{args.package}/{version}/"
+    link = (
+        f"https://github.com/samplics-org/svy/blob/main/packages/"
+        f"{args.package}/CHANGELOG.md"
+    )
+    body += (
+        f"\n\n---\n\nPublished to PyPI as [`{args.package} {version}`]({pypi}).\n"
+        f"Full changelog: [`packages/{args.package}/CHANGELOG.md`]({link})\n"
+    )
+
+    pathlib.Path(args.out).write_text(body)
+    print(f"{len(body.splitlines())} lines of notes for {args.package} {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/svy-io-wheels.yml
+++ b/.github/workflows/svy-io-wheels.yml
@@ -281,3 +281,30 @@ jobs:
         with:
           command: upload
           args: --skip-existing dist/*
+
+  release:
+    name: GitHub Release
+    needs: [publish]
+    # Tag pushes only — a workflow_dispatch to TestPyPI is a rehearsal and should
+    # not leave a release page behind.
+    if: startsWith(github.ref, 'refs/tags/svy-io-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Extract release notes from CHANGELOG
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy-io
+          --tag "${{ github.ref_name }}"
+          --out release-notes.md
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: >
+          gh release create "$TAG"
+          --title "svy-io ${TAG#svy-io-v}"
+          --notes-file release-notes.md
+          --verify-tag

--- a/.github/workflows/svy-io-wheels.yml
+++ b/.github/workflows/svy-io-wheels.yml
@@ -49,6 +49,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Verify tag matches the committed version and CHANGELOG
+        if: startsWith(github.ref, 'refs/tags/svy-io-v')
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy-io
+          --tag "${{ github.ref_name }}"
+          --out /dev/null
         with:
           submodules: false
 

--- a/.github/workflows/svy-rs-wheels.yml
+++ b/.github/workflows/svy-rs-wheels.yml
@@ -49,6 +49,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Verify tag matches the committed version and CHANGELOG
+        if: startsWith(github.ref, 'refs/tags/svy-rs-v')
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy-rs
+          --tag "${{ github.ref_name }}"
+          --out /dev/null
 
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:

--- a/.github/workflows/svy-rs-wheels.yml
+++ b/.github/workflows/svy-rs-wheels.yml
@@ -217,3 +217,30 @@ jobs:
         with:
           packages-dir: dist
           skip-existing: true
+
+  release:
+    name: GitHub Release
+    needs: [publish]
+    # Tag pushes only — a workflow_dispatch to TestPyPI is a rehearsal and should
+    # not leave a release page behind.
+    if: startsWith(github.ref, 'refs/tags/svy-rs-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Extract release notes from CHANGELOG
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy-rs
+          --tag "${{ github.ref_name }}"
+          --out release-notes.md
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: >
+          gh release create "$TAG"
+          --title "svy-rs ${TAG#svy-rs-v}"
+          --notes-file release-notes.md
+          --verify-tag

--- a/.github/workflows/svy-wheels.yml
+++ b/.github/workflows/svy-wheels.yml
@@ -58,3 +58,30 @@ jobs:
         with:
           packages-dir: dist
           skip-existing: true
+
+  release:
+    name: GitHub Release
+    needs: [publish]
+    # Tag pushes only — a workflow_dispatch to TestPyPI is a rehearsal and should
+    # not leave a release page behind.
+    if: startsWith(github.ref, 'refs/tags/svy-v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Extract release notes from CHANGELOG
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy
+          --tag "${{ github.ref_name }}"
+          --out release-notes.md
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        run: >
+          gh release create "$TAG"
+          --title "svy ${TAG#svy-v}"
+          --notes-file release-notes.md
+          --verify-tag

--- a/.github/workflows/svy-wheels.yml
+++ b/.github/workflows/svy-wheels.yml
@@ -24,6 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+      - name: Verify tag matches the committed version and CHANGELOG
+        if: startsWith(github.ref, 'refs/tags/svy-v')
+        run: >
+          python .github/scripts/release_notes.py
+          --package svy
+          --tag "${{ github.ref_name }}"
+          --out /dev/null
       - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2
         with:
           version: "latest"

--- a/makefile
+++ b/makefile
@@ -27,6 +27,11 @@ help:
 	@echo "  bench-check         - check for perf regressions vs the baseline (needs release build)"
 	@echo "  bench-record        - re-record the perf baseline (commit the result)"
 	@echo ""
+	@echo "Release Targets (PKG=svy|svy-io|svy-rs):"
+	@echo "  release-notes       - preview the notes CI will publish for the current version"
+	@echo "  release-check       - pre-flight a release BEFORE tagging (safe, read-only)"
+	@echo "  release-tag         - run release-check, then create and push the tag"
+	@echo ""
 	@echo "svy-io Targets (local dev only — published separately):"
 	@echo "  build-svy-io        - build svy-io native extension locally"
 	@echo "  test-svy-io         - run tests for svy-io"
@@ -186,3 +191,43 @@ clean:
 	rm -rf $(PKG_SVY)/dist
 	rm -rf $(PKG_SVY_IO)/dist
 	rm -rf $(PKG_SVY_RS)/target $(PKG_SVY_RS)/dist
+
+
+# ====== Release ======
+# Pushing a <pkg>-v* tag publishes to PyPI, and PyPI never lets a version number
+# be reused. CI checks the tag against the committed version, but it can only do
+# so once the tag exists — by which point the mistake is already made. These run
+# the same check locally, before the tag is created, which is the last point
+# where a wrong version costs nothing.
+.PHONY: release-notes release-check release-tag
+PKG     ?= svy
+VERSION  = $(shell sed -n 's/^version = "\(.*\)"/\1/p' packages/$(PKG)/pyproject.toml | head -1)
+TAG      = $(PKG)-v$(VERSION)
+
+release-notes:
+	@echo "▶ Notes CI would publish for $(PKG) $(VERSION):"
+	@$(PYTHON) .github/scripts/release_notes.py --package $(PKG) --tag $(TAG) --out /dev/stdout
+
+release-check:
+	@echo "▶ Pre-flight for $(TAG)"
+	@test -z "$$(git status --porcelain)" || { echo "  ✗ working tree is dirty"; exit 1; }
+	@echo "  ✓ working tree clean"
+	@test "$$(git rev-parse --abbrev-ref HEAD)" = "main" || { echo "  ✗ not on main"; exit 1; }
+	@echo "  ✓ on main"
+	@git fetch -q origin main && test -z "$$(git rev-list HEAD..origin/main)" || \
+		{ echo "  ✗ behind origin/main — pull first"; exit 1; }
+	@echo "  ✓ up to date with origin/main"
+	@git rev-parse -q --verify "refs/tags/$(TAG)" >/dev/null && \
+		{ echo "  ✗ tag $(TAG) already exists locally"; exit 1; } || true
+	@test -z "$$(git ls-remote --tags origin '$(TAG)')" || \
+		{ echo "  ✗ tag $(TAG) already exists on origin"; exit 1; }
+	@echo "  ✓ tag $(TAG) is free"
+	@$(PYTHON) .github/scripts/release_notes.py --package $(PKG) --tag $(TAG) --out /dev/null
+	@echo "  ✓ version and CHANGELOG agree"
+	@echo "▶ Ready. 'make release-tag PKG=$(PKG)' will publish $(PKG) $(VERSION) to PyPI."
+
+release-tag: release-check
+	@echo "▶ Tagging $(TAG) — this publishes to PyPI and cannot be undone."
+	git tag -a $(TAG) -m "$(PKG) $(VERSION)"
+	git push origin $(TAG)
+	@echo "▶ Pushed. Watch: gh run list --workflow=$(PKG)-wheels.yml --limit 1"


### PR DESCRIPTION
## Why

27 tags published, 0 release pages — until `svy-v0.26.0`, which I created by hand after the fact.

That ordering is backwards. The manual step gets skipped when someone is in a hurry, and hurried releases are the ones most needing notes. 0.26.0 is the case in point: it changes `Sample.weighting` from mutating in place to returning a new `Sample`, and until the page existed that warning lived only in `packages/svy/CHANGELOG.md`. A Dependabot PR proposing `0.25.0 → 0.26.0` would have shown an empty release body.

## What

Each of the three wheels workflows gets a `release` job after `publish`: extract the matching `## [X.Y.Z]` section from the package CHANGELOG, `gh release create`. Gated on tag pushes, so a `workflow_dispatch` rehearsal to TestPyPI leaves no page behind.

Extraction lives in `.github/scripts/release_notes.py` rather than as three copies of inline Python — the packages share a CHANGELOG format, and triplicated YAML-embedded scripts drift.

## It fails rather than degrades

Two guards, both deliberate:

- **No `## [X.Y.Z]` section for the tag** → the job fails. A release with no notes is a mistake, and a red build is how you find out.
- **Tag disagrees with the committed `pyproject.toml` version** → the job fails. This is the ordering error the flow invites: tag before the release PR lands, and the wheel's version contradicts its tag. Caught here it costs a re-tag; caught on PyPI it cannot be undone.

## Verification

Ran the extractor against all three packages at their current versions and both failure paths:

```
71 lines of notes for svy 0.26.0
30 lines of notes for svy-io 0.3.0
31 lines of notes for svy-rs 0.15.0

::error::tag svy-v9.9.9 does not match packages/svy/pyproject.toml version 0.26.0.
         The version bump must be committed before the tag is pushed.
::error::tag 'wrong-v0.26.0' does not start with 'svy-v'
```

All three workflows parse as valid YAML with the job wired to `needs: [publish]` and `contents: write`.

## Scope

Publishing is untouched. This only adds the page that should have accompanied it. The 26 earlier tags stay release-less — backfilling is possible but the value here is forward-looking.