### PR TITLE
fix(regression): categorical prediction is coding-independent

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -29,6 +29,10 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Fixed
 
+- **`glm.predict()` and `glm.margins()` were wrong on an int, float or bool-coded `Cat`.** Both rebuilt a dummy column by slicing the level out of the coefficient *name* and comparing it to the raw column as a string, which numpy answers all-False without raising: every row got the reference-level prediction (off by up to 0.26 in probability on the test model) and every categorical average marginal effect came back exactly 0.0 with SE 0.0. The fitted coefficients were correct throughout, which is what kept it quiet. The design matrix is now rebuilt from the level values in their fitted dtype, through the same polars expression the fit used — and, as a side effect, in one pass instead of a Python loop over object arrays (predict on 1e6 rows: 0.72 s → 0.12 s; a 10-level categorical AME: 5.9 s → 0.8 s).
+
+- **Prediction data is validated.** A missing predictor column raises `ModelError` naming it (was a raw polars `ColumnNotFoundError` or a bare `KeyError`), and a categorical value the fit never saw — including a null — raises instead of being silently coded as the reference level, in `predict()` and in `margins(at=)` alike.
+
 - `categorical.tabulate()` ignored `Design.pop_size`: every table on a design with a finite-population correction reported the fpc-free standard errors (the `ttest` facade had the same gap). The fpc is now applied, matching R `svymean(~interaction(...))` and `svychisq` on an `fpc=` design.
 
 ### Changed

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -58,6 +58,17 @@ LinkArg = (
 _FAMILY_NAMES = "'gaussian', 'binomial', 'poisson', 'gamma', or 'inverse_gaussian'"
 
 
+def _dummy_expr(var: str, level: Any) -> pl.Expr:
+    """
+    The indicator expression for one level of a categorical column.
+
+    Used both when the fit engineers its dummies and when prediction rebuilds
+    them, so the two are consistent by construction whatever the column's
+    dtype.
+    """
+    return (pl.col(var) == pl.lit(level)).cast(pl.Float64)
+
+
 def _normalize_family(family: FamilyArg) -> str:
     """
     Normalize user-facing family string to canonical lowercase form.
@@ -451,17 +462,21 @@ class GLM:
                 ref_val = feat.ref if feat.ref is not None else levels[0]
                 levels = [ref_val] + [v for v in levels if v != ref_val]
 
+                # `dummies` pairs each engineered column with the level value
+                # in its native dtype, so prediction rebuilds the column with
+                # the same expression the fit used instead of parsing the
+                # level back out of the column name as a string.
+                dummies = [(f"{feat.name}_{level}", level) for level in levels[1:]]
                 term_info[feat.name] = {
                     "type": "categorical",
                     "levels": levels,
                     "ref": ref_val,
+                    "dummies": dummies,
                 }
 
                 exprs, names = [], []
-                for level in levels[1:]:
-                    name = f"{feat.name}_{level}"
-                    expr = (pl.col(feat.name) == level).cast(pl.Float64).alias(name)
-                    exprs.append(expr)
+                for name, level in dummies:
+                    exprs.append(_dummy_expr(feat.name, level).alias(name))
                     names.append(name)
                 return exprs, names
 
@@ -854,105 +869,142 @@ class GLM:
                 cols.extend(self._collect_feature_cols([feat.left, feat.right]))
         return cols
 
+    def _term_expr(
+        self,
+        name: str,
+        term_info: dict,
+        dummy_map: dict[str, tuple[str, Any]],
+        columns: set[str],
+        missing: set[str],
+    ) -> pl.Expr:
+        """The polars expression rebuilding one engineered feature column."""
+        if name == "_intercept_":
+            # pl.repeat, not pl.lit: an intercept-only model would otherwise
+            # select a single broadcast row instead of one per observation.
+            return pl.repeat(1.0, pl.len(), dtype=pl.Float64)
+
+        if ":" in name:
+            expr = None
+            for part in name.split(":"):
+                part_expr = self._term_expr(part, term_info, dummy_map, columns, missing)
+                expr = part_expr if expr is None else expr * part_expr
+            return cast(pl.Expr, expr)
+
+        dummy = dummy_map.get(name)
+        if dummy is not None:
+            var, level = dummy
+            if var not in columns:
+                missing.add(var)
+                return pl.repeat(0.0, pl.len(), dtype=pl.Float64)
+            return _dummy_expr(var, level)
+
+        if name not in columns:
+            missing.add(name)
+            return pl.repeat(0.0, pl.len(), dtype=pl.Float64)
+        return pl.col(name).cast(pl.Float64)
+
+    def _build_term_matrix(
+        self,
+        new_data: pl.DataFrame,
+        fit: GLMFit,
+        names: Sequence[str],
+    ) -> np.ndarray:
+        """
+        Build the n x len(names) matrix of engineered feature columns for
+        `new_data`, evaluating every term as one polars select.
+        """
+        term_info = fit.term_info or {}
+        dummy_map: dict[str, tuple[str, Any]] = {}
+        for var, info in term_info.items():
+            if info.get("type") != "categorical":
+                continue
+            for dummy_name, level in info.get("dummies") or []:
+                dummy_map[dummy_name] = (var, level)
+
+        columns = set(new_data.columns)
+        missing: set[str] = set()
+        exprs = [
+            self._term_expr(name, term_info, dummy_map, columns, missing).alias(f"__f{j}__")
+            for j, name in enumerate(names)
+        ]
+        if missing:
+            raise ModelError(
+                title="Column missing from prediction data",
+                detail=(
+                    "The model was fitted on columns that are absent from the "
+                    f"data given here: {sorted(missing)!r}."
+                ),
+                code="PRED_COLUMN_MISSING",
+                where="GLM.predict",
+                expected=sorted(missing),
+                got=sorted(columns),
+                hint="Provide every predictor the model was fitted on.",
+            )
+
+        self._validate_prediction_levels(new_data, term_info, dummy_map, names)
+
+        if not exprs:
+            return np.zeros((new_data.height, 0))
+        return new_data.select(exprs).to_numpy()
+
+    @staticmethod
+    def _validate_prediction_levels(
+        new_data: pl.DataFrame,
+        term_info: dict,
+        dummy_map: dict[str, tuple[str, Any]],
+        names: Sequence[str],
+    ) -> None:
+        """
+        Refuse levels the fit never saw (and nulls) in a categorical column.
+
+        Silently coding them as the reference level would change the meaning
+        of the prediction without saying so.
+        """
+        used: set[str] = set()
+        for name in names:
+            for part in name.split(":"):
+                dummy = dummy_map.get(part)
+                if dummy is not None:
+                    used.add(dummy[0])
+
+        for var in sorted(used):
+            levels = list((term_info.get(var) or {}).get("levels") or [])
+            col = new_data.get_column(var)
+            try:
+                wanted = pl.Series(var, levels, dtype=col.dtype)
+            except Exception:
+                # The column's dtype cannot even hold the fitted levels, so
+                # every value in it is unknown; report them rather than the
+                # polars construction error.
+                wanted = None
+            if wanted is not None:
+                unseen = pl.col(var).is_null() | ~pl.col(var).is_in(wanted.implode())
+                bad = new_data.filter(unseen).get_column(var).unique().sort().to_list()
+            else:
+                bad = [v for v in col.unique().to_list() if v not in levels]
+            if bad:
+                raise ModelError(
+                    title="Unknown level in prediction data",
+                    detail=(
+                        f"Column {var!r} holds {bad!r}, which the fit never saw. "
+                        "Coding them as the reference level would silently change "
+                        "the prediction."
+                    ),
+                    code="PRED_UNKNOWN_LEVEL",
+                    where="GLM.predict",
+                    param=var,
+                    got=bad,
+                    expected=levels,
+                    hint="Drop those rows, or refit with the level present.",
+                )
+
     def _build_prediction_matrix(
         self,
         new_data: pl.DataFrame,
         fit: GLMFit,
     ) -> np.ndarray:
         """Build design matrix for prediction."""
-        n = new_data.height
-        terms = [c.term for c in fit.coefs]
-        term_info = fit.term_info or {}
-        k = len(terms)
-
-        # Identify simple continuous columns that can be batch-extracted in one select
-        simple_cont = {
-            t
-            for t in terms
-            if t in new_data.columns
-            and ":" not in t
-            and t != "_intercept_"
-            and term_info.get(t, {}).get("type") == "continuous"
-        }
-
-        # Batch-extract continuous columns in a single Polars select
-        batch_mat: np.ndarray | None = None
-        batch_cols: list[str] = []
-        if simple_cont:
-            batch_cols = [t for t in terms if t in simple_cont]  # preserves order
-            batch_mat = new_data.select(
-                [pl.col(c).cast(pl.Float64) for c in batch_cols]
-            ).to_numpy()
-
-        batch_idx = {col: i for i, col in enumerate(batch_cols)}
-
-        X = np.zeros((n, k))
-        for j, term in enumerate(terms):
-            if term in batch_idx:
-                X[:, j] = batch_mat[:, batch_idx[term]]
-            else:
-                X[:, j] = self._resolve_pred_term(term, new_data, term_info)
-
-        return X
-
-    def _resolve_pred_term(
-        self,
-        term: str,
-        data: pl.DataFrame,
-        term_info: dict,
-    ) -> np.ndarray:
-        """Resolve a single term for prediction."""
-        n = data.height
-
-        if term == "_intercept_":
-            return np.ones(n)
-
-        if ":" in term:
-            parts = term.split(":")
-            result = np.ones(n)
-            for part in parts:
-                result = result * self._resolve_pred_term(part, data, term_info)
-            return result
-
-        for var_name, info in term_info.items():
-            if info.get("type") == "categorical":
-                prefix = f"{var_name}_"
-                if term.startswith(prefix):
-                    level = term[len(prefix) :]
-                    if level in info["levels"]:
-                        col = data.get_column(var_name)
-                        return self._compare_level(col, level)
-
-        if term in data.columns:
-            return data.get_column(term).cast(pl.Float64).to_numpy()
-
-        if "_" in term:
-            for i in range(len(term) - 1, 0, -1):
-                if term[i] == "_":
-                    var = term[:i]
-                    level = term[i + 1 :]
-                    if var in data.columns:
-                        col = data.get_column(var)
-                        return self._compare_level(col, level)
-
-        raise KeyError(f"Cannot resolve term '{term}'")
-
-    def _compare_level(self, col: pl.Series, level) -> np.ndarray:
-        """Compare column to level, handling type coercion."""
-        col_np = col.to_numpy()
-
-        try:
-            return (col_np == level).astype(np.float64)
-        except (TypeError, ValueError):
-            pass
-
-        try:
-            level_num = float(level) if "." in str(level) else int(level)
-            return (col_np == level_num).astype(np.float64)
-        except (TypeError, ValueError):
-            pass
-
-        return (col_np.astype(str) == str(level)).astype(np.float64)
+        return self._build_term_matrix(new_data, fit, [c.term for c in fit.coefs])
 
     def to_polars(self) -> pl.DataFrame:
         """Export fitted coefficients to a Polars DataFrame."""

--- a/packages/svy/src/svy/regression/margins.py
+++ b/packages/svy/src/svy/regression/margins.py
@@ -366,10 +366,23 @@ def _term_derivative_matrix(
     at their observed values). Terms not involving `var` have zero
     derivative.
     """
-    term_info = fit.term_info or {}
     terms = fit.feature_names
     n = data.height
     D = np.zeros((n, len(terms)))
+
+    # Every factor that survives the product rule, evaluated once.
+    needed = sorted(
+        {
+            part
+            for term in terms
+            if term != "_intercept_"
+            for parts in [term.split(":")]
+            if var in parts
+            for part in parts
+        }
+    )
+    factors = glm._build_term_matrix(data, fit, needed) if needed else np.zeros((n, 0))
+    factor_idx = {name: i for i, name in enumerate(needed)}
 
     for j, term in enumerate(terms):
         if term == "_intercept_":
@@ -384,7 +397,7 @@ def _term_derivative_matrix(
             for i, part in enumerate(parts):
                 if i == occ:
                     continue
-                prod = prod * glm._resolve_pred_term(part, data, term_info)
+                prod = prod * factors[:, factor_idx[part]]
             dcol += prod
         D[:, j] = dcol
 
@@ -432,7 +445,9 @@ def _categorical_contrast_ame(
     offset = offset_values(fit, data)
 
     def _counterfactual(level: object) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        cf = data.with_columns(pl.lit(level).alias(var))
+        # The counterfactual column keeps the fitted dtype, so the rebuilt
+        # dummies compare like for like whatever the Cat column is coded as.
+        cf = data.with_columns(pl.lit(level, dtype=data.schema[var]).alias(var))
         X = glm._build_prediction_matrix(cf, fit)
         eta = X @ beta_vec + offset
         return link_inverse(fit.link, eta), link_mu_eta(fit.link, eta), X
@@ -521,7 +536,15 @@ def compute_predictive_margins(
             X_cf = X_base.copy()
             X_cf[:, col_idx] = float(val)
         else:
-            cf_data = data.with_columns(pl.lit(val).alias(variable))
+            # A categorical `at` level must keep the column's fitted dtype so
+            # the rebuilt dummies match; a continuous one must not, or an
+            # integer column would truncate a fractional value.
+            lit_dtype = (
+                data.schema.get(variable)
+                if (fit.term_info or {}).get(variable, {}).get("type") == "categorical"
+                else None
+            )
+            cf_data = data.with_columns(pl.lit(val, dtype=lit_dtype).alias(variable))
             X_cf = glm._build_prediction_matrix(cf_data, fit)
 
         # Counterfactual rows are the fitted rows with one column overwritten,

--- a/packages/svy/tests/svy/regression/test_glm_cat_coding.py
+++ b/packages/svy/tests/svy/regression/test_glm_cat_coding.py
@@ -1,0 +1,225 @@
+# tests/svy/regression/test_glm_cat_coding.py
+"""
+A Cat predictor must give the same predictions and margins whatever dtype it
+is coded in.
+
+Prediction used to slice the level back out of the dummy's *name* as a string
+and compare it to the raw column, so an int/float/bool-coded Cat matched
+nothing: `predict()` silently returned the reference-level prediction for
+every row and every categorical AME came back exactly 0.0 with SE 0.0. The
+fitted coefficients were right the whole time, which is what made it quiet.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+from svy.core.sample import Design, Sample
+from svy.core.terms import Cat, Cross
+from svy.errors.model_errors import ModelError
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
+
+# Three-level codings of the same partition, in the same level order.
+CODINGS = {
+    "str": {"E": "0", "H": "1", "M": "2"},
+    "int": {"E": 0, "H": 1, "M": 2},
+    "float": {"E": 0.0, "H": 1.0, "M": 2.0},
+}
+
+# Two-level codings, for the Boolean case.
+CODINGS2 = {
+    "str": {False: "F", True: "T"},
+    "bool": {False: False, True: True},
+    "int": {False: 0, True: 1},
+}
+
+
+@pytest.fixture
+def api():
+    return pl.read_csv(DATA_DIR / "apistrat.csv").with_columns(
+        (pl.col("api00") > 600).cast(pl.Int32).alias("y")
+    )
+
+
+def _coded(api: pl.DataFrame, mapping: dict, source: pl.Expr) -> pl.DataFrame:
+    return api.with_columns(source.replace_strict(mapping).alias("g"))
+
+
+def _fit(df: pl.DataFrame, **kw):
+    return Sample(df, Design(wgt="pw")).glm.fit(
+        y="y", x=["ell", Cat("g")], family="binomial", tol=1e-12, **kw
+    )
+
+
+@pytest.fixture(params=sorted(CODINGS))
+def coded_pair(request, api):
+    """(reference string-coded fit+data, fit+data under the coding under test)."""
+    src = pl.col("stype")
+    ref_df = _coded(api, CODINGS["str"], src)
+    alt_df = _coded(api, CODINGS[request.param], src)
+    return (_fit(ref_df), ref_df), (_fit(alt_df), alt_df), request.param
+
+
+class TestCodingIndependence:
+    def test_coefficients_are_identical(self, coded_pair):
+        (ref, _), (alt, _), _ = coded_pair
+        np.testing.assert_allclose(
+            [c.est for c in alt.fitted.coefs],
+            [c.est for c in ref.fitted.coefs],
+            rtol=0,
+            atol=1e-12,
+        )
+
+    def test_predictions_are_identical(self, coded_pair):
+        (ref, ref_df), (alt, alt_df), _ = coded_pair
+        p_ref = ref.predict(ref_df)
+        p_alt = alt.predict(alt_df)
+
+        np.testing.assert_allclose(p_alt.yhat, p_ref.yhat, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(p_alt.se, p_ref.se, rtol=0, atol=1e-12)
+
+    def test_predictions_actually_vary_by_level(self, coded_pair):
+        """The old path returned the reference prediction for every row."""
+        (_, _), (alt, alt_df), _ = coded_pair
+        yhat = alt.predict(alt_df).yhat
+
+        assert len(np.unique(np.round(yhat, 12))) > 1
+
+    def test_categorical_ame_is_identical(self, coded_pair):
+        (ref, _), (alt, _), _ = coded_pair
+        m_ref = next(m for m in ref.margins() if m.term == "g")
+        m_alt = next(m for m in alt.margins() if m.term == "g")
+
+        np.testing.assert_allclose(m_alt.margin, m_ref.margin, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(m_alt.se, m_ref.se, rtol=0, atol=1e-12)
+
+    def test_categorical_ame_is_not_degenerate(self, coded_pair):
+        """Every non-string coding used to give AME 0.0 with SE 0.0."""
+        (_, _), (alt, _), _ = coded_pair
+        m = next(mm for mm in alt.margins() if mm.term == "g")
+
+        assert np.all(np.abs(m.margin) > 1e-6)
+        assert np.all(m.se > 1e-6)
+
+    def test_continuous_ame_is_identical(self, coded_pair):
+        (ref, _), (alt, _), _ = coded_pair
+        m_ref = next(m for m in ref.margins() if m.term == "ell")
+        m_alt = next(m for m in alt.margins() if m.term == "ell")
+
+        np.testing.assert_allclose(m_alt.margin, m_ref.margin, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(m_alt.se, m_ref.se, rtol=0, atol=1e-12)
+
+    def test_predictive_margins_at_a_level_are_identical(self, coded_pair):
+        (ref, _), (alt, _), coding = coded_pair
+        m_ref = ref.margins(at={"g": list(CODINGS["str"].values())})
+        m_alt = alt.margins(at={"g": list(CODINGS[coding].values())})
+
+        np.testing.assert_allclose(m_alt.margin, m_ref.margin, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(m_alt.se, m_ref.se, rtol=0, atol=1e-12)
+
+
+class TestBooleanCoding:
+    """A Boolean Cat column, against the same two-level partition as strings."""
+
+    @pytest.fixture(params=sorted(CODINGS2))
+    def pair(self, request, api):
+        src = pl.col("stype") == "E"
+        ref_df = _coded(api, CODINGS2["str"], src)
+        alt_df = _coded(api, CODINGS2[request.param], src)
+        return (_fit(ref_df), ref_df), (_fit(alt_df), alt_df)
+
+    def test_predictions_and_margins_match_the_string_coding(self, pair):
+        (ref, ref_df), (alt, alt_df) = pair
+
+        np.testing.assert_allclose(
+            alt.predict(alt_df).yhat, ref.predict(ref_df).yhat, rtol=0, atol=1e-12
+        )
+        m_ref = next(m for m in ref.margins() if m.term == "g")
+        m_alt = next(m for m in alt.margins() if m.term == "g")
+        np.testing.assert_allclose(m_alt.margin, m_ref.margin, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(m_alt.se, m_ref.se, rtol=0, atol=1e-12)
+
+
+class TestInteractionCoding:
+    """The same, through an interaction, where the dummy is one factor."""
+
+    @pytest.fixture(params=sorted(CODINGS))
+    def pair(self, request, api):
+        src = pl.col("stype")
+        ref_df = _coded(api, CODINGS["str"], src)
+        alt_df = _coded(api, CODINGS[request.param], src)
+
+        def fit(df):
+            return Sample(df, Design(wgt="pw")).glm.fit(
+                y="y",
+                x=[Cat("g"), "ell", Cross(Cat("g"), "ell")],
+                family="binomial",
+                tol=1e-12,
+            )
+
+        return (fit(ref_df), ref_df), (fit(alt_df), alt_df)
+
+    def test_predictions_match(self, pair):
+        (ref, ref_df), (alt, alt_df) = pair
+        np.testing.assert_allclose(
+            alt.predict(alt_df).yhat, ref.predict(ref_df).yhat, rtol=0, atol=1e-12
+        )
+
+    def test_continuous_ame_through_the_interaction_matches(self, pair):
+        (ref, _), (alt, _) = pair
+        m_ref = next(m for m in ref.margins() if m.term == "ell")
+        m_alt = next(m for m in alt.margins() if m.term == "ell")
+
+        np.testing.assert_allclose(m_alt.margin, m_ref.margin, rtol=0, atol=1e-12)
+        np.testing.assert_allclose(m_alt.se, m_ref.se, rtol=0, atol=1e-12)
+
+
+class TestPredictionDataValidation:
+    """Levels the fit never saw are refused, not coded as the reference."""
+
+    @pytest.fixture
+    def model(self, api):
+        return _fit(_coded(api, CODINGS["int"], pl.col("stype")))
+
+    def test_unseen_level_raises(self, model, api):
+        new_data = _coded(api.head(5), CODINGS["int"], pl.col("stype")).with_columns(
+            pl.lit(9, dtype=pl.Int64).alias("g")
+        )
+
+        with pytest.raises(ModelError, match="never saw"):
+            model.predict(new_data)
+
+    def test_null_level_raises(self, model, api):
+        new_data = _coded(api.head(5), CODINGS["int"], pl.col("stype")).with_columns(
+            pl.lit(None, dtype=pl.Int64).alias("g")
+        )
+
+        with pytest.raises(ModelError, match="never saw"):
+            model.predict(new_data)
+
+    def test_missing_categorical_column_names_it(self, model, api):
+        new_data = _coded(api.head(5), CODINGS["int"], pl.col("stype")).drop("g")
+
+        with pytest.raises(ModelError, match="'g'"):
+            model.predict(new_data)
+
+    def test_missing_continuous_column_names_it(self, model, api):
+        new_data = _coded(api.head(5), CODINGS["int"], pl.col("stype")).drop("ell")
+
+        with pytest.raises(ModelError, match="'ell'"):
+            model.predict(new_data)
+
+    def test_margins_at_an_unseen_level_raises(self, model):
+        with pytest.raises(ModelError, match="never saw"):
+            model.margins(at={"g": [9]})
+
+    def test_wrong_dtype_is_reported_as_unknown_levels(self, model, api):
+        """String '0'/'1'/'2' against an int-coded fit is a level error."""
+        new_data = _coded(api.head(5), CODINGS["str"], pl.col("stype"))
+
+        with pytest.raises(ModelError, match="never saw"):
+            model.predict(new_data)

--- a/packages/svy/tests/svy/regression/test_glm_predict.py
+++ b/packages/svy/tests/svy/regression/test_glm_predict.py
@@ -12,6 +12,7 @@ import pytest
 from svy.core.enumerations import DistFamily
 from svy.core.sample import Design, Sample
 from svy.core.terms import Cat
+from svy.errors.model_errors import ModelError
 
 
 DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
@@ -740,5 +741,5 @@ class TestGLMPredictEdgeCases:
 
         bad_data = api_strat.head(5).drop("meals")
 
-        with pytest.raises(KeyError):
+        with pytest.raises(ModelError, match="meals"):
             model.predict(bad_data)


### PR DESCRIPTION
`predict()` and `margins()` rebuilt a `Cat` dummy by slicing the level out of the coefficient *name* and comparing it to the raw column as a string. numpy answers that all-False without raising, so an int/float/bool-coded `Cat` gave every row the reference-level prediction (off by up to 0.26 in probability on the test model) and every categorical AME exactly 0.0 with SE 0.0 — while the coefficients stayed correct, which is what kept it quiet.

## Changes

- Fit time records `dummies: [(col_name, level)]` in `term_info`, levels in their native dtype.
- `_build_prediction_matrix` is one polars select, each term an expression built by the same `_dummy_expr` helper the fit uses, so the two are consistent by construction. `_resolve_pred_term`, `_compare_level` and the right-to-left underscore guess are gone.
- Prediction data is validated: a missing column raises `ModelError` naming it (was a raw polars `ColumnNotFoundError` or a bare `KeyError`); a `Cat` value the fit never saw, including a null, raises instead of being silently coded as the reference level — in `predict()` and `margins(at=)` alike.
- Counterfactual columns in `margins` keep the fitted dtype; the derivative matrix evaluates each distinct factor once through the new builder.

## Performance

| case | before | after |
|---|---|---|
| predict, 1e6 rows | 0.72 s | 0.12 s |
| categorical AME, 10 levels | 5.9 s | 0.79 s |

## Tests

New `test_glm_cat_coding.py`: 36 tests over str/int/float/bool codings of the same partition — plain, Boolean, and through an interaction — asserting identical coefficients, predictions, SEs and margins to 1e-12, plus the four validation errors. Existing R-parity numbers are unchanged (string-coded).

`test_predict_missing_column_raises` now expects `ModelError` instead of `KeyError`.

Full suite: 3562 passed, 1 skipped.