### PR TITLE
docs(core): drop the stale NotImplemented marker on SingletonHandling.CENTER

### DIFF
--- a/packages/svy/src/svy/core/enumerations.py
+++ b/packages/svy/src/svy/core/enumerations.py
@@ -237,7 +237,7 @@ class SingletonHandling(Enum):
     COLLAPSE = "collapse"  # Merge into existing strata
     POOL = "pool"  # Combine singletons into pseudo-stratum
     SCALE = "scale"  # Post-hoc variance inflation (R's "average")
-    CENTER = "center"  # Grand-mean centering (R's "adjust") - NotImplemented
+    CENTER = "center"  # Grand-mean centering (R's "adjust", Stata's singleunit(centered))
 
 
 # @unique

--- a/packages/svy/src/svy/core/singleton.py
+++ b/packages/svy/src/svy/core/singleton.py
@@ -1019,7 +1019,9 @@ class Singleton:
         the variance estimation engine to compute singleton variance
         contribution using (stratum_total - grand_mean)².
 
-        This is equivalent to R's `lonely.psu = "adjust"` option.
+        This is equivalent to R's `lonely.psu = "adjust"` option and to
+        Stata's `singleunit(centered)` — the conventional lonely-PSU
+        handling for DHS analyses.
 
         Returns
         -------


### PR DESCRIPTION
Comment-only. `SingletonHandling.CENTER` was still marked `NotImplemented`, which it has not been for some time: it has a dispatch entry, a dedicated variance column (`__svy_var_is_singleton__`), and the grand-mean centering the marker said was missing.

Also records the Stata equivalence next to the R one. `CENTER` is R's `lonely.psu = "adjust"` and Stata's `singleunit(centered)`, and it is the conventional lonely-PSU handling for DHS analyses — worth saying where someone chooses between the four options.

No behaviour change: two comments and a docstring.
