### PR TITLE
ci: fix svy-io wheels workflow schema

### DIFF
--- a/.github/workflows/svy-io-wheels.yml
+++ b/.github/workflows/svy-io-wheels.yml
@@ -49,6 +49,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          submodules: false
       - name: Verify tag matches the committed version and CHANGELOG
         if: startsWith(github.ref, 'refs/tags/svy-io-v')
         run: >
@@ -56,8 +58,6 @@ jobs:
           --package svy-io
           --tag "${{ github.ref_name }}"
           --out /dev/null
-        with:
-          submodules: false
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:


### PR DESCRIPTION
The Verify-tag step inserted in #145 split checkout from its with: block, leaving a run step with with:. GitHub rejected the file and emitted an instant failed run on every push. Move the block back to checkout.