### PR TITLE
Calibration-aware variance for glm and t-tests, and the t-test FPC fix

### DIFF
--- a/packages/svy-rs/src/categorical/ranktest.rs
+++ b/packages/svy-rs/src/categorical/ranktest.rs
@@ -282,6 +282,7 @@ pub fn ranktest_two_sample(
         fpc,
         fpc_ssu,
         singleton_method,
+        None,
     )?;
 
     // 6. Test statistic
@@ -378,7 +379,7 @@ pub fn ranktest_k_sample(
         fit_wols(&rankscore, &xmat, w, n, k).map_err(|e| PolarsError::ComputeError(e.into()))?;
 
     // 4. Design-based covariance of coefficients
-    let cov_flat = influence_covariance(&wols.influence, w, n, k, strata, psu, singleton_method)?;
+    let cov_flat = influence_covariance(&wols.influence, w, n, k, strata, psu, singleton_method, None)?;
 
     // 5. Wald test on non-intercept coefficients
     // Extract beta[-1] and V[-1,-1]
@@ -421,6 +422,7 @@ pub fn ranktest_k_sample(
         fpc,
         fpc_ssu,
         singleton_method,
+        None,
     )?;
 
     let mut group_means = vec![wols.beta[0]]; // reference group mean

--- a/packages/svy-rs/src/categorical/ranktest.rs
+++ b/packages/svy-rs/src/categorical/ranktest.rs
@@ -379,7 +379,8 @@ pub fn ranktest_k_sample(
         fit_wols(&rankscore, &xmat, w, n, k).map_err(|e| PolarsError::ComputeError(e.into()))?;
 
     // 4. Design-based covariance of coefficients
-    let cov_flat = influence_covariance(&wols.influence, w, n, k, strata, psu, singleton_method, None)?;
+    let cov_flat =
+        influence_covariance(&wols.influence, w, n, k, strata, psu, singleton_method, None)?;
 
     // 5. Wald test on non-intercept coefficients
     // Extract beta[-1] and V[-1,-1]

--- a/packages/svy-rs/src/categorical/ttest.rs
+++ b/packages/svy-rs/src/categorical/ttest.rs
@@ -219,6 +219,7 @@ pub fn ttest_two_sample(
         fpc,
         fpc_ssu,
         singleton_method,
+        calib,
     )?;
 
     // coef[1] = difference in means, SE[1] = design-based SE

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -744,7 +744,9 @@ pub fn scores_ratio_domain(
 /// R's survey package. The score is that residual **centered on its own
 /// weighted mean**, exactly as the linearization of a weighted mean does:
 ///
-///     score_i = (w_i / sum_w) * (u_i - u_bar),   u_bar = sum(w_i u_i) / sum_w
+/// ```text
+/// score_i = (w_i / sum_w) * (u_i - u_bar),   u_bar = sum(w_i u_i) / sum_w
+/// ```
 ///
 /// The centering is not cosmetic. `u_bar` is zero only if `F(q)` lands exactly
 /// on `p`, which discreteness prevents — on a 5000-row fixture it sits around

--- a/packages/svy-rs/src/regression/api.rs
+++ b/packages/svy-rs/src/regression/api.rs
@@ -12,6 +12,7 @@ use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 
+use crate::estimation::calib_sweep::{CalibSpec, CalibSweep, build_calib_sweep};
 use crate::regression::glm::{fit_glm, fit_glm_by};
 
 type GlmTuple = (
@@ -54,6 +55,12 @@ fn optional_column_to_series(df: &DataFrame, name: &Option<String>) -> PyResult<
     tol=1e-8,
     max_iter=100,
     data=None,
+    calib_kind=None,
+    calib_cells=None,
+    calib_aux=None,
+    calib_prev_wgt=None,
+    calib_pins_total=None,
+    calib_new_wgt=None,
 ))]
 pub fn fit_glm_rs(
     _py: Python,
@@ -69,6 +76,12 @@ pub fn fit_glm_rs(
     tol: f64,
     max_iter: usize,
     data: Option<PyDataFrame>,
+    calib_kind: Option<String>,
+    calib_cells: Option<Vec<String>>,
+    calib_aux: Option<Vec<String>>,
+    calib_prev_wgt: Option<String>,
+    calib_pins_total: Option<bool>,
+    calib_new_wgt: Option<String>,
 ) -> PyResult<Vec<GlmTuple>> {
     let df: DataFrame = data
         .ok_or_else(|| PyErr::new::<pyo3::exceptions::PyValueError, _>("`data` is required"))?
@@ -86,6 +99,23 @@ pub fn fit_glm_rs(
     let psu = optional_column_to_series(&df, &psu_name)?;
     let fpc = optional_column_to_series(&df, &fpc_name)?;
 
+    // The weight-adjustment record, when Python judged it still valid. `new_wgt`
+    // is normally the active weight; a subpopulation filter zeroes that column in
+    // place, so Python snapshots the full-sample calibrated weights and names the
+    // snapshot here.
+    let calib: Option<CalibSweep> = calib_kind.and_then(|kind| {
+        let spec = CalibSpec {
+            kind,
+            cells_cols: calib_cells.unwrap_or_default(),
+            aux_cols: calib_aux.unwrap_or_default(),
+            prev_wgt_col: calib_prev_wgt?,
+            new_wgt_col: calib_new_wgt.unwrap_or_else(|| weight_name.clone()),
+            pins_total: calib_pins_total.unwrap_or(true),
+        };
+        build_calib_sweep(&df, &spec)
+    });
+    let calib = calib.as_ref();
+
     // No by_col: single fit, wrap in one-element vec for API uniformity.
     if by_col.is_none() {
         // Release the GIL for the (iterative, CPU-bound) IRLS solve.
@@ -102,6 +132,7 @@ pub fn fit_glm_rs(
                     &link,
                     tol,
                     max_iter,
+                    calib,
                 )
             })
             .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
@@ -138,6 +169,7 @@ pub fn fit_glm_rs(
                 &link,
                 tol,
                 max_iter,
+                calib,
             )
         })
         .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -23,6 +23,8 @@ use faer::prelude::Solve;
 use faer::{Mat, MatRef, Side};
 
 use polars::prelude::*;
+
+use crate::estimation::calib_sweep::CalibSweep;
 use rayon::prelude::*;
 use std::collections::HashMap;
 
@@ -457,9 +459,10 @@ pub fn fit_glm(
     link_str: &str,
     tol: f64,
     max_iter: usize,
+    calib: Option<&CalibSweep>,
 ) -> PolarsResult<GlmResult> {
     fit_glm_domain(
-        y, x_cols, weights, strata, psu, fpc, None, family_str, link_str, tol, max_iter,
+        y, x_cols, weights, strata, psu, fpc, None, family_str, link_str, tol, max_iter, calib,
     )
 }
 
@@ -482,6 +485,7 @@ pub fn fit_glm_by(
     link_str: &str,
     tol: f64,
     max_iter: usize,
+    calib: Option<&CalibSweep>,
 ) -> PolarsResult<Vec<(String, GlmResult)>> {
     // Materialize by_col as strings, enumerate unique levels.
     let by_str_series = by_col.cast(&DataType::String)?;
@@ -516,6 +520,7 @@ pub fn fit_glm_by(
                 link_str,
                 tol,
                 max_iter,
+                calib,
             );
             (group_val.to_string(), res)
         })
@@ -561,6 +566,7 @@ fn fit_glm_domain(
     link_str: &str,
     tol: f64,
     max_iter: usize,
+    calib: Option<&CalibSweep>,
 ) -> PolarsResult<GlmResult> {
     let family = Family::from_str(family_str)?;
     let link = Link::from_str(link_str)?;
@@ -826,9 +832,55 @@ fn fit_glm_domain(
         None => None,
     };
 
+    // Score contribution (estimating function) for row i: w (y - mu) (dmu/deta) / V.
+    // Computed directly instead of w_irls * working_resid: the working-residual
+    // guard (d + eps) biased scores wherever dmu/deta is small (visible at ~1e-7
+    // in SEs), while for canonical links d/V cancels exactly.
+    //
+    // Domain-aware: w_irls[i] is 0 for out-of-domain rows, which therefore score 0.
+    let score_at = |i: usize| -> f64 {
+        let w_i = w_samp[i];
+        if w_i <= 0.0 || w_irls[i] <= 0.0 {
+            return 0.0;
+        }
+        let mu_i = mu[i];
+        let d = link.mu_eta(mu_i, eta[i]);
+        let v = family.variance(mu_i).max(1e-12);
+        w_i * (Y[(i, 0)] - mu_i) * d / v
+    };
+
+    // Calibration-aware variance. R centres the INFLUENCE functions --
+    // `svyrecvar(estfun %*% Ainv, ..., postStrata=)` in `svy.varcoef` -- but every
+    // sweep branch is a left multiplication by an operator fixed by the weights,
+    // cells and aux matrix alone, applied identically to each column. It therefore
+    // commutes with the bread: S(E A) = (S E) A, so centring the estimating
+    // functions here and sandwiching afterwards is the same estimator. Checked
+    // against survey 4.5 on apiclus1 (both routes agree to 1.6e-14).
+    //
+    // Two things the sweep needs that the uncentred path does not. Every row must
+    // be materialised, zero-score ones included: their weight carries the cell
+    // denominators. And every row must then be ACCUMULATED, because centring
+    // leaves a zero-score row nonzero -- it is charged its cell's mean. Skipping
+    // them is what makes a nearly-right SE.
+    //
+    // Column-major so each column hands `apply` a contiguous slice.
+    let ef: Option<Vec<f64>> = calib.map(|c| {
+        let mut m = vec![0.0; n * k];
+        for i in 0..n {
+            let s_i = score_at(i);
+            if s_i != 0.0 {
+                for j in 0..k {
+                    m[j * n + i] = s_i * X[(i, j)];
+                }
+            }
+        }
+        for j in 0..k {
+            c.apply(&mut m[j * n..(j + 1) * n]);
+        }
+        m
+    });
+
     // MEAT = sum_h Var_h( PSU totals ) with svytotal-style centering.
-    // Out-of-domain rows have w_irls[i] == 0 from build_irls_normal_eqs, so
-    // their score contributions are naturally 0.
     let mut meat_acc = vec![Kahan::new(); k * k];
 
     for h in 0..n_strata {
@@ -843,28 +895,21 @@ fn fit_glm_domain(
                 new_i
             });
 
-            let w_i = w_samp[i];
-            let w_irls_i = w_irls[i];
-
-            // Domain-aware: w_irls_i is 0 for out-of-domain rows.
-            if w_i <= 0.0 || w_irls_i <= 0.0 {
-                continue;
-            }
-
-            let y_i = Y[(i, 0)];
-            let mu_i = mu[i];
-            let d = link.mu_eta(mu_i, eta[i]);
-            let v = family.variance(mu_i).max(1e-12);
-
-            // Score contribution (estimating function): w (y - mu) (dmu/deta) / V.
-            // Computed directly instead of w_irls * working_resid: the
-            // working-residual guard (d + eps) biased scores wherever
-            // dmu/deta is small (visible at ~1e-7 in SEs), while for
-            // canonical links d/V cancels exactly.
-            let s_i = w_i * (y_i - mu_i) * d / v;
-
-            for j in 0..k {
-                totals[li][j].add(s_i * X[(i, j)]);
+            match &ef {
+                Some(m) => {
+                    for j in 0..k {
+                        totals[li][j].add(m[j * n + i]);
+                    }
+                }
+                None => {
+                    if w_samp[i] <= 0.0 || w_irls[i] <= 0.0 {
+                        continue;
+                    }
+                    let s_i = score_at(i);
+                    for j in 0..k {
+                        totals[li][j].add(s_i * X[(i, j)]);
+                    }
+                }
             }
         }
 

--- a/packages/svy-rs/src/regression/wols.rs
+++ b/packages/svy-rs/src/regression/wols.rs
@@ -16,6 +16,8 @@
 //   SE(tot.infn)  # design-based SE for each coefficient
 
 use polars::prelude::*;
+
+use crate::estimation::calib_sweep::CalibSweep;
 use std::collections::HashMap;
 
 use crate::estimation::taylor::taylor_variance;
@@ -296,19 +298,25 @@ pub fn influence_se(
     fpc: Option<&Float64Chunked>,
     fpc_ssu: Option<&Float64Chunked>,
     singleton_method: Option<&str>,
-    // NOTE: no calibration sweep here. These influence functions already carry
-    // the bread matrix; R sweeps the estimating functions BEFORE the bread, and
-    // since the sweep is per-column while the bread mixes columns, sweeping
-    // afterwards is not equivalent -- it lands within about 1% of R, which is
-    // worse than not sweeping because it looks correct. Doing it properly means
-    // sweeping where the scores are built, the same change glm.rs needs.
+    // Swept here, on the weight-scaled influence functions, because that is
+    // literally R's matrix: `svy.varcoef` calls
+    // `svyrecvar(estfun %*% Ainv, ..., postStrata=)`, and `influence * w` IS
+    // `estfun %*% Ainv`. Sweeping after the bread is not the compromise an
+    // earlier note here claimed -- every sweep branch is a left multiplication
+    // by an operator fixed by the weights, cells and aux alone, applied
+    // identically to each column, so it commutes with any right multiplication:
+    // S(E A) = (S E) A. Confirmed against survey 4.5 on apiclus1.
+    calib: Option<&CalibSweep>,
 ) -> PolarsResult<Vec<f64>> {
     let mut ses = Vec::with_capacity(k);
 
     for j in 0..k {
         // Extract column j of influence matrix, scaled by weights:
         // score_i = infn_i * w_i  (matches R's svytotal internals)
-        let col_vals: Vec<f64> = (0..n).map(|i| influence[i * k + j] * w[i]).collect();
+        let mut col_vals: Vec<f64> = (0..n).map(|i| influence[i * k + j] * w[i]).collect();
+        if let Some(c) = calib {
+            c.apply(&mut col_vals);
+        }
         let scores = Float64Chunked::from_vec("infn".into(), col_vals);
 
         let var = taylor_variance(&scores, strata, psu, ssu, fpc, fpc_ssu, singleton_method)?;
@@ -334,12 +342,15 @@ pub fn influence_covariance(
     strata: Option<&Column>,
     psu: Option<&Column>,
     singleton_method: Option<&str>,
-    // NOTE: no calibration sweep here. These influence functions already carry
-    // the bread matrix; R sweeps the estimating functions BEFORE the bread, and
-    // since the sweep is per-column while the bread mixes columns, sweeping
-    // afterwards is not equivalent -- it lands within about 1% of R, which is
-    // worse than not sweeping because it looks correct. Doing it properly means
-    // sweeping where the scores are built, the same change glm.rs needs.
+    // Swept here, on the weight-scaled influence functions, because that is
+    // literally R's matrix: `svy.varcoef` calls
+    // `svyrecvar(estfun %*% Ainv, ..., postStrata=)`, and `influence * w` IS
+    // `estfun %*% Ainv`. Sweeping after the bread is not the compromise an
+    // earlier note here claimed -- every sweep branch is a left multiplication
+    // by an operator fixed by the weights, cells and aux alone, applied
+    // identically to each column, so it commutes with any right multiplication:
+    // S(E A) = (S E) A. Confirmed against survey 4.5 on apiclus1.
+    calib: Option<&CalibSweep>,
 ) -> PolarsResult<Vec<f64>> {
     // Index strata and PSUs. The GLM/WOLS prep always passes String design
     // columns (it does not use the Phase C integer-code cache), and this path
@@ -397,6 +408,22 @@ pub fn influence_covariance(
 
     let mut cov = vec![0.0; k * k];
 
+    // Weight-scaled influence, centred against the calibration when the design
+    // carries a record. Materialised column-major only in that case: `apply`
+    // wants a contiguous column, and the uncentred path has no reason to pay
+    // for the copy.
+    let swept: Option<Vec<f64>> = calib.map(|c| {
+        let mut m = vec![0.0; n * k];
+        for j in 0..k {
+            let col = &mut m[j * n..(j + 1) * n];
+            for (i, slot) in col.iter_mut().enumerate() {
+                *slot = influence[i * k + j] * w[i];
+            }
+            c.apply(col);
+        }
+        m
+    });
+
     // Pre-build strata → obs index to avoid O(n_strata × N) scan
     let mut strata_obs: Vec<Vec<usize>> = vec![Vec::new(); n_strata as usize];
     for i in 0..n {
@@ -416,9 +443,18 @@ pub fn influence_covariance(
                 psu_totals.push(vec![0.0; k]);
                 idx
             });
-            for j in 0..k {
-                // Weight-scaled influence: infn_i * w_i (matches R svytotal)
-                psu_totals[li][j] += influence[i * k + j] * w[i];
+            match &swept {
+                Some(m) => {
+                    for j in 0..k {
+                        psu_totals[li][j] += m[j * n + i];
+                    }
+                }
+                None => {
+                    for j in 0..k {
+                        // Weight-scaled influence: infn_i * w_i (matches R svytotal)
+                        psu_totals[li][j] += influence[i * k + j] * w[i];
+                    }
+                }
             }
         }
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -27,6 +27,10 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
   **Standardized weights are analysis-specific.** `where` bakes one variable's missingness into the weights and `by` bakes in the domain structure, so estimating a different variable or a different breakdown on the same standardized sample is silently wrong.
 
+- **Calibration-aware Taylor variance.** A weighting method that pins population quantities now records what it pinned, and the Taylor path centres the linearized scores against that structure — R `survey`'s `svyrecvar` `postStrata` loop. Covers `mean`, `total`, `ratio`, proportions, quantiles, tabulation, `glm`, and one- and two-sample t-tests, grouped and ungrouped, under poststratification, raking, GREG calibration and standardization.
+
+  Verified against survey 4.5 on apiclus1 to twelve significant figures or better, including the cases where the two implementations are easy to get subtly wrong: raking centres on the *unweighted* margin mean, GREG fits its residual with the *previous* weights, and cell means are always whole-sample — a subpopulation filter does not restrict them, because the adjustment was not performed inside the subpopulation.
+
 - **`where=` on all seven weighting methods.** Scope, not domain: matching rows receive the adjustment, and the rest keep their previous weight, so the new column is complete and `design.wgt` can repoint to it. This is the same keyword and the same reading as estimation's `where=`, with a different consequence — estimation zero-weights for subpopulation variance.
 
 ### Changed
@@ -45,10 +49,14 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Fixed
 
+- **`categorical.ttest` ignored the finite population correction.** The t-test built its variance without ever asking for an FPC column, so on a design with `pop_size` it returned the answer for sampling with replacement — standard errors too wide, `t` too small. One- and two-sample tests were both affected; on apiclus1 the statistic was off by a factor of `1/sqrt(1 − 15/757)`. It now matches R `svyttest` to fourteen significant figures.
+
 - **One target-resolution path.** `normalize` and `poststratify` derived their control arrays independently, with two different label-to-code conventions. Both now resolve every argument form to absolute per-cell targets in one place, which is also the single form crossing into Rust.
 
 
-> **Note on variance after a calibrating adjustment.** `poststratify`, `rake`, `calibrate` and `standardize` pin quantities in the population, which removes sampling variability. svy's *replication* path accounts for this today — each replicate column is independently re-adjusted — so `method="replication"` gives correct standard errors on a calibrated design. The *Taylor* path does not yet: it treats the adjusted weights as fixed, so its standard errors answer a slightly different question. Point estimates are unaffected. On the NHANES standardization example the Taylor SEs differ from R by roughly −11% to +14%; the replication SEs do not.
+> **Note on variance after a calibrating adjustment.** `poststratify`, `rake`, `calibrate` and `standardize` pin quantities in the population, which removes sampling variability. Both variance paths now account for this: replication re-adjusts each replicate column, and Taylor centres the linearized scores within the pinned cells. Previously only replication did, so Taylor standard errors on a calibrated design answered a slightly different question — on the NHANES standardization example they differed from R by roughly −11% to +14%. Point estimates were never affected.
+>
+> The record is honoured only while it still describes the data. Estimating on a different weight, or dropping a column the adjustment referenced, falls back to treating weights as fixed — and says so, once per data/design rebind.
 
 
 ## [0.26.0] — 2026-08-28

--- a/packages/svy/src/svy/categorical/base.py
+++ b/packages/svy/src/svy/categorical/base.py
@@ -457,6 +457,18 @@ class Categorical:
             TTestOneGroup for one-sample tests, TTestTwoGroups for two-sample tests.
             When `by` is specified, returns a list of test results.
         """
+        # The population-size column has to survive prepare_data's projection
+        # for the FPC to be computable below.
+        pop_size = self._sample._design.pop_size
+        pop_cols: list[str] = []
+        if pop_size is not None:
+            _pop = pop_size if isinstance(pop_size, str) else pop_size.psu
+            if isinstance(_pop, str):
+                pop_cols.append(_pop)
+            _ssu = None if isinstance(pop_size, str) else pop_size.ssu
+            if isinstance(_ssu, str):
+                pop_cols.append(_ssu)
+
         prep = prepare_data(
             self._sample,
             y=y,
@@ -464,6 +476,7 @@ class Categorical:
             y_pair=y_pair,
             by=by,
             where=where,
+            extra_cols=pop_cols,
             drop_nulls=drop_nulls,
             cast_y_float=True,
             select_columns=True,
@@ -471,18 +484,33 @@ class Categorical:
         )
         y_name = f"svy_{y}_minus_{y_pair}" if y_pair else y
 
+        # FPC. prepare_data leaves this to each facade, and this one used to
+        # skip it, so every t-test on a design with pop_size silently answered
+        # the fpc-free question -- R's svyttest, which routes through svyglm on
+        # the full design, applies it.
+        ttest_df = prep.df
+        fpc_col = fpc_ssu_col = None
+        if pop_size is not None:
+            from svy.estimation._fpc import compute_fpc_columns
+
+            ttest_df, fpc_col, fpc_ssu_col = compute_fpc_columns(
+                ttest_df, pop_size, prep.strata_col, prep.psu_col, prep.ssu_col
+            )
+
         # Single Rust call — handles by-levels internally
         result_df: pl.DataFrame = rs.ttest_rs(
-            prep.df,
+            ttest_df,
             y_col=prep.y_col,
             weight_col=prep.weight_col,
             group_col=group,
             strata_col=prep.strata_col,
             psu_col=prep.psu_col,
             ssu_col=prep.ssu_col,
+            fpc_col=fpc_col,
+            fpc_ssu_col=fpc_ssu_col,
             singleton_method=prep.singleton_method,
             null_value=float(mean_h0),
-            **calib_kwargs(self._sample, prep.df),
+            **calib_kwargs(self._sample, ttest_df),
             domain_col=prep.domain_col,
             domain_val=prep.domain_val,
             by_col=prep.by_col,

--- a/packages/svy/src/svy/estimation/_fpc.py
+++ b/packages/svy/src/svy/estimation/_fpc.py
@@ -2,7 +2,7 @@
 """
 Finite Population Correction (FPC) column construction.
 
-Module-level functions that take an Estimation instance as first argument.
+Module-level helpers shared by the estimation, regression and t-test facades.
 Used by taylor.py for FPC-corrected variance estimation.
 """
 
@@ -10,22 +10,16 @@ from __future__ import annotations
 
 import logging
 
-from typing import TYPE_CHECKING
-
 import polars as pl
 
 from svy.core.design import PopSize
 from svy.errors import DimensionError, MethodError
 
 
-if TYPE_CHECKING:
-    from svy.estimation.base import Estimation
-
 log = logging.getLogger(__name__)
 
 
 def compute_fpc_columns(
-    est: Estimation,
     data: pl.DataFrame,
     pop_size: str | PopSize,
     strata_col: str | None,

--- a/packages/svy/src/svy/estimation/base.py
+++ b/packages/svy/src/svy/estimation/base.py
@@ -303,7 +303,7 @@ class Estimation:
     def _compute_fpc_columns(self, data, pop_size, strata_col, psu_col, ssu_col=None):
         from svy.estimation._fpc import compute_fpc_columns
 
-        return compute_fpc_columns(self, data, pop_size, strata_col, psu_col, ssu_col)
+        return compute_fpc_columns(data, pop_size, strata_col, psu_col, ssu_col)
 
     # ----------------------------------------------------------------
     # Internal Helpers

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -22,7 +22,7 @@ except ImportError:
     import svy_rs as rs
 
 from svy.core.containers import FDist, TDist
-from svy.core.data_prep import prepare_data
+from svy.core.data_prep import calib_kwargs, prepare_data
 from svy.core.terms import Cat, Cross, Feature
 from svy.core.types import WhereArg
 from svy.errors.model_errors import ModelError
@@ -444,6 +444,22 @@ class GLM:
 
             df, fpc_name = build_fpc_psu_column(df, pop_cols[0], s_col, p_col, "__svy_fpc_psu__")
 
+        # The weight-adjustment record, if one still describes this data. Only
+        # the main-weight fit is swept: replicate columns were re-adjusted one by
+        # one when they were built, which is replication's own way of crediting
+        # the calibration.
+        calib_kw = calib_kwargs(self._sample, df)
+        calib_cols = [
+            c
+            for c in (
+                calib_kw.get("calib_prev_wgt"),
+                calib_kw.get("calib_new_wgt"),
+                *(calib_kw.get("calib_cells") or ()),
+                *(calib_kw.get("calib_aux") or ()),
+            )
+            if c
+        ]
+
         # Build final selection — include the by_col when domain is set
         final_selects = (
             [pl.col(y).cast(pl.Float64)] + feature_exprs + [pl.col(w_col).cast(pl.Float64)]
@@ -459,6 +475,13 @@ class GLM:
         for rc in rep_cols:
             if rc in df.columns:
                 final_selects.append(pl.col(rc).cast(pl.Float64))
+        _already = {y, w_col, s_col, p_col, by_col_name, fpc_name}
+        _already.update(feature_names)
+        _already.update(rep_cols)
+        for cc in calib_cols:
+            if cc in df.columns and cc not in _already:
+                _already.add(cc)
+                final_selects.append(pl.col(cc))
 
         try:
             eng_df: pl.DataFrame = df.select(final_selects)
@@ -493,6 +516,7 @@ class GLM:
                 tol=tol,
                 max_iter=max_iter,
                 data=eng_df,
+                **(calib_kw if weight_name == w_col else {}),
             )
             if not res:
                 raise RuntimeError("GLM engine returned no results.")

--- a/packages/svy/tests/svy/weighting/test_calibration_variance.py
+++ b/packages/svy/tests/svy/weighting/test_calibration_variance.py
@@ -408,10 +408,8 @@ def test_glm_sweep_tightens_the_se(design):
 
 # --- t-tests -----------------------------------------------------------------
 #
-# On designs with NO population size, where svy and R agree exactly. svy's
-# t-test facade does not yet hand Rust an FPC column, so a `pop_size` design
-# still answers the fpc-free question; that gap is independent of calibration
-# and is pinned by `test_ttest_still_ignores_the_fpc` below.
+# First on designs with NO population size, isolating the sweep from the FPC;
+# the `pop_size` cases follow below.
 
 R_TT2_PS_NOFPC_T = 1.74431180795363
 R_TT2_PS_NOFPC_DIFF = 35.0985134660009
@@ -448,21 +446,44 @@ def test_one_sample_ttest_poststratified_matches_r(design_nofpc):
     assert_allclose(tt["t"][0], R_TT1_PS_NOFPC_T, rtol=1e-10)
 
 
-def test_ttest_still_ignores_the_fpc(design, design_nofpc):
-    """Pins a gap that is NOT calibration's: the t-test facade passes Rust no
-    FPC column, so a design with `pop_size` answers the fpc-free question.
+# On designs WITH a population size. The t-test facade builds the FPC column
+# itself, as the estimation and regression facades do; before it did, every
+# t-test on a `pop_size` design answered the fpc-free question, and the ratio
+# -- exactly 1/sqrt(1 - 15/757), present with or without an adjustment -- was
+# once misread as a failure of the calibration sweep.
 
-    R's svyttest on the poststratified design with fpc gives 1.76185477505784;
-    without it, 1.74431180795363. svy returns the latter either way. Reading
-    that difference as a failure of the calibration sweep is what stalled this
-    work once already -- the ratio is exactly 1/sqrt(1 - 15/757), with or
-    without an adjustment.
-    """
+R_TT2_BASE_T = 2.10898984779292
+R_TT1_BASE_T = 1.87617650680004
+R_TT2_PS_T = 1.76185477505784
+R_TT1_PS_T = 1.76880968991608
+
+
+def test_ttest_applies_the_fpc(design):
+    """No adjustment: the FPC alone, against R."""
+    d = design()
+    two = d.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
+    one = d.categorical.ttest("api00", mean_h0=600).to_polars()["t"][0]
+    assert_allclose(two, R_TT2_BASE_T, rtol=1e-10)
+    assert_allclose(one, R_TT1_BASE_T, rtol=1e-10)
+
+
+def test_ttest_poststratified_with_fpc_matches_r(design):
+    """Both corrections at once -- the sweep and the FPC."""
+    ps = design().weighting.poststratify(STYPE_POP, cells="stype")
+    two = ps.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
+    one = ps.categorical.ttest("api00", mean_h0=600).to_polars()["t"][0]
+    assert_allclose(two, R_TT2_PS_T, rtol=1e-10)
+    assert_allclose(one, R_TT1_PS_T, rtol=1e-10)
+
+
+def test_ttest_fpc_tightens_the_se(design, design_nofpc):
+    """Sampling a known share of a finite population removes variability, so
+    the corrected t must be the larger one."""
     ps = design().weighting.poststratify(STYPE_POP, cells="stype")
     ps0 = design_nofpc().weighting.poststratify(STYPE_POP, cells="stype")
     with_pop = ps.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
     without = ps0.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
-    assert with_pop == pytest.approx(without, rel=1e-12)
+    assert with_pop > without
 
 
 # ---------------------------------------------------------------------------

--- a/packages/svy/tests/svy/weighting/test_calibration_variance.py
+++ b/packages/svy/tests/svy/weighting/test_calibration_variance.py
@@ -333,20 +333,136 @@ def test_poststratified_median_se_matches_r(design):
     assert_allclose(got, R_PS_MEDIAN_SE, rtol=1e-9)
 
 
-def test_regression_paths_are_not_yet_calibration_aware(design):
-    """Explicitly pins what is NOT done, so it cannot be mistaken for done.
+# ---------------------------------------------------------------------------
+# Regression paths
+#
+# glm and the two-sample t-test build variance from influence functions that
+# already carry the bread matrix, and an earlier reading of R took that to mean
+# the sweep could not be applied there. It can. `svy.varcoef` calls
+# `svyrecvar(estfun %*% Ainv, ..., postStrata=)` -- R centres AFTER the bread --
+# and every sweep branch is a left multiplication by an operator fixed by the
+# weights, cells and aux alone, applied identically to each column. It therefore
+# commutes with any right multiplication: S(E A) = (S E) A. glm centres its
+# estimating functions and sandwiches after; wols centres `influence * w`, which
+# IS R's matrix. Both routes were checked against survey 4.5 and agree to 1.6e-14.
+# ---------------------------------------------------------------------------
 
-    `glm` and the two-sample t-test build variance from influence functions
-    that already carry the bread matrix. R sweeps the estimating functions
-    before the bread; since the sweep is per-column and the bread mixes
-    columns, sweeping afterwards is not equivalent. Their SEs therefore still
-    treat the weights as fixed -- use method="replication", which is correct
-    for every adjustment today.
+# svyglm(api00 ~ ell + meals, design=<adjusted>) on apiclus1
+R_GLM_PS_COEF = [808.90531325861, -0.423451436759323, -3.13332460445148]
+R_GLM_PS_SE = [19.638215620182, 0.301676353781227, 0.332436938999844]
+R_GLM_RAKE_COEF = [808.229191981178, -0.397809108649268, -3.14123469449935]
+R_GLM_RAKE_SE = [19.136719810137, 0.296963780915734, 0.330481840079923]
+R_GLM_GREG_COEF = [825.071694299282, -0.527397095251339, -3.1925326169424]
+R_GLM_GREG_SE = [13.8069914557681, 0.345353806000647, 0.308690697513365]
+
+X_COLS = ["ell", "meals"]
+
+
+def _glm(sample):
+    t = sample.glm.fit(y="api00", x=X_COLS).to_polars()
+    return t["estimate"].to_numpy(), t["std_err"].to_numpy()
+
+
+def test_glm_poststratified_matches_r(design):
+    """The cells sweep, reaching variance through glm's sandwich meat."""
+    ps = design().weighting.poststratify(STYPE_POP, cells="stype")
+    coef, se = _glm(ps)
+    assert_allclose(coef, R_GLM_PS_COEF, rtol=1e-10)
+    assert_allclose(se, R_GLM_PS_SE, rtol=1e-9)
+
+
+def test_glm_raked_matches_r(design):
+    """Per-margin sweep, alternated ten times, under the bread."""
+    rk = design().weighting.rake(
+        controls={"stype": STYPE_POP, "sch.wide": SCHWIDE_POP}, tol=1e-12, max_iter=200
+    )
+    coef, se = _glm(rk)
+    assert_allclose(coef, R_GLM_RAKE_COEF, rtol=1e-10)
+    assert_allclose(se, R_GLM_RAKE_SE, rtol=1e-9)
+
+
+def test_glm_calibrated_matches_r(design):
+    """GREG: the WLS residual sweep, fitted with the PREVIOUS weights."""
+    cal = design().weighting.calibrate(controls=GREG_CONTROLS)
+    coef, se = _glm(cal)
+    assert_allclose(coef, R_GLM_GREG_COEF, rtol=1e-10)
+    assert_allclose(se, R_GLM_GREG_SE, rtol=1e-9)
+
+
+def test_glm_calibration_does_not_move_the_coefficients(design):
+    """Centring is a variance operation. It must not touch a point estimate."""
+    ps = design().weighting.poststratify(STYPE_POP, cells="stype")
+    swept, _ = _glm(ps)
+    unswept, _ = _glm(_refit(ps))
+    assert_allclose(swept, unswept, rtol=1e-12)
+
+
+def test_glm_sweep_tightens_the_se(design):
+    """Pinning cells in the population removes variability the uncentred
+    estimator still charges for, so the swept SE must be the smaller one."""
+    ps = design().weighting.poststratify(STYPE_POP, cells="stype")
+    _, swept = _glm(ps)
+    _, unswept = _glm(_refit(ps))
+    assert (swept < unswept).all()
+
+
+# --- t-tests -----------------------------------------------------------------
+#
+# On designs with NO population size, where svy and R agree exactly. svy's
+# t-test facade does not yet hand Rust an FPC column, so a `pop_size` design
+# still answers the fpc-free question; that gap is independent of calibration
+# and is pinned by `test_ttest_still_ignores_the_fpc` below.
+
+R_TT2_PS_NOFPC_T = 1.74431180795363
+R_TT2_PS_NOFPC_DIFF = 35.0985134660009
+R_TT1_PS_NOFPC_T = 1.7511974720176
+R_TT2_RAKE_NOFPC_T = 1.74923396543338
+
+
+@pytest.fixture
+def design_nofpc(apiclus1):
+    def build():
+        return Sample(apiclus1, Design(wgt="pw", psu="dnum"))
+
+    return build
+
+
+def test_two_sample_ttest_poststratified_matches_r(design_nofpc):
+    ps = design_nofpc().weighting.poststratify(STYPE_POP, cells="stype")
+    tt = ps.categorical.ttest("api00", group="sch.wide").to_polars()
+    assert_allclose(tt["diff"][0], R_TT2_PS_NOFPC_DIFF, rtol=1e-12)
+    assert_allclose(tt["t"][0], R_TT2_PS_NOFPC_T, rtol=1e-10)
+
+
+def test_two_sample_ttest_raked_matches_r(design_nofpc):
+    rk = design_nofpc().weighting.rake(
+        controls={"stype": STYPE_POP, "sch.wide": SCHWIDE_POP}, tol=1e-12, max_iter=200
+    )
+    tt = rk.categorical.ttest("api00", group="sch.wide").to_polars()
+    assert_allclose(tt["t"][0], R_TT2_RAKE_NOFPC_T, rtol=1e-10)
+
+
+def test_one_sample_ttest_poststratified_matches_r(design_nofpc):
+    ps = design_nofpc().weighting.poststratify(STYPE_POP, cells="stype")
+    tt = ps.categorical.ttest("api00", mean_h0=600).to_polars()
+    assert_allclose(tt["t"][0], R_TT1_PS_NOFPC_T, rtol=1e-10)
+
+
+def test_ttest_still_ignores_the_fpc(design, design_nofpc):
+    """Pins a gap that is NOT calibration's: the t-test facade passes Rust no
+    FPC column, so a design with `pop_size` answers the fpc-free question.
+
+    R's svyttest on the poststratified design with fpc gives 1.76185477505784;
+    without it, 1.74431180795363. svy returns the latter either way. Reading
+    that difference as a failure of the calibration sweep is what stalled this
+    work once already -- the ratio is exactly 1/sqrt(1 - 15/757), with or
+    without an adjustment.
     """
     ps = design().weighting.poststratify(STYPE_POP, cells="stype")
-    tt = ps.categorical.ttest("api00", group="sch.wide").to_polars()
-    # R's svyttest on the poststratified design gives t = 1.76185477505784.
-    assert tt["t"][0] != pytest.approx(1.76185477505784, rel=1e-6)
+    ps0 = design_nofpc().weighting.poststratify(STYPE_POP, cells="stype")
+    with_pop = ps.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
+    without = ps0.categorical.ttest("api00", group="sch.wide").to_polars()["t"][0]
+    assert with_pop == pytest.approx(without, rel=1e-12)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Finishes the calibration-variance work #147 left open: `glm` and the two-sample t-test now credit a calibrating adjustment, and a pre-existing FPC bug in `ttest` is fixed.

`3261 passed, 1 skipped`; 121 Rust tests; `make bench-check` clean.

## Why the regression paths were held back, and why that was wrong

#147 stopped short of `glm` and the two-sample t-test on the reading that both build variance from influence functions that already carry the bread matrix, that R sweeps the estimating functions *before* the bread, and that a per-column sweep cannot commute with a bread that mixes columns. An attempt measured ~1% off R and was reverted.

Both halves of that were wrong.

R sweeps **after** the bread — `svy.varcoef` calls `svyrecvar(estfun %*% Ainv, ..., postStrata=)`. And the side does not matter: every branch of the `postStrata` loop is a left multiplication by an operator fixed by the weights, cells and aux matrix alone, applied identically to each column. A left operator commutes with any right multiplication, so `S(E·A) = (S·E)·A`. The bread mixing columns is precisely why it is safe. Both orders agree to 1.6e-14 on apiclus1.

So `glm` centres its estimating functions and sandwiches afterwards; `wols` centres `influence * w`, which *is* R's matrix. Two rules the uncentred path did not need: materialise every row, zero-score ones included — their weight carries the cell denominators — and then accumulate every row, because centring leaves a zero-score row charged its cell mean. Skipping either is what produces a nearly-right SE.

## The 1% was never the sweep

`categorical.ttest` never built an FPC column, so every t-test on a design with `pop_size` answered the with-replacement question — one-sample as well as two-sample. `prepare_data` leaves the FPC to each facade; estimation and regression build it, this one did not.

The gap was exactly `1/sqrt(1 - n/N)`, present with or without an adjustment. On apiclus1 that is `1/sqrt(1 - 15/757)` — the reverted attempt's `t = 1.7443` against R's `1.76185477505784` was svy's *correct* fpc-free answer, misread as a broken sweep. Its own test now pins the two apart so they cannot be confused again.

## Validation

Against R survey 4.5 on apiclus1:

- `glm` under poststratification, raking and GREG — coefficients and SEs to ~1e-14
- one- and two-sample t-tests, with and without an FPC, to ~1e-14, including `t = 1.7618547750578`
- uncalibrated results are bit-identical: the scope guard is unchanged and the estimating-function matrix is built only when a record is present

Binomial is covered on the same footing, with the usual caveat: against R's **default** `epsilon = 1e-8` the sandwich SEs sit ~1.4e-5 apart, which is R stopping one IRLS iteration short rather than a difference in svy. This is the artifact already documented in the svy-vs-R comparison note — coefficients agree to ~1e-10 regardless, but the SEs inherit the last IRLS state. With `control = list(epsilon = 1e-12)` agreement is ~6e-9, calibrated and uncalibrated alike.

## Performance

Measured against a rebuild of the pre-change commit, n = 1M. Uncalibrated `glm` 252.2 ms vs 256.2 ms and t-test 221.5 ms vs 222.6 ms — within noise. The sweep costs +5-6% for cells, +12-14% for GREG and +2% for the t-test, paid only when a record is present.

## Also

`compute_fpc_columns` loses an unused first parameter, now that three facades share it. A formula in a `///` comment is fenced so `cargo test --doc` stops trying to compile it — that doctest was already failing before this branch.
