### PR TITLE
fix(contrast): resolve native int keys for integer by columns

### DIFF
--- a/packages/svy/src/svy/estimation/contrast.py
+++ b/packages/svy/src/svy/estimation/contrast.py
@@ -401,7 +401,12 @@ class KeyResolver:
             return self._exact[k]
         if k in self._fallback:
             return self._fallback[k]
-        return self._fallback.get(self._norm(k))
+        # by-levels arrive stringified from the kernel, so an int typed by
+        # the caller only meets its row through the normalized form.
+        nk = self._norm(k)
+        if nk in self._exact:
+            return self._exact[nk]
+        return self._fallback.get(nk)
 
 
 def linear_contrast(

--- a/packages/svy/tests/svy/estimation/test_contrast.py
+++ b/packages/svy/tests/svy/estimation/test_contrast.py
@@ -363,6 +363,25 @@ class TestContrastGuards:
         c1 = r.contrast(estd("Yes") - estd("No"))
         assert np.isfinite(c1.estimates[0].est)
 
+    def test_int_by_column_accepts_native_keys(self):
+        import polars as pl
+
+        df = pl.DataFrame(
+            {
+                "wave": pl.Series([1, 1, 1, 1, 2, 2, 2, 2], dtype=pl.Int64),
+                "y": [1.0, 2.0, 3.0, 4.0, 2.0, 3.0, 4.0, 6.0],
+                "w": [1.0] * 8,
+                "psu": [1, 2, 3, 4, 1, 2, 3, 4],
+            }
+        )
+        r = Sample(df, Design(psu="psu", wgt="w")).estimation.mean("y", by="wave")
+        by_str = r.contrast(estd("2") - estd("1")).estimates[0]
+        by_int = r.contrast(estd(2) - estd(1)).estimates[0]
+        assert by_int.est == by_str.est
+        assert by_int.se == by_str.se
+        with pytest.raises(MethodError, match="Valid keys"):
+            r.contrast(estd(3) - estd(1))
+
 
 class TestLabelResolution:
     """Contrast keys accept metadata value labels wherever unambiguous —


### PR DESCRIPTION
## Summary
- `Estimate.contrast` raised `CONTRAST_UNKNOWN_KEY` for `estd(2) - estd(1)` on an Int64 `by` column; only the string form `estd("2")` resolved.
- Row keys arrive stringified from the kernel. `KeyResolver.resolve` normalized the caller's key but only checked the alias fallback, which never holds the exact keys. It now checks the exact table with the normalized key too.
- Label resolution via `_label_aliases` is unchanged.

## Test plan
- New `test_int_by_column_accepts_native_keys` in `tests/svy/estimation/test_contrast.py`; fails before the fix, passes after.
- `test_contrast.py` and `test_glm_categorical_margins.py` pass (50 tests).