### PR TITLE
docs: drop the commented-out Downloads badge from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 [![PyPI](https://img.shields.io/pypi/v/svy?color=blue)](https://pypi.org/project/svy/)
 [![Python](https://img.shields.io/pypi/pyversions/svy)](https://pypi.org/project/svy/)
-<!--[![Downloads](https://img.shields.io/pypi/dm/svy)](https://pypi.org/project/svy/)-->
-
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![Docs](https://img.shields.io/badge/docs-svylab.com-0b7285)](https://svylab.com/docs/svy)
 


### PR DESCRIPTION
Removes the commented-out Downloads badge and the stray blank line after it.

Your edit — I picked it up out of the working tree while staging the release-automation work, took it back out of that PR to keep it focused, and it needs its own PR since `main` requires one.