### PR TITLE
fix(ci): read the changelog as UTF-8 in release_notes.py

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -40,7 +40,7 @@ def main() -> int:
     # release PR lands would publish a wheel whose version disagrees with its
     # tag — catchable here, and not on PyPI, where it cannot be undone.
     pyproject = root / "pyproject.toml"
-    declared = re.search(r'^version = "([^"]+)"', pyproject.read_text(), re.M)
+    declared = re.search(r'^version = "([^"]+)"', pyproject.read_text(encoding="utf-8"), re.M)
     if not declared:
         fail(f"no version found in {pyproject}")
     if declared.group(1) != version:
@@ -51,7 +51,7 @@ def main() -> int:
 
     # Headings look like: '## [0.26.0] — 2026-08-26' (em dash).
     changelog = root / "CHANGELOG.md"
-    text = changelog.read_text()
+    text = changelog.read_text(encoding="utf-8")
     heading = re.search(rf"^## \[{re.escape(version)}\][^\n]*$", text, re.M)
     if not heading:
         fail(
@@ -75,7 +75,7 @@ def main() -> int:
         f"Full changelog: [`packages/{args.package}/CHANGELOG.md`]({link})\n"
     )
 
-    pathlib.Path(args.out).write_text(body)
+    pathlib.Path(args.out).write_text(body, encoding="utf-8")
     print(f"{len(body.splitlines())} lines of notes for {args.package} {version}")
     return 0
 


### PR DESCRIPTION
Unblocks the svy-rs 0.16.0 release, which is tagged but did not publish.

## What happened

The tag-verification step added in #145 runs `release_notes.py` on every wheel platform. The script opens the changelog with no `encoding=`, so on Windows Python uses cp1252 and any non-cp1252 character raises `UnicodeDecodeError`.

`svy-rs-v0.16.0` hit it. All five wheel jobs succeeded — linux-x86_64, linux-aarch64, macos-x86_64, macos-arm64, sdist — and Windows failed on `(X'WX)⁻¹` in the changelog's 0.15.0 section. `Publish to PyPI` is `needs:`-gated, so **nothing shipped**: no PyPI upload, no GitHub Release. That gating worked exactly as intended.

## Not a new character

The offending byte predates `svy-rs-v0.14.0`. Both 0.14.0 and 0.15.0 released cleanly because the verification step did not exist yet — #145 landed after 0.15.0, so 0.16.0 is the first svy-rs release to run it.

## Blast radius

All three package workflows call this script, and `packages/svy/CHANGELOG.md` has the same hazard (an `❌` in the BRR error example). Without this, the next svy release fails the same way.

## Fix

Pin UTF-8 on all three file accesses in `release_notes.py`. Verified by reproducing the cp1252 decode against the current changelog (fails at byte 18661) and then running the script for real, which now emits the 24-line 0.16.0 notes.

## After merge

`svy-rs-v0.16.0` needs to move to the merge commit — it currently points at `baa7b2c`, which lacks the fix, and re-running the failed job would check out that same tag. Nothing was published under it, so moving it is safe.
