### PR TITLE
release(svy): 0.27.0

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -6,7 +6,29 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ## [Unreleased]
 
+## [0.27.0] — 2026-08-31
+
 ### Added
+
+- **`svy.combine_samples()` — repeated cross-sections and panel waves.** Stacks several samples and analyzes them as one stratified design: data pooling, not estimate pooling. Each independent wave contributes its own strata (wave → stratum → PSU), so Taylor variance treats waves as independent without being told to. Caller order is time order, and an existing wave column (NHANES `SDDSRVYR`, say) is reused and validated rather than replaced.
+
+  ```python
+  svy.combine_samples([w1, w2, w3], adjust="average")   # period-average population
+  ```
+
+  `adjust="average"` divides the weights by k, which matters only for totals — means, proportions and ratios are invariant to it. `units="shared"` is the panel case, where the same units recur across waves.
+
+- **Linear contrasts over estimates, via `svy.estd()`.** Any `Estimate` or `GLMFit` can be contrasted against its own estimands using the between-estimate covariance:
+
+  ```python
+  m = sample.estimation.mean("api00", by="stype")
+  m.contrast(svy.estd("E") - svy.estd("H"))
+  fit.contrast({"H vs E": svy.estd("stype_H") - svy.estd("stype_E")})
+  ```
+
+  Accepts a contrast expression, a sparse `{key: coefficient}` dict, or several named contrasts at once. Keys are the row identities `keys()` lists, and metadata value labels are accepted wherever unambiguous. Inference is t-based on the full design df (R's `degf` convention), not the per-row domain-aware df.
+
+  Quantiles and medians raise rather than returning a number: Woodruff intervals do not arise from a linearized score column, so no between-quantile covariance exists to combine.
 
 - **Marginal effects for categorical predictors.** `margins()` now returns a discrete contrast per non-reference level — `mean_w[mu(x, var=k) - mu(x, var=ref)]` with a delta-method SE — instead of skipping the term. Matches R marginaleffects' factor contrasts; on apistrat the `stype` contrasts agree to 1e-9 and the SEs to 2e-10.
 
@@ -66,6 +88,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Changed
 
+- **Requires `svy-rs >= 0.16.0`.** The GLM offset and the probit/cloglog links call into kernel entry points 0.15.0 does not have, so the pin moves to `>=0.16.0,<0.17.0`.
+
 - **BREAKING: a family now admits only the links it has a model for.** `glm.fit()` validates the `family`/`link` pairing against the `okLinks` set of R's family constructors, so pairings that were never a model are rejected up front instead of failing deep in the kernel — or, in the case of `binomial` + `inverse_squared`, converging on a meaningless fit and reporting it as a result. Newly rejected: `logit`/`probit`/`cloglog` outside `binomial`, `inverse`/`inverse_squared` outside the families whose canonical link they are. Every previously working *model* still works; what stops working is the combinations that only appeared to.
 
 - **BREAKING: `by=` is now `cells=` on `adjust`, `normalize` and `poststratify`.** `cells` names the groups that each receive one derived adjustment factor; `by` continues to mean "repeat independently per group" everywhere it survives (`calibrate`, `trim`, and `standardize`). Keeping one word for both would have compromised a term of art.
@@ -81,6 +105,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 - **`rake` now rejects margins that disagree on a population total.** Margins were validated only in isolation, so inconsistent totals — the classic reason IPF fails to converge — simply ran to `max_iter` and returned whatever they reached. With `shares=` the consistency is structural.
 
 ### Fixed
+
+- **The missing-values error named a parameter that does not exist.** `assert_no_missing` told users to set `drop_missing=True`, which is the internal helper's argument, not a public one — following the advice raised `TypeError`. All four call sites gate on `drop_nulls`, which is what the message now says.
 
 - **`print()` on an `EstimateList` of proportions.** `prop()` over a sequence of variables built one level column *per variable*, so a diagonal concat unioned them into a staircase of mostly-empty columns — eight conditions gave eight sparse columns, a ~118-character box, and every number truncated to an ellipsis. The members now stack under one shared `level` column beside `y`, which for the eight-condition case brings the table to 71 characters at full precision.
 
@@ -733,7 +759,8 @@ Builds on [`svy-rs`](../svy-rs/CHANGELOG.md) 0.11.0 and [`svy-io`](../svy-io/CHA
 
 First release tracked in this changelog. For the history prior to 0.18.2, see the [Git tags](https://github.com/samplics-org/svy/tags) and [GitHub Releases](https://github.com/samplics-org/svy/releases).
 
-[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.26.0...HEAD
+[Unreleased]: https://github.com/samplics-org/svy/compare/svy-v0.27.0...HEAD
+[0.27.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.27.0
 [0.26.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.26.0
 [0.25.0]: https://github.com/samplics-org/svy/releases/tag/svy-v0.25.0
 [0.24.1]: https://github.com/samplics-org/svy/releases/tag/svy-v0.24.1

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "svy"
-version = "0.26.0"
+version = "0.27.0"
 description = "End-to-end surveys: design, sample, analyze, report."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/packages/svy/src/svy/__init__.py
+++ b/packages/svy/src/svy/__init__.py
@@ -143,7 +143,7 @@ from svy.weighting import Threshold, TrimConfig, TrimResult
 # Ensure no “No handlers could be found” warnings in user apps
 logging.getLogger(__name__).addHandler(logging.NullHandler())
 
-__version__ = "0.26.0"
+__version__ = "0.27.0"
 
 __all__ = [
     # --- Modules ----

--- a/uv.lock
+++ b/uv.lock
@@ -2332,7 +2332,7 @@ wheels = [
 
 [[package]]
 name = "svy"
-version = "0.26.0"
+version = "0.27.0"
 source = { editable = "packages/svy" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Cuts svy 0.27.0. `svy-rs 0.16.0` is [live on PyPI](https://pypi.org/project/svy-rs/0.16.0/), so the pin is satisfiable.

## Three entries were missing

Checked every commit since `svy-v0.26.0` against the changelog, the way the svy-rs release turned up three undocumented commits. Same result — these had landed with no entry:

- **`combine_samples()`** (#150) — repeated cross-sections and panel waves
- **Linear contrasts over estimates via `estd()`** (#151) — the original scope of that branch
- **The `drop_nulls` error-message fix** (#152)

All three are exported public API. They are written up now.

## Why minor, not patch

Five breaking changes: the family/link table, `by=` → `cells=`, `factors=` → `shares=`, the scalar-`controls` rule, and the `ModelType`/`FitMethod` removal.

## Pre-release checks

- `release_notes.py` verifies `svy-v0.27.0` — 124 lines of notes, in both the `/dev/null` and `NUL` spellings and under `PYTHONUTF8=0`, which is what broke svy-rs twice
- 3443 tests pass in the dev environment
- **Clean-venv check** (the one that caught the 0.25.0 kernel mismatch): built the wheel, installed it into an empty venv, and it resolved `svy-rs 0.16.0` and `svy-io 0.3.0` from PyPI. 3439 passed.

Two failures in that clean venv, both environment differences rather than regressions, both diagnosed:

- `test_describe_str_and_repr_dont_crash` assumes `rich` is installed; without it the plain-text renderer runs and omits the section the test asserts on. `packages/svy` has an `optional` marker for exactly this and the test does not carry it.
- `test_explode` fails on polars 1.44 (locked: 1.39.3), which warns that `empty_as_null` changes default in Polars 2.0. `packages/svy/pyproject.toml` deliberately makes deprecations errors and is the nearest configfile, so the root `ignore::DeprecationWarning` does not apply. Invisible until the lockfile moves, then CI breaks.

Neither touches companion resolution, which is what the check is for. Both are tracked separately.

## After merge

Tag `svy-v0.27.0` on the squash commit, named explicitly. Nothing else is pending — svy-io is unchanged since `svy-io-v0.3.0`.
