### PR TITLE
fix(readme): repair the quick-start snippet and guard README outputs

### DIFF
--- a/.github/assets/readme_estimate.svg
+++ b/.github/assets/readme_estimate.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 628 220.79999999999998" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" width="628" height="221" viewBox="0 0 628 220.79999999999998" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 

--- a/.github/assets/readme_glm.svg
+++ b/.github/assets/readme_glm.svg
@@ -1,4 +1,4 @@
-<svg class="rich-terminal" viewBox="0 0 994 489.2" xmlns="http://www.w3.org/2000/svg">
+<svg class="rich-terminal" width="970" height="489" viewBox="0 0 970 489.2" xmlns="http://www.w3.org/2000/svg">
     <!-- Generated with Rich https://www.textualize.io -->
     <style>
 
@@ -19,111 +19,111 @@
         font-weight: 700;
     }
 
-    .terminal-432364856-matrix {
+    .terminal-766401668-matrix {
         font-family: Fira Code, monospace;
         font-size: 20px;
         line-height: 24.4px;
         font-variant-east-asian: full-width;
     }
 
-    .terminal-432364856-title {
+    .terminal-766401668-title {
         font-size: 18px;
         font-weight: bold;
         font-family: arial;
     }
 
-    .terminal-432364856-r1 { fill: #68a0b3 }
-.terminal-432364856-r2 { fill: #c5c8c6 }
-.terminal-432364856-r3 { fill: #868887 }
-.terminal-432364856-r4 { fill: #c5c8c6;font-weight: bold }
-.terminal-432364856-r5 { fill: #cc555a;font-weight: bold }
+    .terminal-766401668-r1 { fill: #68a0b3 }
+.terminal-766401668-r2 { fill: #c5c8c6 }
+.terminal-766401668-r3 { fill: #868887 }
+.terminal-766401668-r4 { fill: #c5c8c6;font-weight: bold }
+.terminal-766401668-r5 { fill: #cc555a;font-weight: bold }
     </style>
 
     <defs>
-    <clipPath id="terminal-432364856-clip-terminal">
-      <rect x="0" y="0" width="975.0" height="438.2" />
+    <clipPath id="terminal-766401668-clip-terminal">
+      <rect x="0" y="0" width="950.5999999999999" height="438.2" />
     </clipPath>
-    <clipPath id="terminal-432364856-line-0">
-    <rect x="0" y="1.5" width="976" height="24.65"/>
+    <clipPath id="terminal-766401668-line-0">
+    <rect x="0" y="1.5" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-1">
-    <rect x="0" y="25.9" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-1">
+    <rect x="0" y="25.9" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-2">
-    <rect x="0" y="50.3" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-2">
+    <rect x="0" y="50.3" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-3">
-    <rect x="0" y="74.7" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-3">
+    <rect x="0" y="74.7" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-4">
-    <rect x="0" y="99.1" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-4">
+    <rect x="0" y="99.1" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-5">
-    <rect x="0" y="123.5" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-5">
+    <rect x="0" y="123.5" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-6">
-    <rect x="0" y="147.9" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-6">
+    <rect x="0" y="147.9" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-7">
-    <rect x="0" y="172.3" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-7">
+    <rect x="0" y="172.3" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-8">
-    <rect x="0" y="196.7" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-8">
+    <rect x="0" y="196.7" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-9">
-    <rect x="0" y="221.1" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-9">
+    <rect x="0" y="221.1" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-10">
-    <rect x="0" y="245.5" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-10">
+    <rect x="0" y="245.5" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-11">
-    <rect x="0" y="269.9" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-11">
+    <rect x="0" y="269.9" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-12">
-    <rect x="0" y="294.3" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-12">
+    <rect x="0" y="294.3" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-13">
-    <rect x="0" y="318.7" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-13">
+    <rect x="0" y="318.7" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-14">
-    <rect x="0" y="343.1" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-14">
+    <rect x="0" y="343.1" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-15">
-    <rect x="0" y="367.5" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-15">
+    <rect x="0" y="367.5" width="951.6" height="24.65"/>
             </clipPath>
-<clipPath id="terminal-432364856-line-16">
-    <rect x="0" y="391.9" width="976" height="24.65"/>
+<clipPath id="terminal-766401668-line-16">
+    <rect x="0" y="391.9" width="951.6" height="24.65"/>
             </clipPath>
     </defs>
 
-    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="992" height="487.2" rx="8"/><text class="terminal-432364856-title" fill="#c5c8c6" text-anchor="middle" x="496" y="27">svy</text>
+    <rect fill="#292929" stroke="rgba(255,255,255,0.35)" stroke-width="1" x="1" y="1" width="968" height="487.2" rx="8"/><text class="terminal-766401668-title" fill="#c5c8c6" text-anchor="middle" x="484" y="27">svy</text>
             <g transform="translate(26,22)">
             <circle cx="0" cy="0" r="7" fill="#ff5f57"/>
             <circle cx="22" cy="0" r="7" fill="#febc2e"/>
             <circle cx="44" cy="0" r="7" fill="#28c840"/>
             </g>
         
-    <g transform="translate(9, 41)" clip-path="url(#terminal-432364856-clip-terminal)">
+    <g transform="translate(9, 41)" clip-path="url(#terminal-766401668-clip-terminal)">
     
-    <g class="terminal-432364856-matrix">
-    <text class="terminal-432364856-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-432364856-line-0)">╭─</text><text class="terminal-432364856-r1" x="24.4" y="20" textLength="292.8" clip-path="url(#terminal-432364856-line-0)">────────────────────────</text><text class="terminal-432364856-r1" x="317.2" y="20" textLength="317.2" clip-path="url(#terminal-432364856-line-0)">&#160;GLM:&#160;Gaussian&#160;(identity)&#160;</text><text class="terminal-432364856-r1" x="634.4" y="20" textLength="292.8" clip-path="url(#terminal-432364856-line-0)">────────────────────────</text><text class="terminal-432364856-r1" x="927.2" y="20" textLength="24.4" clip-path="url(#terminal-432364856-line-0)">─╮</text><text class="terminal-432364856-r2" x="976" y="20" textLength="12.2" clip-path="url(#terminal-432364856-line-0)">
-</text><text class="terminal-432364856-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">│</text><text class="terminal-432364856-r3" x="24.4" y="44.4" textLength="244" clip-path="url(#terminal-432364856-line-1)">Modeling:&#160;yrs_school</text><text class="terminal-432364856-r1" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">│</text><text class="terminal-432364856-r2" x="976" y="44.4" textLength="12.2" clip-path="url(#terminal-432364856-line-1)">
-</text><text class="terminal-432364856-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">│</text><text class="terminal-432364856-r1" x="939.4" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">│</text><text class="terminal-432364856-r2" x="976" y="68.8" textLength="12.2" clip-path="url(#terminal-432364856-line-2)">
-</text><text class="terminal-432364856-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">│</text><text class="terminal-432364856-r4" x="24.4" y="93.2" textLength="146.4" clip-path="url(#terminal-432364856-line-3)">Observations</text><text class="terminal-432364856-r2" x="195.2" y="93.2" textLength="122" clip-path="url(#terminal-432364856-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;2900</text><text class="terminal-432364856-r4" x="341.6" y="93.2" textLength="146.4" clip-path="url(#terminal-432364856-line-3)">AIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="93.2" textLength="122" clip-path="url(#terminal-432364856-line-3)">75030.4420</text><text class="terminal-432364856-r1" x="939.4" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">│</text><text class="terminal-432364856-r2" x="976" y="93.2" textLength="12.2" clip-path="url(#terminal-432364856-line-3)">
-</text><text class="terminal-432364856-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">│</text><text class="terminal-432364856-r4" x="24.4" y="117.6" textLength="146.4" clip-path="url(#terminal-432364856-line-4)">DF&#160;Residuals</text><text class="terminal-432364856-r2" x="195.2" y="117.6" textLength="122" clip-path="url(#terminal-432364856-line-4)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;24</text><text class="terminal-432364856-r4" x="341.6" y="117.6" textLength="146.4" clip-path="url(#terminal-432364856-line-4)">BIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="117.6" textLength="122" clip-path="url(#terminal-432364856-line-4)">75048.3594</text><text class="terminal-432364856-r1" x="939.4" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">│</text><text class="terminal-432364856-r2" x="976" y="117.6" textLength="12.2" clip-path="url(#terminal-432364856-line-4)">
-</text><text class="terminal-432364856-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">│</text><text class="terminal-432364856-r4" x="24.4" y="142" textLength="146.4" clip-path="url(#terminal-432364856-line-5)">Deviance&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="195.2" y="142" textLength="122" clip-path="url(#terminal-432364856-line-5)">75024.4420</text><text class="terminal-432364856-r4" x="341.6" y="142" textLength="146.4" clip-path="url(#terminal-432364856-line-5)">Scale&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="142" textLength="122" clip-path="url(#terminal-432364856-line-5)">&#160;2885.5555</text><text class="terminal-432364856-r1" x="939.4" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">│</text><text class="terminal-432364856-r2" x="976" y="142" textLength="12.2" clip-path="url(#terminal-432364856-line-5)">
-</text><text class="terminal-432364856-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">│</text><text class="terminal-432364856-r4" x="24.4" y="166.4" textLength="146.4" clip-path="url(#terminal-432364856-line-6)">R-squared&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="195.2" y="166.4" textLength="122" clip-path="url(#terminal-432364856-line-6)">&#160;&#160;&#160;0.00407</text><text class="terminal-432364856-r4" x="341.6" y="166.4" textLength="146.4" clip-path="url(#terminal-432364856-line-6)">R-sq&#160;(adj)&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="166.4" textLength="122" clip-path="url(#terminal-432364856-line-6)">&#160;&#160;&#160;0.00338</text><text class="terminal-432364856-r1" x="939.4" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">│</text><text class="terminal-432364856-r2" x="976" y="166.4" textLength="12.2" clip-path="url(#terminal-432364856-line-6)">
-</text><text class="terminal-432364856-r1" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">│</text><text class="terminal-432364856-r4" x="341.6" y="190.8" textLength="146.4" clip-path="url(#terminal-432364856-line-7)">Iterations&#160;&#160;</text><text class="terminal-432364856-r2" x="512.4" y="190.8" textLength="122" clip-path="url(#terminal-432364856-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;2</text><text class="terminal-432364856-r1" x="939.4" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">│</text><text class="terminal-432364856-r2" x="976" y="190.8" textLength="12.2" clip-path="url(#terminal-432364856-line-7)">
-</text><text class="terminal-432364856-r1" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">│</text><text class="terminal-432364856-r4" x="24.4" y="215.2" textLength="146.4" clip-path="url(#terminal-432364856-line-8)">F-stat&#160;(adj)</text><text class="terminal-432364856-r2" x="195.2" y="215.2" textLength="122" clip-path="url(#terminal-432364856-line-8)">&#160;&#160;&#160;4.97738</text><text class="terminal-432364856-r4" x="341.6" y="215.2" textLength="146.4" clip-path="url(#terminal-432364856-line-8)">Prob&#160;(F-adj)</text><text class="terminal-432364856-r2" x="512.4" y="215.2" textLength="122" clip-path="url(#terminal-432364856-line-8)">&#160;&#160;&#160;&#160;0.0160</text><text class="terminal-432364856-r1" x="939.4" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">│</text><text class="terminal-432364856-r2" x="976" y="215.2" textLength="12.2" clip-path="url(#terminal-432364856-line-8)">
-</text><text class="terminal-432364856-r1" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">│</text><text class="terminal-432364856-r1" x="939.4" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">│</text><text class="terminal-432364856-r2" x="976" y="239.6" textLength="12.2" clip-path="url(#terminal-432364856-line-9)">
-</text><text class="terminal-432364856-r1" x="0" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">│</text><text class="terminal-432364856-r1" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">│</text><text class="terminal-432364856-r2" x="976" y="264" textLength="12.2" clip-path="url(#terminal-432364856-line-10)">
-</text><text class="terminal-432364856-r1" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">│</text><text class="terminal-432364856-r4" x="36.6" y="288.4" textLength="134.2" clip-path="url(#terminal-432364856-line-11)">Term&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r4" x="207.4" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;Coef.</text><text class="terminal-432364856-r4" x="329.4" y="288.4" textLength="97.6" clip-path="url(#terminal-432364856-line-11)">Std.Err.</text><text class="terminal-432364856-r4" x="463.6" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;t</text><text class="terminal-432364856-r4" x="585.6" y="288.4" textLength="73.2" clip-path="url(#terminal-432364856-line-11)">&#160;P&gt;|t|</text><text class="terminal-432364856-r4" x="695.4" y="288.4" textLength="97.6" clip-path="url(#terminal-432364856-line-11)">&#160;&#160;[0.025</text><text class="terminal-432364856-r4" x="829.6" y="288.4" textLength="85.4" clip-path="url(#terminal-432364856-line-11)">&#160;0.975]</text><text class="terminal-432364856-r1" x="939.4" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">│</text><text class="terminal-432364856-r2" x="976" y="288.4" textLength="12.2" clip-path="url(#terminal-432364856-line-11)">
-</text><text class="terminal-432364856-r1" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">│</text><text class="terminal-432364856-r2" x="24.4" y="312.8" textLength="902.8" clip-path="url(#terminal-432364856-line-12)">&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;</text><text class="terminal-432364856-r1" x="939.4" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">│</text><text class="terminal-432364856-r2" x="976" y="312.8" textLength="12.2" clip-path="url(#terminal-432364856-line-12)">
-</text><text class="terminal-432364856-r1" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">│</text><text class="terminal-432364856-r2" x="36.6" y="337.2" textLength="134.2" clip-path="url(#terminal-432364856-line-13)">_intercept_</text><text class="terminal-432364856-r2" x="207.4" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">4.22276</text><text class="terminal-432364856-r2" x="329.4" y="337.2" textLength="97.6" clip-path="url(#terminal-432364856-line-13)">&#160;0.45871</text><text class="terminal-432364856-r2" x="463.6" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">9.20566</text><text class="terminal-432364856-r5" x="585.6" y="337.2" textLength="73.2" clip-path="url(#terminal-432364856-line-13)">&lt;0.001</text><text class="terminal-432364856-r2" x="695.4" y="337.2" textLength="97.6" clip-path="url(#terminal-432364856-line-13)">&#160;3.27602</text><text class="terminal-432364856-r2" x="829.6" y="337.2" textLength="85.4" clip-path="url(#terminal-432364856-line-13)">5.16950</text><text class="terminal-432364856-r1" x="939.4" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">│</text><text class="terminal-432364856-r2" x="976" y="337.2" textLength="12.2" clip-path="url(#terminal-432364856-line-13)">
-</text><text class="terminal-432364856-r1" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">│</text><text class="terminal-432364856-r2" x="36.6" y="361.6" textLength="134.2" clip-path="url(#terminal-432364856-line-14)">age&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="207.4" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.01023</text><text class="terminal-432364856-r2" x="329.4" y="361.6" textLength="97.6" clip-path="url(#terminal-432364856-line-14)">&#160;0.01129</text><text class="terminal-432364856-r2" x="463.6" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.90674</text><text class="terminal-432364856-r2" x="585.6" y="361.6" textLength="73.2" clip-path="url(#terminal-432364856-line-14)">0.3736</text><text class="terminal-432364856-r2" x="695.4" y="361.6" textLength="97.6" clip-path="url(#terminal-432364856-line-14)">-0.01306</text><text class="terminal-432364856-r2" x="829.6" y="361.6" textLength="85.4" clip-path="url(#terminal-432364856-line-14)">0.03352</text><text class="terminal-432364856-r1" x="939.4" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">│</text><text class="terminal-432364856-r2" x="976" y="361.6" textLength="12.2" clip-path="url(#terminal-432364856-line-14)">
-</text><text class="terminal-432364856-r1" x="0" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">│</text><text class="terminal-432364856-r2" x="36.6" y="386" textLength="134.2" clip-path="url(#terminal-432364856-line-15)">sex_Male&#160;&#160;&#160;</text><text class="terminal-432364856-r2" x="207.4" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">0.50667</text><text class="terminal-432364856-r2" x="329.4" y="386" textLength="97.6" clip-path="url(#terminal-432364856-line-15)">&#160;0.15917</text><text class="terminal-432364856-r2" x="463.6" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">3.18325</text><text class="terminal-432364856-r5" x="585.6" y="386" textLength="73.2" clip-path="url(#terminal-432364856-line-15)">0.0040</text><text class="terminal-432364856-r2" x="695.4" y="386" textLength="97.6" clip-path="url(#terminal-432364856-line-15)">&#160;0.17816</text><text class="terminal-432364856-r2" x="829.6" y="386" textLength="85.4" clip-path="url(#terminal-432364856-line-15)">0.83518</text><text class="terminal-432364856-r1" x="939.4" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">│</text><text class="terminal-432364856-r2" x="976" y="386" textLength="12.2" clip-path="url(#terminal-432364856-line-15)">
-</text><text class="terminal-432364856-r1" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">│</text><text class="terminal-432364856-r1" x="939.4" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">│</text><text class="terminal-432364856-r2" x="976" y="410.4" textLength="12.2" clip-path="url(#terminal-432364856-line-16)">
-</text><text class="terminal-432364856-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-432364856-line-17)">╰────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-432364856-r2" x="976" y="434.8" textLength="12.2" clip-path="url(#terminal-432364856-line-17)">
+    <g class="terminal-766401668-matrix">
+    <text class="terminal-766401668-r1" x="0" y="20" textLength="24.4" clip-path="url(#terminal-766401668-line-0)">╭─</text><text class="terminal-766401668-r1" x="24.4" y="20" textLength="292.8" clip-path="url(#terminal-766401668-line-0)">────────────────────────</text><text class="terminal-766401668-r1" x="317.2" y="20" textLength="317.2" clip-path="url(#terminal-766401668-line-0)">&#160;GLM:&#160;Gaussian&#160;(identity)&#160;</text><text class="terminal-766401668-r1" x="634.4" y="20" textLength="292.8" clip-path="url(#terminal-766401668-line-0)">────────────────────────</text><text class="terminal-766401668-r1" x="927.2" y="20" textLength="24.4" clip-path="url(#terminal-766401668-line-0)">─╮</text><text class="terminal-766401668-r2" x="951.6" y="20" textLength="12.2" clip-path="url(#terminal-766401668-line-0)">
+</text><text class="terminal-766401668-r1" x="0" y="44.4" textLength="12.2" clip-path="url(#terminal-766401668-line-1)">│</text><text class="terminal-766401668-r3" x="24.4" y="44.4" textLength="244" clip-path="url(#terminal-766401668-line-1)">Modeling:&#160;yrs_school</text><text class="terminal-766401668-r1" x="939.4" y="44.4" textLength="12.2" clip-path="url(#terminal-766401668-line-1)">│</text><text class="terminal-766401668-r2" x="951.6" y="44.4" textLength="12.2" clip-path="url(#terminal-766401668-line-1)">
+</text><text class="terminal-766401668-r1" x="0" y="68.8" textLength="12.2" clip-path="url(#terminal-766401668-line-2)">│</text><text class="terminal-766401668-r1" x="939.4" y="68.8" textLength="12.2" clip-path="url(#terminal-766401668-line-2)">│</text><text class="terminal-766401668-r2" x="951.6" y="68.8" textLength="12.2" clip-path="url(#terminal-766401668-line-2)">
+</text><text class="terminal-766401668-r1" x="0" y="93.2" textLength="12.2" clip-path="url(#terminal-766401668-line-3)">│</text><text class="terminal-766401668-r4" x="24.4" y="93.2" textLength="146.4" clip-path="url(#terminal-766401668-line-3)">Observations</text><text class="terminal-766401668-r2" x="195.2" y="93.2" textLength="122" clip-path="url(#terminal-766401668-line-3)">&#160;&#160;&#160;&#160;&#160;&#160;2900</text><text class="terminal-766401668-r4" x="341.6" y="93.2" textLength="146.4" clip-path="url(#terminal-766401668-line-3)">AIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="512.4" y="93.2" textLength="122" clip-path="url(#terminal-766401668-line-3)">17680.7883</text><text class="terminal-766401668-r1" x="939.4" y="93.2" textLength="12.2" clip-path="url(#terminal-766401668-line-3)">│</text><text class="terminal-766401668-r2" x="951.6" y="93.2" textLength="12.2" clip-path="url(#terminal-766401668-line-3)">
+</text><text class="terminal-766401668-r1" x="0" y="117.6" textLength="12.2" clip-path="url(#terminal-766401668-line-4)">│</text><text class="terminal-766401668-r4" x="24.4" y="117.6" textLength="146.4" clip-path="url(#terminal-766401668-line-4)">DF&#160;Residuals</text><text class="terminal-766401668-r2" x="195.2" y="117.6" textLength="122" clip-path="url(#terminal-766401668-line-4)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;24</text><text class="terminal-766401668-r4" x="341.6" y="117.6" textLength="146.4" clip-path="url(#terminal-766401668-line-4)">BIC&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="512.4" y="117.6" textLength="122" clip-path="url(#terminal-766401668-line-4)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;-</text><text class="terminal-766401668-r1" x="939.4" y="117.6" textLength="12.2" clip-path="url(#terminal-766401668-line-4)">│</text><text class="terminal-766401668-r2" x="951.6" y="117.6" textLength="12.2" clip-path="url(#terminal-766401668-line-4)">
+</text><text class="terminal-766401668-r1" x="0" y="142" textLength="12.2" clip-path="url(#terminal-766401668-line-5)">│</text><text class="terminal-766401668-r4" x="24.4" y="142" textLength="146.4" clip-path="url(#terminal-766401668-line-5)">Deviance&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="195.2" y="142" textLength="122" clip-path="url(#terminal-766401668-line-5)">75024.4420</text><text class="terminal-766401668-r4" x="341.6" y="142" textLength="146.4" clip-path="url(#terminal-766401668-line-5)">Scale&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="512.4" y="142" textLength="122" clip-path="url(#terminal-766401668-line-5)">&#160;3229.8321</text><text class="terminal-766401668-r1" x="939.4" y="142" textLength="12.2" clip-path="url(#terminal-766401668-line-5)">│</text><text class="terminal-766401668-r2" x="951.6" y="142" textLength="12.2" clip-path="url(#terminal-766401668-line-5)">
+</text><text class="terminal-766401668-r1" x="0" y="166.4" textLength="12.2" clip-path="url(#terminal-766401668-line-6)">│</text><text class="terminal-766401668-r4" x="24.4" y="166.4" textLength="146.4" clip-path="url(#terminal-766401668-line-6)">R-squared&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="195.2" y="166.4" textLength="122" clip-path="url(#terminal-766401668-line-6)">&#160;&#160;&#160;0.00407</text><text class="terminal-766401668-r4" x="341.6" y="166.4" textLength="146.4" clip-path="url(#terminal-766401668-line-6)">R-sq&#160;(adj)&#160;&#160;</text><text class="terminal-766401668-r2" x="512.4" y="166.4" textLength="122" clip-path="url(#terminal-766401668-line-6)">&#160;&#160;&#160;0.00338</text><text class="terminal-766401668-r1" x="939.4" y="166.4" textLength="12.2" clip-path="url(#terminal-766401668-line-6)">│</text><text class="terminal-766401668-r2" x="951.6" y="166.4" textLength="12.2" clip-path="url(#terminal-766401668-line-6)">
+</text><text class="terminal-766401668-r1" x="0" y="190.8" textLength="12.2" clip-path="url(#terminal-766401668-line-7)">│</text><text class="terminal-766401668-r4" x="341.6" y="190.8" textLength="146.4" clip-path="url(#terminal-766401668-line-7)">Iterations&#160;&#160;</text><text class="terminal-766401668-r2" x="512.4" y="190.8" textLength="122" clip-path="url(#terminal-766401668-line-7)">&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;2</text><text class="terminal-766401668-r1" x="939.4" y="190.8" textLength="12.2" clip-path="url(#terminal-766401668-line-7)">│</text><text class="terminal-766401668-r2" x="951.6" y="190.8" textLength="12.2" clip-path="url(#terminal-766401668-line-7)">
+</text><text class="terminal-766401668-r1" x="0" y="215.2" textLength="12.2" clip-path="url(#terminal-766401668-line-8)">│</text><text class="terminal-766401668-r4" x="24.4" y="215.2" textLength="146.4" clip-path="url(#terminal-766401668-line-8)">F-stat&#160;(adj)</text><text class="terminal-766401668-r2" x="195.2" y="215.2" textLength="122" clip-path="url(#terminal-766401668-line-8)">&#160;&#160;&#160;4.97738</text><text class="terminal-766401668-r4" x="341.6" y="215.2" textLength="146.4" clip-path="url(#terminal-766401668-line-8)">Prob&#160;(F-adj)</text><text class="terminal-766401668-r2" x="512.4" y="215.2" textLength="122" clip-path="url(#terminal-766401668-line-8)">&#160;&#160;&#160;&#160;0.0160</text><text class="terminal-766401668-r1" x="939.4" y="215.2" textLength="12.2" clip-path="url(#terminal-766401668-line-8)">│</text><text class="terminal-766401668-r2" x="951.6" y="215.2" textLength="12.2" clip-path="url(#terminal-766401668-line-8)">
+</text><text class="terminal-766401668-r1" x="0" y="239.6" textLength="12.2" clip-path="url(#terminal-766401668-line-9)">│</text><text class="terminal-766401668-r1" x="939.4" y="239.6" textLength="12.2" clip-path="url(#terminal-766401668-line-9)">│</text><text class="terminal-766401668-r2" x="951.6" y="239.6" textLength="12.2" clip-path="url(#terminal-766401668-line-9)">
+</text><text class="terminal-766401668-r1" x="0" y="264" textLength="12.2" clip-path="url(#terminal-766401668-line-10)">│</text><text class="terminal-766401668-r1" x="939.4" y="264" textLength="12.2" clip-path="url(#terminal-766401668-line-10)">│</text><text class="terminal-766401668-r2" x="951.6" y="264" textLength="12.2" clip-path="url(#terminal-766401668-line-10)">
+</text><text class="terminal-766401668-r1" x="0" y="288.4" textLength="12.2" clip-path="url(#terminal-766401668-line-11)">│</text><text class="terminal-766401668-r4" x="36.6" y="288.4" textLength="134.2" clip-path="url(#terminal-766401668-line-11)">Term&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r4" x="207.4" y="288.4" textLength="85.4" clip-path="url(#terminal-766401668-line-11)">&#160;&#160;Coef.</text><text class="terminal-766401668-r4" x="329.4" y="288.4" textLength="97.6" clip-path="url(#terminal-766401668-line-11)">Std.Err.</text><text class="terminal-766401668-r4" x="463.6" y="288.4" textLength="85.4" clip-path="url(#terminal-766401668-line-11)">&#160;&#160;&#160;&#160;&#160;&#160;t</text><text class="terminal-766401668-r4" x="585.6" y="288.4" textLength="73.2" clip-path="url(#terminal-766401668-line-11)">&#160;P&gt;|t|</text><text class="terminal-766401668-r4" x="695.4" y="288.4" textLength="97.6" clip-path="url(#terminal-766401668-line-11)">&#160;&#160;[0.025</text><text class="terminal-766401668-r4" x="829.6" y="288.4" textLength="85.4" clip-path="url(#terminal-766401668-line-11)">&#160;0.975]</text><text class="terminal-766401668-r1" x="939.4" y="288.4" textLength="12.2" clip-path="url(#terminal-766401668-line-11)">│</text><text class="terminal-766401668-r2" x="951.6" y="288.4" textLength="12.2" clip-path="url(#terminal-766401668-line-11)">
+</text><text class="terminal-766401668-r1" x="0" y="312.8" textLength="12.2" clip-path="url(#terminal-766401668-line-12)">│</text><text class="terminal-766401668-r2" x="24.4" y="312.8" textLength="902.8" clip-path="url(#terminal-766401668-line-12)">&#160;━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━&#160;</text><text class="terminal-766401668-r1" x="939.4" y="312.8" textLength="12.2" clip-path="url(#terminal-766401668-line-12)">│</text><text class="terminal-766401668-r2" x="951.6" y="312.8" textLength="12.2" clip-path="url(#terminal-766401668-line-12)">
+</text><text class="terminal-766401668-r1" x="0" y="337.2" textLength="12.2" clip-path="url(#terminal-766401668-line-13)">│</text><text class="terminal-766401668-r2" x="36.6" y="337.2" textLength="134.2" clip-path="url(#terminal-766401668-line-13)">_intercept_</text><text class="terminal-766401668-r2" x="207.4" y="337.2" textLength="85.4" clip-path="url(#terminal-766401668-line-13)">4.22276</text><text class="terminal-766401668-r2" x="329.4" y="337.2" textLength="97.6" clip-path="url(#terminal-766401668-line-13)">&#160;0.45871</text><text class="terminal-766401668-r2" x="463.6" y="337.2" textLength="85.4" clip-path="url(#terminal-766401668-line-13)">9.20566</text><text class="terminal-766401668-r5" x="585.6" y="337.2" textLength="73.2" clip-path="url(#terminal-766401668-line-13)">&lt;0.001</text><text class="terminal-766401668-r2" x="695.4" y="337.2" textLength="97.6" clip-path="url(#terminal-766401668-line-13)">&#160;3.27602</text><text class="terminal-766401668-r2" x="829.6" y="337.2" textLength="85.4" clip-path="url(#terminal-766401668-line-13)">5.16950</text><text class="terminal-766401668-r1" x="939.4" y="337.2" textLength="12.2" clip-path="url(#terminal-766401668-line-13)">│</text><text class="terminal-766401668-r2" x="951.6" y="337.2" textLength="12.2" clip-path="url(#terminal-766401668-line-13)">
+</text><text class="terminal-766401668-r1" x="0" y="361.6" textLength="12.2" clip-path="url(#terminal-766401668-line-14)">│</text><text class="terminal-766401668-r2" x="36.6" y="361.6" textLength="134.2" clip-path="url(#terminal-766401668-line-14)">age&#160;&#160;&#160;&#160;&#160;&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="207.4" y="361.6" textLength="85.4" clip-path="url(#terminal-766401668-line-14)">0.01023</text><text class="terminal-766401668-r2" x="329.4" y="361.6" textLength="97.6" clip-path="url(#terminal-766401668-line-14)">&#160;0.01129</text><text class="terminal-766401668-r2" x="463.6" y="361.6" textLength="85.4" clip-path="url(#terminal-766401668-line-14)">0.90674</text><text class="terminal-766401668-r2" x="585.6" y="361.6" textLength="73.2" clip-path="url(#terminal-766401668-line-14)">0.3736</text><text class="terminal-766401668-r2" x="695.4" y="361.6" textLength="97.6" clip-path="url(#terminal-766401668-line-14)">-0.01306</text><text class="terminal-766401668-r2" x="829.6" y="361.6" textLength="85.4" clip-path="url(#terminal-766401668-line-14)">0.03352</text><text class="terminal-766401668-r1" x="939.4" y="361.6" textLength="12.2" clip-path="url(#terminal-766401668-line-14)">│</text><text class="terminal-766401668-r2" x="951.6" y="361.6" textLength="12.2" clip-path="url(#terminal-766401668-line-14)">
+</text><text class="terminal-766401668-r1" x="0" y="386" textLength="12.2" clip-path="url(#terminal-766401668-line-15)">│</text><text class="terminal-766401668-r2" x="36.6" y="386" textLength="134.2" clip-path="url(#terminal-766401668-line-15)">sex_Male&#160;&#160;&#160;</text><text class="terminal-766401668-r2" x="207.4" y="386" textLength="85.4" clip-path="url(#terminal-766401668-line-15)">0.50667</text><text class="terminal-766401668-r2" x="329.4" y="386" textLength="97.6" clip-path="url(#terminal-766401668-line-15)">&#160;0.15917</text><text class="terminal-766401668-r2" x="463.6" y="386" textLength="85.4" clip-path="url(#terminal-766401668-line-15)">3.18325</text><text class="terminal-766401668-r5" x="585.6" y="386" textLength="73.2" clip-path="url(#terminal-766401668-line-15)">0.0040</text><text class="terminal-766401668-r2" x="695.4" y="386" textLength="97.6" clip-path="url(#terminal-766401668-line-15)">&#160;0.17816</text><text class="terminal-766401668-r2" x="829.6" y="386" textLength="85.4" clip-path="url(#terminal-766401668-line-15)">0.83518</text><text class="terminal-766401668-r1" x="939.4" y="386" textLength="12.2" clip-path="url(#terminal-766401668-line-15)">│</text><text class="terminal-766401668-r2" x="951.6" y="386" textLength="12.2" clip-path="url(#terminal-766401668-line-15)">
+</text><text class="terminal-766401668-r1" x="0" y="410.4" textLength="12.2" clip-path="url(#terminal-766401668-line-16)">│</text><text class="terminal-766401668-r1" x="939.4" y="410.4" textLength="12.2" clip-path="url(#terminal-766401668-line-16)">│</text><text class="terminal-766401668-r2" x="951.6" y="410.4" textLength="12.2" clip-path="url(#terminal-766401668-line-16)">
+</text><text class="terminal-766401668-r1" x="0" y="434.8" textLength="951.6" clip-path="url(#terminal-766401668-line-17)">╰────────────────────────────────────────────────────────────────────────────╯</text><text class="terminal-766401668-r2" x="951.6" y="434.8" textLength="12.2" clip-path="url(#terminal-766401668-line-17)">
 </text>
     </g>
     </g>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,7 @@ Lint/format/type-check settings (ruff, mypy, pytest) are configured once in the 
    Prefer tiny generated fixtures over large binary files; add round-trip tests when
    changing I/O behavior; cover edge cases (encodings, missing values, temporals).
 4. **Docs**: update README examples and docstrings if public behavior changes.
+   The outputs shown in the READMEs are generated: run `make readme-svy` after editing a snippet. The svy test suite fails when they drift.
 5. **PR**: explain the "why", link issues, note trade-offs, keep CI green.
 
 ### svy-io API guidance

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ literacy_rate = (
     # 2. Adjust the weights for nonresponse, within urban/rural classes
     .weighting.adjust(
         resp_status="resp_status",
-        by="urbrur",
+        cells="urbrur",
         resp_mapping={"rr": "respondent", "nr": "non-respondent"},
         wgt_name="nr_wgt",
     )
@@ -89,8 +89,8 @@ print(sample.estimation.mean("age", by="urbrur"))
 │                                                          │
 │  urbrur       est       se       lci       uci   cv (%)  │
 │  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━  │
-│  Rural    27.4893   3.1681   20.9771   34.0015    11.53  │
-│  Urban    29.7557   2.5016   24.6135   34.8978     8.41  │
+│  Rural    27.4893   3.1681   20.5163   34.4624    11.53  │
+│  Urban    29.7557   2.5016   24.4236   35.0877     8.41  │
 │                                                          │
 ╰──────────────────────────────────────────────────────────╯
 ```

--- a/makefile
+++ b/makefile
@@ -26,6 +26,7 @@ help:
 	@echo "  lint-svy            - lint svy"
 	@echo "  bench-check         - check for perf regressions vs the baseline (needs release build)"
 	@echo "  bench-record        - re-record the perf baseline (commit the result)"
+	@echo "  readme-svy          - re-run the README snippets and refresh their outputs"
 	@echo ""
 	@echo "Release Targets (PKG=svy|svy-io|svy-rs):"
 	@echo "  release-notes       - preview the notes CI will publish for the current version"
@@ -91,6 +92,10 @@ test-all: test-svy test-svy-io test-svy-rs
 test-svy:
 	@echo "▶ Testing svy..."
 	cd $(PKG_SVY) && uv run pytest
+
+readme-svy:
+	@echo "▶ Refreshing README outputs..."
+	cd $(PKG_SVY) && uv run python scripts/render_readme.py
 
 test-svy-io:
 	@echo "▶ Testing svy-io..."

--- a/packages/svy/scripts/render_readme.py
+++ b/packages/svy/scripts/render_readme.py
@@ -1,0 +1,155 @@
+"""Execute the Python fences of a README and refresh the outputs shown next to them.
+
+A fence's last ``print(...)`` argument is rendered into whatever output slot follows
+the fence: a bare (or ``text``) code fence gets the plain-text rendering, an image
+line pointing at an ``.svg`` gets a Rich SVG export. Fences share one namespace, so
+later snippets can reuse objects built earlier.
+
+    uv run python scripts/render_readme.py            # rewrite outputs in place
+    uv run python scripts/render_readme.py --check    # exit 1 if anything drifted
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import io
+import re
+import sys
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+
+PKG_ROOT = Path(__file__).resolve().parents[1]
+README_FILES = (PKG_ROOT.parents[1] / "README.md", PKG_ROOT / "README.md")
+
+_IMG_RE = re.compile(r"^!\[[^\]]*\]\((?P<path>[^)]+\.svg)\)\s*$")
+_SVG_TEXT_RE = re.compile(r"<text[^>]*>(.*?)</text>", re.S)
+
+
+@dataclass
+class Snippet:
+    code: str
+    text_slot: tuple[int, int] | None = None  # line range of the output fence body
+    svg_path: Path | None = None
+    printed: list = field(default_factory=list)
+
+
+def parse(readme: Path) -> tuple[list[str], list[Snippet]]:
+    lines = readme.read_text(encoding="utf-8").splitlines()
+    snippets: list[Snippet] = []
+    i = 0
+    while i < len(lines):
+        if lines[i].strip() != "```python":
+            i += 1
+            continue
+        start = i + 1
+        while lines[i].strip() != "```" or i == start - 1:
+            i += 1
+        snippet = Snippet(code="\n".join(lines[start:i]))
+        i += 1
+        j = i
+        while j < len(lines) and not lines[j].strip():
+            j += 1
+        if j < len(lines):
+            head = lines[j].strip()
+            if head in ("```", "```text"):
+                end = j + 1
+                while lines[end].strip() != "```":
+                    end += 1
+                snippet.text_slot = (j + 1, end)
+                i = end + 1
+            elif m := _IMG_RE.match(head):
+                snippet.svg_path = (readme.parent / m.group("path")).resolve()
+                i = j + 1
+        snippets.append(snippet)
+    return lines, snippets
+
+
+def execute(snippets: list[Snippet]) -> None:
+    ns: dict = {}
+    for snippet in snippets:
+        ns["print"] = lambda *args, _s=snippet, **kw: _s.printed.extend(args)
+        exec(compile(snippet.code, "<readme>", "exec"), ns)
+
+
+def _console(width: int | None, *, color: bool):
+    from rich.console import Console
+
+    return Console(
+        record=True,
+        width=width,
+        file=io.StringIO(),
+        force_terminal=color,
+        color_system="truecolor" if color else None,
+        emoji=False,
+        soft_wrap=False,
+    )
+
+
+def render_text(obj) -> list[str]:
+    from svy.ui.printing import resolve_width
+
+    console = _console(resolve_width(obj), color=False)
+    console.print(obj)
+    return [ln.rstrip() for ln in console.export_text().rstrip("\n").splitlines()]
+
+
+def render_svg(obj) -> str:
+    width = max(len(ln) for ln in render_text(obj))
+    console = _console(width, color=True)
+    console.print(obj)
+    svg = console.export_svg(title="svy")
+    # Rich emits only a viewBox; without intrinsic dimensions GitHub stretches the image.
+    m = re.search(r'viewBox="0 0 ([\d.]+) ([\d.]+)"', svg)
+    size = f'width="{round(float(m[1]))}" height="{round(float(m[2]))}" '
+    return svg.replace("viewBox=", size + "viewBox=", 1)
+
+
+def svg_text(svg: str) -> str:
+    chunks = (html.unescape(t) for t in _SVG_TEXT_RE.findall(svg))
+    return re.sub(r"\s+", "", "".join(chunks))
+
+
+def refresh(readme: Path, *, check: bool) -> list[str]:
+    lines, snippets = parse(readme)
+    execute(snippets)
+    problems: list[str] = []
+    for snippet in reversed(snippets):  # bottom-up so line indices stay valid
+        if not snippet.printed or (snippet.text_slot is None and snippet.svg_path is None):
+            continue
+        obj = snippet.printed[-1]
+        if snippet.text_slot is not None:
+            a, b = snippet.text_slot
+            fresh = render_text(obj)
+            if lines[a:b] != fresh:
+                problems.append(f"{readme}: output block after line {a} is stale")
+                lines[a:b] = fresh
+        if snippet.svg_path is not None:
+            fresh = render_svg(obj)
+            current = snippet.svg_path.read_text(encoding="utf-8")
+            if svg_text(current) != svg_text(fresh):
+                problems.append(f"{snippet.svg_path}: stale")
+                if not check:
+                    snippet.svg_path.write_text(fresh, encoding="utf-8")
+    if problems and not check:
+        readme.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--check", action="store_true", help="report drift instead of rewriting")
+    ap.add_argument("readme", nargs="*", type=Path, default=list(README_FILES))
+    args = ap.parse_args(argv)
+    problems = [p for readme in args.readme for p in refresh(readme, check=args.check)]
+    for p in problems:
+        print(p, file=sys.stderr)
+    if not problems:
+        print("README outputs are up to date")
+    return 1 if (problems and args.check) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/svy/tests/test_readme.py
+++ b/packages/svy/tests/test_readme.py
@@ -1,0 +1,36 @@
+"""Every Python fence in the READMEs must run, and the outputs shown must match."""
+
+import importlib.util
+import sys
+
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "render_readme.py"
+
+pytestmark = pytest.mark.optional
+
+
+def _load_renderer():
+    spec = importlib.util.spec_from_file_location("render_readme", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod  # dataclasses resolve postponed annotations via sys.modules
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.mark.skipif(not _SCRIPT.exists(), reason="scripts/ not shipped in sdist")
+@pytest.mark.skipif(
+    "rich" not in sys.modules and importlib.util.find_spec("rich") is None,
+    reason="rich not installed",
+)
+def test_readme_snippets_run_and_outputs_are_current():
+    renderer = _load_renderer()
+    readmes = [p for p in renderer.README_FILES if p.exists()]
+    assert readmes, "no README found"
+    problems = [p for readme in readmes for p in renderer.refresh(readme, check=True)]
+    assert not problems, "stale README outputs, run scripts/render_readme.py:\n" + "\n".join(
+        problems
+    )


### PR DESCRIPTION
The README quick-start crashed: `weighting.adjust` renamed `by=` to `cells=` and the README still used the old name. The domain-mean output block and the GLM screenshot were also stale. Nothing executed the README, so none of this was caught.

- Fix the snippet and refresh the stale outputs.
- Add intrinsic width/height to the SVGs so GitHub renders them at native size.
- `scripts/render_readme.py` runs every `python` fence in both READMEs and renders each fence's last printed object into the text block or SVG that follows it. `--check` reports drift.
- `tests/test_readme.py` runs that check, so CI fails when a snippet breaks or an output goes stale.
- `make readme-svy` refreshes the outputs; noted in CONTRIBUTING.