### PR TITLE
feat(svy-io): encoding= and utf8-lossy on all readers, readable parse errors

### DIFF
--- a/.github/workflows/svy-io-tests.yml
+++ b/.github/workflows/svy-io-tests.yml
@@ -39,8 +39,8 @@ jobs:
       - name: Run Python tests
         run: make test-svy-io
 
-  # No Rust job yet. All three checks are red on main today and clearing that
-  # is its own piece of work: `cargo fmt --check` fails on four drifted files,
-  # `cargo clippy -- -D warnings` reports 28 errors across nine lint kinds, and
-  # a plain `cargo test` cannot link the pyo3 cdylib against libpython. Adding
-  # a job that always fails would train people to ignore it.
+  # No Rust job yet. `cargo test` links and passes now that `extension-module`
+  # is a crate feature maturin enables, but `cargo fmt --check` fails on four
+  # drifted files and `cargo clippy -- -D warnings` reports 28 errors across
+  # nine lint kinds. Adding a job that always fails would train people to
+  # ignore it.

--- a/packages/svy-io/CHANGELOG.md
+++ b/packages/svy-io/CHANGELOG.md
@@ -6,6 +6,20 @@ All notable changes to **svy-io**, high-speed reading and writing of survey file
 
 <!-- ### Added, ### Changed, ### Fixed, ### Deprecated, ### Removed, ### Security -->
 
+### Added
+
+- **`read_dta(encoding=)`.** ReadStat decodes Stata 13 and older files (format ≤ 117) as Windows-1252 and Stata 14+ as UTF-8; a byte sequence invalid in that encoding failed the whole read with an opaque `rc=17`. This is what a Stata 13 export holding UTF-8 free text does — the Nigeria GHS-Panel Wave 5 "other, specify" columns carry emoji whose bytes are undefined in CP1252. The option takes an iconv name (`"utf-8"`, `"latin1"`, …) and is forwarded to `readstat_set_file_character_encoding`, as `read_sav` and `read_sas` already do. `read_stata_arrow` takes the same option, and `read_por` gains it too.
+- **`encoding="utf8-lossy"` on every reader.** The special value (polars' spelling) decodes as UTF-8 and replaces undecodable bytes with U+FFFD, reporting it in `meta["had_invalid_utf8"]`. It matters most for SPSS and SAS: those headers declare an encoding, so ReadStat always transcodes and one stray byte failed the whole read with no way through short of lying about the encoding.
+
+### Changed
+
+- **Parse errors carry ReadStat's message.** `Failed to parse SAV: rc=17` is now `… Unable to convert string to the requested encoding (invalid byte sequence) (rc=17)` across all readers, and that case appends a hint naming `encoding=`.
+- **`had_invalid_utf8` covers labels and names too.** Only data strings set it before; variable labels, value labels, notes and the file label were replaced silently.
+
+### Fixed
+
+- **`cargo test` in the native crate builds again.** pyo3's `extension-module` feature was on unconditionally, so the test binary linked without libpython and failed on undefined symbols; it is now a crate feature that maturin enables from `pyproject.toml`, the same arrangement `svy-rs` uses. The SAS reader's unit tests also still called `parse_sas_impl` with the argument list from before the encoding parameters were added.
+
 ## [0.3.0] — 2026-08-26
 
 ### Added

--- a/packages/svy-io/native/svyreadstat_rs/Cargo.toml
+++ b/packages/svy-io/native/svyreadstat_rs/Cargo.toml
@@ -15,8 +15,11 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = "1"
-# ABI-stable for CPython ≥3.11; still an extension module
-pyo3 = { version = "0.29", features = ["extension-module", "abi3-py311"] }
+# ABI-stable for CPython ≥3.11. `extension-module` is enabled only through
+# this crate's feature of the same name (passed by maturin via pyproject.toml),
+# so `cargo test` links a normal binary against libpython instead of failing
+# on undefined Python symbols.
+pyo3 = { version = "0.29", features = ["abi3-py311"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 arrow = "58"
@@ -28,6 +31,7 @@ rayon = { version = "1", optional = true }
 parallel = ["rayon"]
 # Forward a vendored build flag to readstat-sys (expects readstat-sys to define it)
 vendored = ["readstat-sys/vendored"]
+extension-module = ["pyo3/extension-module"]
 default = ["vendored"]
 
 [dev-dependencies]

--- a/packages/svy-io/native/svyreadstat_rs/src/core.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/core.rs
@@ -5,6 +5,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::ipc::writer::{FileWriter, IpcWriteOptions};
 use arrow::record_batch::RecordBatch;
 use serde::Serialize;
+use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_void};
@@ -168,6 +169,10 @@ pub(crate) struct ParseCtx {
     pub(crate) last_counted_row: Option<usize>,
     /// Any string in the file failed strict UTF-8 decoding (lossy-replaced).
     pub(crate) had_invalid_utf8: bool,
+    /// Decode every string as UTF-8 with U+FFFD replacement. The parser must
+    /// then be configured with ISO-8859-1 input, which maps each source byte
+    /// to one char so `decode` can recover the raw bytes.
+    pub(crate) lossy_utf8: bool,
     pub(crate) label_sets: HashMap<String, BTreeMap<String, String>>,
     pub(crate) file_label: Option<String>,
     pub(crate) last_err: Option<String>,
@@ -180,6 +185,63 @@ pub(crate) struct ParseCtx {
     /// callbacks catch panics, record the message here, and abort the parse;
     /// callers must check this after `readstat_parse_*` returns.
     pub(crate) panic_err: Option<String>,
+}
+
+impl ParseCtx {
+    /// Decode a string handed back by readstat, flagging any lossy replacement.
+    pub(crate) fn decode<'a>(&mut self, cs: &'a CStr) -> Cow<'a, str> {
+        if self.lossy_utf8 {
+            let s = cs.to_string_lossy();
+            if s.is_ascii() {
+                return s;
+            }
+            let bytes: Vec<u8> = s.chars().map(|c| c as u32 as u8).collect();
+            return match String::from_utf8(bytes) {
+                Ok(v) => Cow::Owned(v),
+                Err(e) => {
+                    self.had_invalid_utf8 = true;
+                    Cow::Owned(String::from_utf8_lossy(e.as_bytes()).into_owned())
+                }
+            };
+        }
+        match cs.to_str() {
+            Ok(s) => Cow::Borrowed(s),
+            Err(_) => {
+                self.had_invalid_utf8 = true;
+                cs.to_string_lossy()
+            }
+        }
+    }
+}
+
+/// Input encoding to hand readstat. ISO-8859-1 is byte-transparent, so the
+/// lossy path receives the raw bytes and decodes them itself (see
+/// `ParseCtx::decode`).
+pub(crate) fn input_encoding(encoding: Option<&str>, lossy_utf8: bool) -> Option<&str> {
+    if lossy_utf8 {
+        Some("ISO-8859-1")
+    } else {
+        encoding
+    }
+}
+
+/// Describe a failed parse: readstat's text for the return code, plus the
+/// last message its error handler delivered, if any.
+pub(crate) fn parse_failure(
+    rc: readstat_sys::readstat_error_t,
+    last_err: Option<String>,
+) -> String {
+    let p = unsafe { readstat_sys::readstat_error_message(rc) };
+    let mut msg = if p.is_null() {
+        format!("rc={rc}")
+    } else {
+        let text = unsafe { CStr::from_ptr(p) }.to_string_lossy();
+        format!("{text} (rc={rc})")
+    };
+    if let Some(err) = last_err {
+        msg = format!("{msg}: {err}");
+    }
+    msg
 }
 
 #[inline(always)]
@@ -307,7 +369,7 @@ pub(crate) unsafe extern "C" fn on_metadata_cb(
 unsafe fn on_metadata_impl(metadata: *mut readstat_metadata_t, rctx: &mut ParseCtx) -> c_int {
     let label_ptr = readstat_get_file_label(metadata);
     if !label_ptr.is_null() {
-        let label = CStr::from_ptr(label_ptr).to_string_lossy().into_owned();
+        let label = rctx.decode(CStr::from_ptr(label_ptr)).into_owned();
         rctx.file_label = if label.trim().is_empty() {
             None
         } else {
@@ -348,7 +410,7 @@ unsafe fn on_variable_impl(
         if p.is_null() {
             format!("V{index}")
         } else {
-            CStr::from_ptr(p).to_string_lossy().trim().to_string()
+            rctx.decode(CStr::from_ptr(p)).trim().to_string()
         }
     };
 
@@ -381,7 +443,7 @@ unsafe fn on_variable_impl(
         if p.is_null() {
             None
         } else {
-            let s = CStr::from_ptr(p).to_string_lossy().to_string();
+            let s = rctx.decode(CStr::from_ptr(p)).into_owned();
             let st = s.trim();
             if st.is_empty() {
                 None
@@ -396,7 +458,7 @@ unsafe fn on_variable_impl(
         if p.is_null() {
             None
         } else {
-            let s = CStr::from_ptr(p).to_string_lossy().to_string();
+            let s = rctx.decode(CStr::from_ptr(p)).into_owned();
             let st = s.trim();
             if st.is_empty() {
                 None
@@ -425,7 +487,7 @@ unsafe fn on_variable_impl(
     let label_set = if label_set_name.is_null() {
         None
     } else {
-        let s = CStr::from_ptr(label_set_name).to_string_lossy().to_string();
+        let s = rctx.decode(CStr::from_ptr(label_set_name)).into_owned();
         let st = s.trim();
         if st.is_empty() {
             None
@@ -555,7 +617,7 @@ unsafe fn on_value_impl(
         if p.is_null() {
             return HANDLER_OK;
         }
-        CStr::from_ptr(p).to_string_lossy().trim().to_string()
+        rctx.decode(CStr::from_ptr(p)).trim().to_string()
     };
 
     if let Some(skip) = &rctx.cols_skip {
@@ -563,6 +625,23 @@ unsafe fn on_value_impl(
             return HANDLER_OK;
         }
     }
+
+    let is_tagged = rctx.detect_tagged && readstat_value_is_tagged_missing(value) != 0;
+    let is_missing = readstat_value_is_system_missing(value) != 0;
+    let vt = rs_value_type(value);
+    let is_str = vt == T_STRING || vt == T_STRING_REF;
+
+    // Decoded before borrowing the column builder (decode needs &mut ctx).
+    let str_val: Option<Cow<'_, str>> = if !is_tagged && !is_missing && is_str {
+        let sp = readstat_string_value(value);
+        if sp.is_null() {
+            None
+        } else {
+            Some(rctx.decode(CStr::from_ptr(sp)))
+        }
+    } else {
+        None
+    };
 
     let idx = match rctx.name_to_idx.get(&name) {
         Some(i) => *i,
@@ -573,7 +652,7 @@ unsafe fn on_value_impl(
         None => return HANDLER_OK,
     };
 
-    if rctx.detect_tagged && readstat_value_is_tagged_missing(value) != 0 {
+    if is_tagged {
         let tag_ch = readstat_value_tag(value) as u8 as char;
         let (rows, tags) = rctx
             .tagged
@@ -582,28 +661,16 @@ unsafe fn on_value_impl(
         rows.push(row as usize);
         tags.push(tag_ch.to_string());
         col.push_missing();
-    } else if readstat_value_is_system_missing(value) != 0 {
+    } else if is_missing {
         col.push_missing();
-    } else {
-        let vt = rs_value_type(value);
-        if vt == T_STRING || vt == T_STRING_REF {
-            let sp = readstat_string_value(value);
-            if sp.is_null() {
-                col.push_missing();
-            } else {
-                let cs = CStr::from_ptr(sp);
-                match cs.to_str() {
-                    Ok(s) => col.push_str(s),
-                    Err(_) => {
-                        rctx.had_invalid_utf8 = true;
-                        col.push_str(&cs.to_string_lossy());
-                    }
-                }
-            }
-        } else {
-            let d = readstat_double_value(value);
-            col.push_f64(d);
+    } else if is_str {
+        match str_val {
+            Some(s) => col.push_str(&s),
+            None => col.push_missing(),
         }
+    } else {
+        let d = readstat_double_value(value);
+        col.push_f64(d);
     }
 
     HANDLER_OK
@@ -618,7 +685,7 @@ pub(crate) unsafe extern "C" fn on_note_cb(
         return HANDLER_OK;
     }
     guard_cb(ctx, |rctx| {
-        let s = unsafe { CStr::from_ptr(note) }.to_string_lossy().into_owned();
+        let s = rctx.decode(unsafe { CStr::from_ptr(note) }).into_owned();
         rctx.notes.push(s);
         HANDLER_OK
     })
@@ -647,15 +714,12 @@ unsafe fn on_value_label_impl(
     let set = if set_name.is_null() {
         "__default__".to_string()
     } else {
-        CStr::from_ptr(set_name)
-            .to_string_lossy()
-            .trim()
-            .to_string()
+        rctx.decode(CStr::from_ptr(set_name)).trim().to_string()
     };
     let lab = if label.is_null() {
         String::new()
     } else {
-        CStr::from_ptr(label).to_string_lossy().into_owned()
+        rctx.decode(CStr::from_ptr(label)).into_owned()
     };
 
     let key = if readstat_value_is_system_missing(val) != 0 {
@@ -665,7 +729,7 @@ unsafe fn on_value_label_impl(
         if sp.is_null() {
             String::new()
         } else {
-            CStr::from_ptr(sp).to_string_lossy().into_owned()
+            rctx.decode(CStr::from_ptr(sp)).into_owned()
         }
     } else {
         format!("{}", readstat_double_value(val))
@@ -851,6 +915,7 @@ mod tests {
             n_rows_emitted: 0,
             last_counted_row: None,
             had_invalid_utf8: false,
+            lossy_utf8: false,
             label_sets: HashMap::new(),
             file_label: None,
             last_err: None,

--- a/packages/svy-io/native/svyreadstat_rs/src/sas_read.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/sas_read.rs
@@ -36,6 +36,7 @@ fn parse_sas_impl(
     rows_skip: usize,
     n_max: Option<usize>,
     cols_skip: Option<Vec<String>>,
+    lossy_utf8: bool,
 ) -> Result<(Vec<u8>, crate::core::MetaOut)> {
     // Pre-calculate skip set for O(1) lookup
     let cols_skip_set = cols_skip.map(|v| {
@@ -56,6 +57,7 @@ fn parse_sas_impl(
         n_rows_emitted: 0,
         last_counted_row: None,
         had_invalid_utf8: false,
+        lossy_utf8,
         label_sets: HashMap::with_capacity(64), // Pre-allocate for value labels
         file_label: None,
         last_err: None,
@@ -77,8 +79,8 @@ fn parse_sas_impl(
             // Only need value label handler for catalog
             readstat_set_value_label_handler(parser, Some(on_value_label_cb));
 
-            let _keep_enc = match crate::core::configure_parser(parser, catalog_encoding, 0, None)
-            {
+            let cat_enc = crate::core::input_encoding(catalog_encoding, lossy_utf8);
+            let _keep_enc = match crate::core::configure_parser(parser, cat_enc, 0, None) {
                 Ok(k) => k,
                 Err(msg) => {
                     readstat_parser_free(parser);
@@ -122,7 +124,8 @@ fn parse_sas_impl(
         readstat_set_variable_handler(parser, Some(on_variable_cb));
         readstat_set_value_handler(parser, Some(on_value_cb));
 
-        let _keep_enc = match crate::core::configure_parser(parser, encoding, rows_skip, n_max) {
+        let enc = crate::core::input_encoding(encoding, lossy_utf8);
+        let _keep_enc = match crate::core::configure_parser(parser, enc, rows_skip, n_max) {
             Ok(k) => k,
             Err(msg) => {
                 readstat_parser_free(parser);
@@ -149,10 +152,7 @@ fn parse_sas_impl(
 
         // Handle errors
         if rc != RS_OK && !early_ok && rc != RS_USER_ABORT {
-            let msg = ctx
-                .last_err
-                .take()
-                .unwrap_or_else(|| format!("Data parse failed with code {rc}"));
+            let msg = crate::core::parse_failure(rc, ctx.last_err.take());
             return Err(anyhow!("Failed to parse SAS data file: {msg}"));
         }
     }
@@ -182,7 +182,8 @@ fn parse_sas_impl(
     catalog_encoding=None,
     cols_skip=None,
     n_max=None,
-    rows_skip=0
+    rows_skip=0,
+    lossy_utf8=false
 ))]
 pub fn df_parse_sas_file<'py>(
     py: Python<'py>,
@@ -193,6 +194,7 @@ pub fn df_parse_sas_file<'py>(
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    lossy_utf8: bool,
 ) -> PyResult<(Py<PyAny>, String)> {
     // Release GIL during parsing for better Python concurrency
     let result =
@@ -205,6 +207,7 @@ pub fn df_parse_sas_file<'py>(
                 rows_skip,
                 n_max,
                 cols_skip,
+                lossy_utf8,
             )
         });
 
@@ -230,7 +233,7 @@ mod tests {
 
     #[test]
     fn test_parse_sas_validates_path() {
-        let result = parse_sas_impl("nonexistent.sas7bdat", None, None, None, 0, None, None);
+        let result = parse_sas_impl("nonexistent.sas7bdat", None, None, None, 0, None, None, false);
         assert!(result.is_err());
     }
 
@@ -238,14 +241,23 @@ mod tests {
     fn test_parse_sas_handles_skip_params() {
         // Test that skip parameters are properly configured
         let cols_skip = Some(vec!["var1".to_string(), "var2".to_string()]);
-        let result = parse_sas_impl("test.sas7bdat", None, 10, Some(50), cols_skip);
+        let result = parse_sas_impl("test.sas7bdat", None, None, None, 10, Some(50), cols_skip, false);
         // Will fail on nonexistent file, but tests parameter handling
         assert!(result.is_err());
     }
 
     #[test]
     fn test_parse_sas_with_catalog() {
-        let result = parse_sas_impl("test.sas7bdat", Some("test.sas7bcat"), 0, None, None);
+        let result = parse_sas_impl(
+            "test.sas7bdat",
+            Some("test.sas7bcat"),
+            None,
+            None,
+            0,
+            None,
+            None,
+            false,
+        );
         // Will fail on nonexistent files, but tests catalog parameter
         assert!(result.is_err());
     }

--- a/packages/svy-io/native/svyreadstat_rs/src/spss_read.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/spss_read.rs
@@ -20,7 +20,7 @@ use crate::core::{
 
 /// Parse SPSS .sav file
 #[pyfunction]
-#[pyo3(signature = (path, encoding=None, _user_na=false, cols_skip=None, n_max=None, rows_skip=0))]
+#[pyo3(signature = (path, encoding=None, _user_na=false, cols_skip=None, n_max=None, rows_skip=0, lossy_utf8=false))]
 pub fn df_parse_sav_file(
     py: Python<'_>,
     path: &str,
@@ -29,9 +29,11 @@ pub fn df_parse_sav_file(
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    lossy_utf8: bool,
 ) -> PyResult<(Py<PyAny>, String)> {
     // Release GIL during parsing for better Python concurrency
-    let result = py.detach(|| parse_sav_impl(path, encoding, cols_skip, n_max, rows_skip));
+    let result =
+        py.detach(|| parse_sav_impl(path, encoding, cols_skip, n_max, rows_skip, lossy_utf8));
 
     let (ipc, meta) = result?;
     let meta_json = serde_json::to_string(&meta).map_err(|e| {
@@ -47,7 +49,7 @@ pub fn df_parse_sav_file(
 
 /// Parse SPSS portable (.por) file
 #[pyfunction]
-#[pyo3(signature = (path, encoding=None, _user_na=false, cols_skip=None, n_max=None, rows_skip=0))]
+#[pyo3(signature = (path, encoding=None, _user_na=false, cols_skip=None, n_max=None, rows_skip=0, lossy_utf8=false))]
 pub fn df_parse_por_file(
     py: Python<'_>,
     path: &str,
@@ -56,9 +58,11 @@ pub fn df_parse_por_file(
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    lossy_utf8: bool,
 ) -> PyResult<(Py<PyAny>, String)> {
     // Release GIL during parsing for better Python concurrency
-    let result = py.detach(|| parse_por_impl(path, encoding, cols_skip, n_max, rows_skip));
+    let result =
+        py.detach(|| parse_por_impl(path, encoding, cols_skip, n_max, rows_skip, lossy_utf8));
 
     let (ipc, meta) = result?;
     let meta_json = serde_json::to_string(&meta).map_err(|e| {
@@ -80,6 +84,7 @@ fn parse_sav_impl(
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    lossy_utf8: bool,
 ) -> PyResult<(Vec<u8>, crate::core::MetaOut)> {
     // Pre-calculate skip set for O(1) lookup
     let cols_skip_map = cols_skip.map(|v| {
@@ -100,6 +105,7 @@ fn parse_sav_impl(
         n_rows_emitted: 0,
         last_counted_row: None,
         had_invalid_utf8: false,
+        lossy_utf8,
         label_sets: HashMap::with_capacity(64), // Pre-allocate for value labels
         file_label: None,
         last_err: None,
@@ -124,7 +130,8 @@ fn parse_sav_impl(
         readstat_set_value_handler(p, Some(on_value_cb));
         readstat_set_value_label_handler(p, Some(on_value_label_cb));
 
-        let _keep_enc = match crate::core::configure_parser(p, encoding, rows_skip, n_max) {
+        let enc = crate::core::input_encoding(encoding, lossy_utf8);
+        let _keep_enc = match crate::core::configure_parser(p, enc, rows_skip, n_max) {
             Ok(k) => k,
             Err(msg) => {
                 readstat_parser_free(p);
@@ -149,7 +156,7 @@ fn parse_sav_impl(
             .map(|nm| ctx.n_rows_emitted >= nm)
             .unwrap_or(false);
         if rc != RS_OK && !early_ok && rc != RS_USER_ABORT {
-            let msg = ctx.last_err.take().unwrap_or_else(|| format!("rc={rc}"));
+            let msg = crate::core::parse_failure(rc, ctx.last_err.take());
             return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
                 "Failed to parse SAV: {msg}"
             )));
@@ -168,6 +175,7 @@ fn parse_por_impl(
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    lossy_utf8: bool,
 ) -> PyResult<(Vec<u8>, crate::core::MetaOut)> {
     // Pre-calculate skip set for O(1) lookup
     let cols_skip_map = cols_skip.map(|v| {
@@ -188,6 +196,7 @@ fn parse_por_impl(
         n_rows_emitted: 0,
         last_counted_row: None,
         had_invalid_utf8: false,
+        lossy_utf8,
         label_sets: HashMap::with_capacity(64), // Pre-allocate for value labels
         file_label: None,
         last_err: None,
@@ -212,7 +221,8 @@ fn parse_por_impl(
         readstat_set_value_handler(p, Some(on_value_cb));
         readstat_set_value_label_handler(p, Some(on_value_label_cb));
 
-        let _keep_enc = match crate::core::configure_parser(p, encoding, rows_skip, n_max) {
+        let enc = crate::core::input_encoding(encoding, lossy_utf8);
+        let _keep_enc = match crate::core::configure_parser(p, enc, rows_skip, n_max) {
             Ok(k) => k,
             Err(msg) => {
                 readstat_parser_free(p);
@@ -237,7 +247,7 @@ fn parse_por_impl(
             .map(|nm| ctx.n_rows_emitted >= nm)
             .unwrap_or(false);
         if rc != RS_OK && !early_ok && rc != RS_USER_ABORT {
-            let msg = ctx.last_err.take().unwrap_or_else(|| format!("rc={rc}"));
+            let msg = crate::core::parse_failure(rc, ctx.last_err.take());
             return Err(pyo3::exceptions::PyRuntimeError::new_err(format!(
                 "Failed to parse POR: {msg}"
             )));

--- a/packages/svy-io/native/svyreadstat_rs/src/stata_read.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/stata_read.rs
@@ -21,6 +21,8 @@ fn parse_dta_impl(
     rows_skip: usize,
     n_max: Option<usize>,
     cols_skip: Option<Vec<String>>,
+    encoding: Option<&str>,
+    lossy_utf8: bool,
 ) -> Result<(Vec<u8>, crate::core::MetaOut)> {
     let mut ctx = ParseCtx {
         cols: Vec::with_capacity(64), // Pre-allocate for typical files
@@ -38,6 +40,7 @@ fn parse_dta_impl(
         n_rows_emitted: 0,
         last_counted_row: None,
         had_invalid_utf8: false,
+        lossy_utf8,
         label_sets: HashMap::with_capacity(32), // Pre-allocate
         file_label: None,
         last_err: None,
@@ -58,9 +61,8 @@ fn parse_dta_impl(
         readstat_set_variable_handler(p, Some(on_variable_cb));
         readstat_set_value_handler(p, Some(on_value_cb));
 
-        // Defensive row limit for untrusted files (n_max already aborts in
-        // the value callback; this stops the C parser earlier too).
-        let _keep_enc = match crate::core::configure_parser(p, None, rows_skip, n_max) {
+        let enc = crate::core::input_encoding(encoding, lossy_utf8);
+        let _keep_enc = match crate::core::configure_parser(p, enc, rows_skip, n_max) {
             Ok(k) => k,
             Err(msg) => {
                 readstat_parser_free(p);
@@ -85,7 +87,7 @@ fn parse_dta_impl(
             .unwrap_or(false);
 
         if rc != RS_OK && !early_ok && rc != RS_USER_ABORT {
-            let msg = ctx.last_err.take().unwrap_or_else(|| format!("rc={rc}"));
+            let msg = crate::core::parse_failure(rc, ctx.last_err.take());
             return Err(anyhow!("Failed to parse .dta: {msg}"));
         }
     }
@@ -94,16 +96,19 @@ fn parse_dta_impl(
 }
 
 #[pyfunction]
-#[pyo3(signature = (data_path, cols_skip=None, n_max=None, rows_skip=0))]
+#[pyo3(signature = (data_path, cols_skip=None, n_max=None, rows_skip=0, encoding=None, lossy_utf8=false))]
 pub fn df_parse_dta_file<'py>(
     py: Python<'py>,
     data_path: &str,
     cols_skip: Option<Vec<String>>,
     n_max: Option<usize>,
     rows_skip: usize,
+    encoding: Option<&str>,
+    lossy_utf8: bool,
 ) -> PyResult<(Py<PyAny>, String)> {
     // Release GIL during parsing for better Python concurrency
-    let result = py.detach(|| parse_dta_impl(data_path, rows_skip, n_max, cols_skip));
+    let result =
+        py.detach(|| parse_dta_impl(data_path, rows_skip, n_max, cols_skip, encoding, lossy_utf8));
 
     let (ipc, meta) =
         result.map_err(|e| pyo3::exceptions::PyRuntimeError::new_err(e.to_string()))?;

--- a/packages/svy-io/native/svyreadstat_rs/src/xpt_read.rs
+++ b/packages/svy-io/native/svyreadstat_rs/src/xpt_read.rs
@@ -33,6 +33,7 @@ fn parse_xpt_impl(
         n_rows_emitted: 0,
         last_counted_row: None,
         had_invalid_utf8: false,
+        lossy_utf8: false,
         label_sets: HashMap::new(),
         file_label: None,
         last_err: None,
@@ -81,7 +82,7 @@ fn parse_xpt_impl(
             .map(|nm| ctx.n_rows_emitted >= nm)
             .unwrap_or(false);
         if rc != RS_OK && !early_ok && rc != RS_USER_ABORT {
-            let msg = ctx.last_err.take().unwrap_or_else(|| format!("rc={rc}"));
+            let msg = crate::core::parse_failure(rc, ctx.last_err.take());
             return Err(anyhow!("Failed to parse XPT: {msg}"));
         }
     }

--- a/packages/svy-io/pyproject.toml
+++ b/packages/svy-io/pyproject.toml
@@ -31,7 +31,7 @@ include = [
   "ReadStat/LICENSE",
   "ReadStat/README.md",
 ]
-features = ["vendored"]
+features = ["vendored", "extension-module"]
 
 [dependency-groups]
 dev = [

--- a/packages/svy-io/python/svy_io/helpers.py
+++ b/packages/svy-io/python/svy_io/helpers.py
@@ -6,6 +6,32 @@ import tempfile
 from typing import Any
 
 
+# ---------------- encoding ----------------
+
+_LOSSY_ENCODINGS = frozenset({"utf8-lossy", "utf-8-lossy"})
+
+# Appended to the parse error for READSTAT_ERROR_CONVERT_BAD_STRING (rc=17).
+BAD_STRING_HINT = (
+    "pass encoding='utf8-lossy' to replace undecodable bytes with U+FFFD "
+    "(flagged in meta['had_invalid_utf8']), or the file's actual encoding if "
+    "the one assumed is wrong"
+)
+
+
+def _split_encoding(encoding: str | None) -> tuple[str | None, bool]:
+    """Map the public ``encoding`` to (iconv name, lossy_utf8) for the native layer."""
+    if encoding is not None and encoding.lower() in _LOSSY_ENCODINGS:
+        return None, True
+    return encoding, False
+
+
+def _with_bad_string_hint(e: RuntimeError, hint: str = BAD_STRING_HINT) -> RuntimeError:
+    """Attach a ``Hint:`` naming the encoding option to an rc=17 parse error."""
+    if "(rc=17)" in str(e):
+        return RuntimeError(f"{e}. Hint: {hint}.")
+    return e
+
+
 # ---------------- n_max normalization ----------------
 
 

--- a/packages/svy-io/python/svy_io/sas.py
+++ b/packages/svy-io/python/svy_io/sas.py
@@ -19,7 +19,7 @@ from polars.exceptions import ComputeError
 import svy_io.svyreadstat_rs as native
 
 from .factor import as_factor, check_ordered_levels, ordered_categories
-from .helpers import _normalize_n_max
+from .helpers import _normalize_n_max, _split_encoding, _with_bad_string_hint
 from .metadata import normalize_user_missing
 from .tagged_na import TaggedNA
 
@@ -606,15 +606,13 @@ def read_sas(
         elif catalog_path is not None:
             catalog_path = _as_path_like(catalog_path, _tmp_stack)
 
-        ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
-            data_path,
-            catalog_path,
-            encoding,
-            catalog_encoding,
-            cols_skip,
-            n_max,
-            rows_skip,
-        )
+        enc, lossy = _split_encoding(encoding)
+        try:
+            ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
+                data_path, catalog_path, enc, catalog_encoding, cols_skip, n_max, rows_skip, lossy
+            )
+        except RuntimeError as e:
+            raise _with_bad_string_hint(e) from e
 
     # Robust loader: try FILE first; if footer is missing, use STREAM.
     bio = io.BytesIO(ipc_bytes)
@@ -694,9 +692,13 @@ def read_sas_arrow(
     if zero_rows:
         n_max = 1
 
-    ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
-        data_path, catalog_path, encoding, catalog_encoding, cols_skip, n_max, rows_skip
-    )
+    enc, lossy = _split_encoding(encoding)
+    try:
+        ipc_bytes, meta_json = native.df_parse_sas_file(  # type: ignore[attr-defined]
+            data_path, catalog_path, enc, catalog_encoding, cols_skip, n_max, rows_skip, lossy
+        )
+    except RuntimeError as e:
+        raise _with_bad_string_hint(e) from e
 
     bio = io.BytesIO(ipc_bytes)
     # Use FileReader first (Rust likely wrote a file IPC); fallback to stream

--- a/packages/svy-io/python/svy_io/spss.py
+++ b/packages/svy-io/python/svy_io/spss.py
@@ -14,7 +14,7 @@ from polars.exceptions import ComputeError
 
 import svy_io.svyreadstat_rs as native
 
-from .helpers import _as_path, _normalize_n_max
+from .helpers import _as_path, _normalize_n_max, _split_encoding, _with_bad_string_hint
 from .labelled import LabelledSPSS, labelled_spss
 from .metadata import normalize_user_missing
 
@@ -283,16 +283,15 @@ def read_sav(
 
     normalized_cols_skip = _normalize_cols_skip(cols_skip)
 
+    enc, lossy = _split_encoding(encoding)
     # Native parse (GIL released)
     with _as_path(data_path) as _path:
-        ipc_bytes, meta_json = native.df_parse_sav_file(
-            _path,
-            encoding or None,
-            user_na,
-            normalized_cols_skip,
-            n_max,
-            rows_skip,
-        )
+        try:
+            ipc_bytes, meta_json = native.df_parse_sav_file(
+                _path, enc, user_na, normalized_cols_skip, n_max, rows_skip, lossy
+            )
+        except RuntimeError as e:
+            raise _with_bad_string_hint(e) from e
 
     meta: Dict[str, Any] = json.loads(meta_json)
 
@@ -331,6 +330,7 @@ def read_sav(
 def read_por(
     data_path: str | os.PathLike | io.BufferedIOBase,
     *,
+    encoding: str | None = None,
     user_na: bool = False,
     cols_skip: list[str] | None = None,
     n_max: int | None = None,
@@ -351,15 +351,14 @@ def read_por(
 
     normalized_cols_skip = _normalize_cols_skip(cols_skip)
 
+    enc, lossy = _split_encoding(encoding)
     with _as_path(data_path) as _path:
-        ipc_bytes, meta_json = native.df_parse_por_file(
-            _path,
-            None,
-            user_na,
-            normalized_cols_skip,
-            n_max,
-            rows_skip,
-        )
+        try:
+            ipc_bytes, meta_json = native.df_parse_por_file(
+                _path, enc, user_na, normalized_cols_skip, n_max, rows_skip, lossy
+            )
+        except RuntimeError as e:
+            raise _with_bad_string_hint(e) from e
 
     meta: Dict[str, Any] = json.loads(meta_json)
 
@@ -427,6 +426,7 @@ def read_spss(
     elif ext == ".por":
         return read_por(
             data_path,
+            encoding=encoding,
             user_na=user_na,
             cols_skip=cols_skip,
             n_max=n_max,

--- a/packages/svy-io/python/svy_io/stata.py
+++ b/packages/svy-io/python/svy_io/stata.py
@@ -17,8 +17,8 @@ from polars.exceptions import ComputeError
 
 import svy_io.svyreadstat_rs as native
 
+from .helpers import _as_path, _normalize_n_max, _split_encoding, _with_bad_string_hint
 from .metadata import normalize_user_missing
-from .helpers import _as_path, _normalize_n_max
 from .tagged_na import TaggedNA
 
 
@@ -119,9 +119,33 @@ def get_value_labels_for_column(meta: dict, col_name: str) -> dict[str, str] | N
     return labels
 
 
+_BAD_STRING_HINT = (
+    "Stata 13 and older files are decoded as Windows-1252 unless told otherwise; "
+    "pass encoding='utf-8' if the file holds UTF-8 text, or encoding='utf8-lossy' "
+    "to replace undecodable bytes with U+FFFD (flagged in meta['had_invalid_utf8'])"
+)
+
+
+def _parse_dta_native(
+    path: str,
+    cols_skip: list[str] | None,
+    n_max: int | None,
+    rows_skip: int,
+    encoding: str | None,
+) -> Tuple[bytes, str]:
+    enc, lossy = _split_encoding(encoding)
+    try:
+        return native.df_parse_dta_file(  # type: ignore[attr-defined]
+            path, cols_skip, n_max, rows_skip, enc, lossy
+        )
+    except RuntimeError as e:
+        raise _with_bad_string_hint(e, _BAD_STRING_HINT) from e
+
+
 def read_dta(
     data_path: str | os.PathLike | io.BufferedIOBase,
     *,
+    encoding: str | None = None,
     cols_skip: list[str] | None = None,
     n_max: int | None = None,
     rows_skip: int = 0,
@@ -131,6 +155,16 @@ def read_dta(
     levels: str = "default",
     ordered: bool = False,
 ) -> Tuple[pl.DataFrame, Dict[str, Any]]:
+    """
+    Read a Stata .dta file into a Polars frame plus metadata.
+
+    ``encoding`` is the file's character encoding (an iconv name such as
+    ``"utf-8"`` or ``"windows-1252"``). By default ReadStat assumes UTF-8 for
+    Stata 14+ (format 118+) and Windows-1252 for older files, and fails with
+    rc=17 on a byte sequence invalid in that encoding. ``"utf8-lossy"`` decodes
+    as UTF-8 and replaces undecodable bytes with U+FFFD, setting
+    ``meta["had_invalid_utf8"]``.
+    """
     # Lazy imports only when needed
     if coerce_temporals:
         from svy_io.temporals import coerce_stata_temporals  # type: ignore
@@ -149,12 +183,7 @@ def read_dta(
 
     # Rust does the heavy lifting here (with GIL released).
     with _as_path(data_path) as _path:
-        ipc_bytes, meta_json = native.df_parse_dta_file(  # type: ignore[attr-defined]
-            _path,
-            cols_skip,
-            n_max,
-            rows_skip,
-        )
+        ipc_bytes, meta_json = _parse_dta_native(_path, cols_skip, n_max, rows_skip, encoding)
 
     # Parse JSON once
     meta: Dict[str, Any] = json.loads(meta_json)
@@ -196,12 +225,12 @@ read_stata = read_dta
 def read_stata_arrow(
     data_path: str | os.PathLike | io.BufferedIOBase,
     *,
+    encoding: str | None = None,
     cols_skip: list[str] | None = None,
     n_max: int | None = None,
     rows_skip: int = 0,
 ):
     """Arrow-table variant."""
-    import pyarrow as pa
     import pyarrow.ipc as pa_ipc
 
     from pyarrow import ArrowInvalid
@@ -215,12 +244,7 @@ def read_stata_arrow(
         n_max = 1
 
     with _as_path(data_path) as _path:
-        ipc_bytes, meta_json = native.df_parse_dta_file(  # type: ignore[attr-defined]
-            _path,
-            cols_skip,
-            n_max,
-            rows_skip,
-        )
+        ipc_bytes, meta_json = _parse_dta_native(_path, cols_skip, n_max, rows_skip, encoding)
 
     bio = io.BytesIO(ipc_bytes)
     try:

--- a/packages/svy-io/tests/test_spss_encoding.py
+++ b/packages/svy-io/tests/test_spss_encoding.py
@@ -1,0 +1,87 @@
+# tests/test_spss_encoding.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from svy_io.sas import read_sas
+from svy_io.spss import read_sav, write_sav
+
+
+CAFE_CP1252 = b"caf\xe9"  # "café" in Windows-1252, invalid as UTF-8
+HERE = Path(__file__).resolve().parent
+
+
+def _sav_with_bytes(tmp_path: Path, value: bytes, label: bytes | None = None) -> Path:
+    """Write a UTF-8 .sav with ASCII placeholders, then splice raw bytes into it."""
+    out = tmp_path / "enc.sav"
+    df = pl.DataFrame({"x": ["pre VALUE post", "plain"], "y": [1.0, 2.0]})
+    write_sav(df, out, var_labels={"x": "LABEL here"})
+    raw = out.read_bytes()
+    for old, new in [(b"VALUE", value), (b"LABEL", label)]:
+        if new is None:
+            continue
+        assert raw.count(old) == 1 and len(old) == len(new)
+        raw = raw.replace(old, new)
+    out.write_bytes(raw)
+    return out
+
+
+def _label(meta: dict) -> str:
+    return next(v["label"] for v in meta["vars"] if v["name"] == "x")
+
+
+def test_sav_invalid_utf8_raises_and_names_the_option(tmp_path: Path):
+    path = _sav_with_bytes(tmp_path, CAFE_CP1252 + b" ")
+    with pytest.raises(RuntimeError, match=r"invalid byte sequence.*\(rc=17\).*utf8-lossy"):
+        read_sav(path)
+
+
+def test_sav_explicit_encoding_decodes_the_bytes(tmp_path: Path):
+    path = _sav_with_bytes(tmp_path, CAFE_CP1252 + b" ", label=CAFE_CP1252 + b" ")
+    df, meta = read_sav(path, encoding="windows-1252")
+    assert df["x"][0] == "pre café  post"
+    assert _label(meta) == "café  here"
+    assert meta["had_invalid_utf8"] is False
+
+
+def test_sav_utf8_lossy_replaces_invalid_bytes(tmp_path: Path):
+    path = _sav_with_bytes(tmp_path, CAFE_CP1252 + b" ", label=CAFE_CP1252 + b" ")
+    df, meta = read_sav(path, encoding="utf8-lossy")
+    assert df["x"].to_list() == ["pre caf�  post", "plain"]
+    assert _label(meta) == "caf�  here"
+    assert meta["had_invalid_utf8"] is True
+
+
+def test_sav_valid_utf8_is_unchanged_under_lossy(tmp_path: Path):
+    path = _sav_with_bytes(tmp_path, "b\U0001f3cd".encode())
+    for enc in (None, "utf8-lossy"):
+        df, meta = read_sav(path, encoding=enc)
+        assert df["x"][0] == "pre b\U0001f3cd post"
+        assert meta["had_invalid_utf8"] is False
+
+
+def test_sav_unknown_encoding_raises(tmp_path: Path):
+    path = _sav_with_bytes(tmp_path, b"VALUE")
+    with pytest.raises(RuntimeError, match=r"unsupported character set \(rc=7\)"):
+        read_sav(path, encoding="no-such-codec")
+
+
+# No sas7bdat writer exists, so SAS is checked on the shipped fixtures: lossy
+# mode must round-trip clean data, labels included, and the error path must
+# carry ReadStat's text.
+def test_sas_utf8_lossy_round_trips_clean_data():
+    data = str(HERE / "data/sas/hadley.sas7bdat")
+    catalog = str(HERE / "data/sas/formats.sas7bcat")
+    strict = read_sas(data, catalog_path=catalog)
+    lossy = read_sas(data, catalog_path=catalog, encoding="utf8-lossy")
+    assert lossy[0].equals(strict[0])
+    assert lossy[1]["value_labels"] == strict[1]["value_labels"]
+    assert lossy[1]["had_invalid_utf8"] is False
+
+
+def test_sas_unknown_encoding_raises():
+    with pytest.raises(RuntimeError, match=r"unsupported character set \(rc=7\)"):
+        read_sas(str(HERE / "data/sas/hadley.sas7bdat"), encoding="no-such-codec")

--- a/packages/svy-io/tests/test_spss_encoding.py
+++ b/packages/svy-io/tests/test_spss_encoding.py
@@ -78,7 +78,9 @@ def test_sas_utf8_lossy_round_trips_clean_data():
     strict = read_sas(data, catalog_path=catalog)
     lossy = read_sas(data, catalog_path=catalog, encoding="utf8-lossy")
     assert lossy[0].equals(strict[0])
-    assert lossy[1]["value_labels"] == strict[1]["value_labels"]
+    # value_labels is emitted in hash order; compare as a mapping
+    by_set = lambda meta: {vl["set_name"]: vl["mapping"] for vl in meta["value_labels"]}  # noqa: E731
+    assert by_set(lossy[1]) == by_set(strict[1])
     assert lossy[1]["had_invalid_utf8"] is False
 
 

--- a/packages/svy-io/tests/test_stata_encoding.py
+++ b/packages/svy-io/tests/test_stata_encoding.py
@@ -1,0 +1,85 @@
+# tests/test_stata_encoding.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+from svy_io.stata import read_dta, write_dta
+
+
+CAFE_CP1252 = b"caf\xe9"  # "café" in Windows-1252, invalid as UTF-8
+MOTORBIKE_UTF8 = "\U0001f3cd".encode()  # F0 9F 8F 8D: 8D and 8F are undefined in CP1252
+
+
+def _dta_with_bytes(
+    tmp_path: Path, version: int, value: bytes, label: bytes | None = None
+) -> Path:
+    """Write a .dta with ASCII placeholders, then splice raw bytes into it."""
+    out = tmp_path / f"enc{version}.dta"
+    df = pl.DataFrame({"x": ["pre VALUE post", "plain"], "y": [1.0, 2.0]})
+    write_dta(df, out, version=version, var_labels={"x": "LABEL here"})
+    raw = out.read_bytes()
+    for old, new in [(b"VALUE", value), (b"LABEL", label)]:
+        if new is None:
+            continue
+        assert raw.count(old) == 1 and len(old) == len(new)
+        raw = raw.replace(old, new)
+    out.write_bytes(raw)
+    return out
+
+
+def _label(meta: dict) -> str:
+    return next(v["label"] for v in meta["vars"] if v["name"] == "x")
+
+
+def test_stata13_decodes_windows1252_by_default(tmp_path: Path):
+    path = _dta_with_bytes(tmp_path, 117, b"caf\xe9\x20", label=b"caf\xe9\x20")
+    for enc in (None, "windows-1252", "latin1"):
+        df, meta = read_dta(path, encoding=enc)
+        assert df["x"][0] == "pre café  post"
+        assert _label(meta) == "café  here"
+        assert meta["had_invalid_utf8"] is False
+
+
+def test_stata13_with_utf8_text_raises_and_names_the_option(tmp_path: Path):
+    path = _dta_with_bytes(tmp_path, 117, b"b" + MOTORBIKE_UTF8)
+    with pytest.raises(RuntimeError, match=r"\(rc=17\).*encoding='utf-8'.*utf8-lossy"):
+        read_dta(path)
+
+
+@pytest.mark.parametrize("enc", ["utf-8", "utf8-lossy", "UTF8-LOSSY"])
+def test_stata13_with_utf8_text_reads_with_encoding(tmp_path: Path, enc: str):
+    path = _dta_with_bytes(tmp_path, 117, b"b" + MOTORBIKE_UTF8, label=b"L" + MOTORBIKE_UTF8)
+    df, meta = read_dta(path, encoding=enc)
+    assert df["x"].to_list() == ["pre b\U0001f3cd post", "plain"]
+    assert _label(meta) == "L\U0001f3cd here"
+    assert meta["had_invalid_utf8"] is False
+
+
+def test_strict_utf8_rejects_invalid_bytes_and_lossy_replaces_them(tmp_path: Path):
+    path = _dta_with_bytes(tmp_path, 117, CAFE_CP1252 + b" ", label=CAFE_CP1252 + b" ")
+    with pytest.raises(RuntimeError, match=r"\(rc=17\)"):
+        read_dta(path, encoding="utf-8")
+
+    df, meta = read_dta(path, encoding="utf8-lossy")
+    assert df["x"][0] == "pre caf�  post"
+    assert _label(meta) == "caf�  here"
+    assert meta["had_invalid_utf8"] is True
+
+
+def test_stata14_invalid_utf8_is_lossy_by_default(tmp_path: Path):
+    path = _dta_with_bytes(tmp_path, 118, CAFE_CP1252 + b" ")
+    df, meta = read_dta(path)
+    assert df["x"][0] == "pre caf�  post"
+    assert meta["had_invalid_utf8"] is True
+
+    with pytest.raises(RuntimeError, match=r"\(rc=17\)"):
+        read_dta(path, encoding="utf-8")
+
+
+def test_unknown_encoding_raises(tmp_path: Path):
+    path = _dta_with_bytes(tmp_path, 117, b"VALUE")
+    with pytest.raises(RuntimeError, match="unsupported character set"):
+        read_dta(path, encoding="no-such-codec")

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,8 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Added
 
+- **`read_stata(encoding=)` is forwarded to the reader** instead of being dropped with a warning. A Stata 13 file holding UTF-8 text (the Nigeria GHS-Panel Wave 5 free-text sections) now reads with `encoding="utf-8"`, or `encoding="utf8-lossy"` to replace undecodable bytes, an option `read_spss` and `read_sas` accept as well; the parse `IoError` for that failure carries the engine's hint naming the option.
+
 - **Panel surveys, with no new type.** A panel is a long `Sample` whose `Design.case_id` identifies the followed case and whose `Design.wave` orders its rows. `svy.combine_samples(kind="panel", case_id=...)` stacks the waves and validates the pairing (unique id within each wave, consecutive-wave overlap, design columns constant within a case, later waves' units a subset of wave 1's); `Design(case_id=..., wave=...)` declares the same on a long file. When no PSU is declared the case is the variance PSU, so `mean(y, by="wave")` and its contrasts carry the between-wave covariance without being told to — the change SE equals the wide-frame individual-change SE, not the naive independent-waves one. Producer longitudinal weights stay ordinary columns selected with `use_weight()`; identical producer replicate weights are accepted across waves.
 
   ```python

--- a/packages/svy/src/svy/engine/io/stata.py
+++ b/packages/svy/src/svy/engine/io/stata.py
@@ -41,13 +41,12 @@ def _read_stata(
         - Raw metadata dict (to be imported via import_labels_from_svyio_meta)
         - File info dict
     """
-    # 1. Warning for unsupported arguments
+    # 1. Forward the file encoding (iconv name, or "utf8-lossy")
     if encoding is not None:
-        log.warning("Stata engine does not support 'encoding'. It will be ignored.")
+        kwargs["encoding"] = encoding
 
     # 2. Call Engine
-    # CRITICAL: We pass ONLY kwargs.
-    # 'columns' and 'encoding' are captured by the signature above and NOT passed to sio.
+    # 'columns' is applied here, after the read, and NOT passed to sio.
     res = sio.read_stata(str(path), **kwargs)
 
     # 3. Normalize Result

--- a/packages/svy/src/svy/io/base.py
+++ b/packages/svy/src/svy/io/base.py
@@ -109,7 +109,13 @@ def _wrap_io_op(op_name: str, fmt: str, path: str | Path, engine_fn: Callable, *
         raise map_os_error(e, where=where, path=path_obj) from e
     except RuntimeError as e:
         log.debug("%s parse failed: %s", where, e)
-        raise IoError.parse_failed(where=where, fmt=fmt, path=path_obj, engine_msg=str(e)) from e
+        # The engine appends ". Hint: ..." to errors it knows the fix for
+        # (e.g. a Stata 13 file holding UTF-8 text needs encoding="utf-8").
+        engine_msg, _, hint = str(e).partition(". Hint: ")
+        extra = {"hint": hint} if hint else {}
+        raise IoError.parse_failed(
+            where=where, fmt=fmt, path=path_obj, engine_msg=engine_msg, **extra
+        ) from e
     except Exception as e:
         log.debug("%s failed: %s", where, e, exc_info=True)
         # Check if it's a known Polars error we want to wrap, otherwise re-raise or wrap generic

--- a/packages/svy/tests/svy/io/test_base.py
+++ b/packages/svy/tests/svy/io/test_base.py
@@ -72,15 +72,10 @@ def test_read_other_formats(dummy_svyio, reader, ext, tmp_path):
     calls = [c for c in dummy_svyio.calls if c.fn.startswith("read_")]
     last_call = calls[-1]
 
-    if "dta" in ext:
-        # Stata Engine: explicit columns/encoding are removed to prevent crashes
-        assert "columns" not in last_call.kwargs
-        assert "cols_skip" not in last_call.kwargs
-        # We explicitly verify encoding is NOT passed
-        assert "encoding" not in last_call.kwargs
-    elif "sas" in ext:
-        # SAS Engine: encoding is supported and passed through
-        assert last_call.kwargs.get("encoding") == "latin1"
+    # Column selection happens in the wrapper; encoding is passed through
+    assert "columns" not in last_call.kwargs
+    assert "cols_skip" not in last_call.kwargs
+    assert last_call.kwargs.get("encoding") == "latin1"
 
 
 def test_create_from_stata_and_sas_return_sample(dummy_svyio, tmp_path):
@@ -183,3 +178,26 @@ def test_aliases_point_to_spss_variants():
     assert read_sav is read_spss
     assert write_sav is write_spss
     assert create_from_sav is create_from_spss
+
+
+def test_read_stata_parse_error_surfaces_engine_hint(dummy_svyio, tmp_path, monkeypatch):
+    from svy.errors.io_errors import IoError
+
+    p = tmp_path / "fake.dta"
+    p.touch()
+    msg = (
+        "Failed to parse .dta: Unable to convert string to the requested encoding "
+        "(invalid byte sequence) (rc=17). Hint: pass encoding='utf-8' or encoding='utf8-lossy'"
+    )
+
+    def boom(path, **kwargs):
+        raise RuntimeError(msg)
+
+    monkeypatch.setattr(dummy_svyio, "read_stata", boom)
+    with pytest.raises(IoError) as ei:
+        read_stata(p)
+    err = ei.value
+    assert err.code == "READSTAT_PARSE_FAILED"
+    assert err.detail.endswith("(rc=17)")
+    assert "encoding='utf-8'" in err.hint and "utf8-lossy" in err.hint
+    assert "encoding=" in str(err)


### PR DESCRIPTION
## Why

Five files of the Nigeria GHS-Panel Wave 5 release fail with `RuntimeError: Failed to parse .dta: rc=17`. They are Stata 13 format (117), which ReadStat decodes as Windows-1252, but their free-text "other, specify" columns hold UTF-8 (emoji whose bytes are undefined in CP1252). `read_dta` exposed no way around it, and svy dropped `encoding` with a warning.

## What

- `read_dta` / `read_stata_arrow` / `read_por` gain `encoding=` (iconv name, forwarded to `readstat_set_file_character_encoding`, as `read_sav` / `read_sas` already did).
- `encoding="utf8-lossy"` on every reader: decodes as UTF-8, replaces undecodable bytes with U+FFFD, reports it in `meta["had_invalid_utf8"]`. Implemented once in the shared parse context (ISO-8859-1 input as a byte-transparent channel, re-decoded in Rust). Matters most for SPSS/SAS, whose headers declare an encoding so a single stray byte previously failed the read with no escape.
- `had_invalid_utf8` now also covers variable/value labels, notes and the file label.
- Parse errors carry ReadStat's text for all formats (`… (invalid byte sequence) (rc=17)`), and rc=17 appends a hint naming the option. `svy.read_stata` forwards `encoding`; the `IoError` surfaces the hint.
- `cargo test` in the native crate links again: `extension-module` is now a crate feature enabled by maturin via `pyproject.toml` (same arrangement as svy-rs); stale SAS unit-test calls updated.

## Verification

- All five GHS files read with `encoding="utf-8"` (260 MB sect4b in 3 s), no lossy replacement needed.
- New `test_stata_encoding.py` / `test_spss_encoding.py` splice raw bytes into written files: CP1252 default for Stata 13, strict failure with hint, explicit encodings, lossy replacement with flag, format-118 default, bad codec name. SAS covered by a lossy round-trip of the shipped fixture with catalog.
- svy-io: 266 passed; `cargo test`: 8 passed; svy io tests: 9 passed.

Note: one assertion in `packages/svy/tests/svy/io/test_base.py` asserted the Stata engine drops `encoding`; it now asserts it is forwarded.
