### PR TITLE
fix(utils): name drop_nulls in the missing-values error

### DIFF
--- a/packages/svy/src/svy/utils/checks.py
+++ b/packages/svy/src/svy/utils/checks.py
@@ -223,7 +223,7 @@ def assert_no_missing(*, df: pl.DataFrame, subset: Sequence[str]) -> None:
         detail = ", ".join(missing_errors)
         raise ValueError(
             "Missing or invalid values found in required columns; "
-            "set drop_missing=True to automatically drop them. "
+            "set drop_nulls=True to automatically drop them. "
             f"Affected: {detail}"
         )
 


### PR DESCRIPTION
`assert_no_missing` told users to `set drop_missing=True`. That name is the internal helper in `checks.py`, not a public parameter — following the advice raised `TypeError: ... unexpected keyword argument 'drop_missing'`. The public parameter is `drop_nulls`.

```
sample.categorical.tabulate("col_with_nulls", units="percent")
# ValueError: ... set drop_missing=True ...
# -> tabulate() got an unexpected keyword argument 'drop_missing'
```

Not parameterized by caller: all four call sites (`data_prep`, `categorical/base`, `selection/srs`, `selection/pps`) have the same `if drop_nulls: ... else: assert_no_missing(...)` shape, so one name is correct for every caller.

Checked the rest of the package for the same leak — of the 16 error messages that advise setting a keyword, `drop_missing` was the only name with no parameter declaration anywhere. No test asserted on the old text.

Verified by reproducing first, then confirming `drop_nulls=True` works on the same call. `test_checks.py` passes.