### PR TITLE
fix(ci): do not write release notes to /dev/null on Windows

### DIFF
--- a/.github/scripts/release_notes.py
+++ b/.github/scripts/release_notes.py
@@ -13,9 +13,26 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import os
 import pathlib
 import re
 import sys
+
+
+def is_null_device(path: str) -> bool:
+    """True when `path` names the platform's discard target.
+
+    The wheels workflows verify a tag by generating the notes and throwing
+    them away, passing `--out /dev/null`. That is not a path on Windows:
+    pathlib renders it `\\dev\\null` and the write raises FileNotFoundError.
+    Recognise the null device by name rather than trying to open it, so the
+    same invocation works on every runner.
+    """
+    return path.replace("\\", "/").lower() in {
+        "/dev/null",
+        "nul",
+        os.devnull.replace("\\", "/").lower(),
+    }
 
 
 def fail(message: str) -> None:
@@ -75,8 +92,13 @@ def main() -> int:
         f"Full changelog: [`packages/{args.package}/CHANGELOG.md`]({link})\n"
     )
 
+    lines = len(body.splitlines())
+    if is_null_device(args.out):
+        print(f"{lines} lines of notes for {args.package} {version} (verify only)")
+        return 0
+
     pathlib.Path(args.out).write_text(body, encoding="utf-8")
-    print(f"{len(body.splitlines())} lines of notes for {args.package} {version}")
+    print(f"{lines} lines of notes for {args.package} {version}")
     return 0
 
 


### PR DESCRIPTION
Second half of #153. Still blocking svy-rs 0.16.0.

## What happened

#153 pinned UTF-8 and the Windows job got one line further, to the write:

```
FileNotFoundError: [Errno 2] No such file or directory: '\\dev\\null'
  pathlib.Path(args.out).write_text(body, encoding="utf-8")
```

The wheels workflows verify a tag by generating the notes and discarding them with `--out /dev/null`. That is not a path on Windows — pathlib renders it `\dev\null`. The encoding crash was masking it, since the script died at the changelog read before ever reaching the write.

## Fix

Recognise the null device by name and skip the write. All three workflows keep passing `--out /dev/null` unchanged, and the real generation path (`--out release-notes.md`, read by the GitHub Release step) is untouched.

## Audited, not patched line by line

My mistake in #153 was fixing the reported line without reading the rest. This time the whole script was audited: the only platform-sensitive operations are the two reads #153 pinned and this write. Everything else is relative paths and regexes.

Verified locally on all three packages, both invocation styles, and both spellings of the null device:

```
verify-only  --out /dev/null   -> 24 lines of notes for svy-rs 0.16.0 (verify only)
verify-only  --out NUL         -> 24 lines ... (verify only), no file created
real write   --out /tmp/rn.md  -> 24 lines, file has 24 lines
svy-rs 0.16.0 / svy-io 0.3.0 / svy 0.26.0 all verify
```

That last line matters: the already-released svy-io and svy tags still validate, so this does not change behaviour for them.

## After merge

`svy-rs-v0.16.0` needs moving to the merge commit again — it points at `17ff34b`, which lacks this fix.
