### PR TITLE
perf(svy-rs): blocked GLM normal equations, and refuse the fits that were nonsense

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,7 +6,33 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 ### Added
 
+- `converged` on `GlmResult`, and `where_col` on `fit_glm_rs`: a Boolean column marking a subpopulation, fitted as one domain. A `where=` clause used to be routed through `fit_glm_by` on a "true"/"false" string column, which fitted the complement as well and threw it away.
+
 - `domain_col` on `tabulate_rs`: a Boolean column marking the rows of a subpopulation. Out-of-domain rows keep their design columns and get weight 0 (R's `subset()` on a design), so the PSU structure is intact and `degrees_of_freedom` counts the units with an in-domain row; cells are formed from in-domain keys only (a null key outside the domain is not missing), and the Rao-Scott `n`, strata and PSU counts are taken over in-domain rows. `estimate_proportions`, `estimate_totals` and `count_strata_psus` gain the matching `domain` parameter.
+
+### Changed
+
+- **The IRLS normal equations are a blocked cross-product** (`build_irls_normal_eqs`). The row-outer Kahan loop became columns-outer over 256-row blocks of the column-major X, so the inner loop is a contiguous dot product that vectorizes, with `w * X_a` formed once per (block, column) instead of once per (block, column pair). Blocks are grouped into fixed 8192-row parallel chunks and summed in index order, so the result is independent of the core count and of how rayon schedules the work. Kahan compensation is gone — R's `crossprod` is plain summation, and blocked f64 is ~1e-14 relative at 1e6 rows.
+
+- **The sandwich meat no longer materialises PSU totals when there is no PSU.** Every row is then its own PSU, so `sum_i (t_i - tbar)(t_i - tbar)'` telescopes to one weighted cross-product over all rows plus a k-vector per stratum — in place of a million heap `Vec<Kahan>` behind a million-entry `HashMap`, walked k² times. With real PSUs the totals are one flat `m x k` buffer addressed through a dense slot table keyed on the PSU code, rather than a per-stratum hash map of per-PSU vectors.
+
+- **Strata and PSU codes reuse the estimation namespace's factorizers** (`design_col_codes` / `design_pair_codes`, now `pub(crate)`). The Python layer already hands the kernel dense integer code columns with the PSU code encoding the (stratum, psu) pair; the GLM kernel was casting them back to String and hashing a `(&str, &str)` per row, ~0.4 s at 1e6 rows.
+
+- The redundant eta/mu passes are gone: the loop's own recomputation at `beta_new` already leaves them at the committed beta, so neither the top of the next iteration nor the post-loop bread rebuild needs to redo them. That recomputation is now column-outer, one contiguous pass over X per term. `cols_to_vec` replaces `cols_to_mat` and copies each chunk's value slice wholesale instead of iterating `Option<f64>` per element.
+
+  GLM, 1e6 rows x 20 covariates, binomial logit, release build: strata+PSU 1.60 s → 0.52 s, weights-only 5.36 s → 0.43 s, `where=` domain 1.22 s → 0.45 s.
+
+### Fixed
+
+- **`fit_glm_rs` returned a zero fit as a success** when nothing could contribute — an empty `where` domain, or an all-zero weight column. The normal equations are then the zero matrix, whose SVD pseudoinverse is also zero, and `beta = 0` passed the finite check. The kernel now counts the contributing rows up front and errors when there are no more of them than parameters.
+
+- **An aliased design matrix "fitted"**: `x` and `2 * x` returned SE 0 or NaN and an F statistic around 1e30, and k >= n came back through a pseudoinverse. A pivot-free Cholesky of the first information matrix, in the model's own column order, now names the collinear column and errors. Same "the columns that came first are kept" rule as R, but raising rather than reporting NA coefficients.
+
+- **Non-finite inputs are rejected.** Nulls were, NaN/Inf were not, and Rust's `f64::max` returns the other operand for a NaN, so `.max(1e-12)` on the variance hid one all the way to a NaN beta. y, X and the offset are checked over the contributing rows, which leaves padded zero-weight rows alone.
+
+- `invert_matrix` reached `thin_svd().unwrap()` — a panic, not an error — on a non-finite information matrix. It returns a `PolarsResult` now, like the solver beside it.
+
+- `fit_glm_by` dropped a level that failed to fit, so a caller asking for every level got a short list with no way to tell which one was missing or why. It now names the failed levels and reports the first error.
 
 ## [0.16.0] — 2026-08-30
 

--- a/packages/svy-rs/src/estimation/taylor.rs
+++ b/packages/svy-rs/src/estimation/taylor.rs
@@ -974,7 +974,7 @@ fn densify_int_codes(col: &Column) -> PolarsResult<(Vec<u32>, u32)> {
 /// treated as pre-factorized codes and densified. This is the fallback-safe
 /// polymorphic entry — the String path keeps svy-rs's public API working for
 /// direct callers, the integer path is the Phase C fast path.
-fn design_col_codes(col: &Column) -> PolarsResult<(Vec<u32>, u32)> {
+pub(crate) fn design_col_codes(col: &Column) -> PolarsResult<(Vec<u32>, u32)> {
     let dt = col.dtype();
     if matches!(dt, DataType::String) {
         Ok(index_categorical(col.str()?))
@@ -994,7 +994,7 @@ fn design_col_codes(col: &Column) -> PolarsResult<(Vec<u32>, u32)> {
 /// columns the PSU code is assumed already pair-nested by the Python layer
 /// (`__svy_psu_code__` encodes the (stratum, psu) pair), so it is densified
 /// directly — matching the string pair's first-appearance order.
-fn design_pair_codes(strata: &Column, psu: &Column) -> PolarsResult<(Vec<u32>, u32)> {
+pub(crate) fn design_pair_codes(strata: &Column, psu: &Column) -> PolarsResult<(Vec<u32>, u32)> {
     let dt = psu.dtype();
     if matches!(dt, DataType::String) {
         Ok(index_categorical_pair(strata.str()?, psu.str()?))

--- a/packages/svy-rs/src/regression/api.rs
+++ b/packages/svy-rs/src/regression/api.rs
@@ -3,17 +3,17 @@
 // PyO3-facing wrapper for the GLM regression function.
 // The actual fitting logic lives in regression/glm.rs.
 //
-// Return shape: Vec<(level, params, cov_params, scale, df_resid, deviance,
-//                    null_deviance, iterations, n_obs)>.
-// When by_col is None, a single-element vec with level="" is returned, so the
-// Python side can treat both cases uniformly.
+// Return shape: Vec<(level, params, cov_params, naive_cov, scale, df_resid,
+//                    deviance, null_deviance, iterations, n_obs, converged)>.
+// When neither by_col nor where_col is given, a single-element vec with
+// level="" is returned, so the Python side can treat every case uniformly.
 
 use polars::prelude::*;
 use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 
 use crate::estimation::calib_sweep::{CalibSpec, CalibSweep, build_calib_sweep};
-use crate::regression::glm::{fit_glm, fit_glm_by};
+use crate::regression::glm::{fit_glm, fit_glm_by, fit_glm_where};
 
 type GlmTuple = (
     String,
@@ -26,6 +26,7 @@ type GlmTuple = (
     f64,
     u32,
     usize,
+    bool,
 );
 
 fn column_to_series(df: &DataFrame, name: &str) -> PyResult<Series> {
@@ -51,6 +52,7 @@ fn optional_column_to_series(df: &DataFrame, name: &Option<String>) -> PyResult<
     fpc_name=None,
     offset_name=None,
     by_col=None,
+    where_col=None,
     family="gaussian".to_string(),
     link="identity".to_string(),
     tol=1e-8,
@@ -73,6 +75,7 @@ pub fn fit_glm_rs(
     fpc_name: Option<String>,
     offset_name: Option<String>,
     by_col: Option<String>,
+    where_col: Option<String>,
     family: String,
     link: String,
     tol: f64,
@@ -119,6 +122,46 @@ pub fn fit_glm_rs(
     });
     let calib = calib.as_ref();
 
+    // A `where=` domain is one fit. It used to be routed through `fit_glm_by`
+    // on a "true"/"false" string column, which fitted the complement as well
+    // and discarded it.
+    if let Some(name) = where_col {
+        let mask = column_to_series(&df, &name)?;
+        let result = _py
+            .detach(|| {
+                fit_glm_where(
+                    &y,
+                    x_cols,
+                    &weights,
+                    stratum.as_ref(),
+                    psu.as_ref(),
+                    fpc.as_ref(),
+                    offset.as_ref(),
+                    &mask,
+                    &family,
+                    &link,
+                    tol,
+                    max_iter,
+                    calib,
+                )
+            })
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))?;
+
+        return Ok(vec![(
+            String::new(),
+            result.params,
+            result.cov_params,
+            result.naive_cov,
+            result.scale,
+            result.df_resid,
+            result.deviance,
+            result.null_deviance,
+            result.iterations,
+            result.n_obs,
+            result.converged,
+        )]);
+    }
+
     // No by_col: single fit, wrap in one-element vec for API uniformity.
     if by_col.is_none() {
         // Release the GIL for the (iterative, CPU-bound) IRLS solve.
@@ -152,6 +195,7 @@ pub fn fit_glm_rs(
             result.null_deviance,
             result.iterations,
             result.n_obs,
+            result.converged,
         )]);
     }
 
@@ -193,6 +237,7 @@ pub fn fit_glm_rs(
                 r.null_deviance,
                 r.iterations,
                 r.n_obs,
+                r.converged,
             )
         })
         .collect())

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -26,8 +26,8 @@ use polars::prelude::*;
 
 use crate::categorical::ranktest::probit;
 use crate::estimation::calib_sweep::CalibSweep;
+use crate::estimation::taylor::{design_col_codes, design_pair_codes};
 use rayon::prelude::*;
-use std::collections::HashMap;
 
 // ============================================================================
 // Enums & Config
@@ -290,151 +290,205 @@ impl Kahan {
 // Helpers
 // ============================================================================
 
-fn cols_to_mat(cols: &[&Float64Chunked], nrows: usize) -> Mat<f64> {
-    let ncols = cols.len();
-    let mut mat = Mat::<f64>::zeros(nrows, ncols);
+/// Materialise columns into one column-major `nrows * ncols` buffer.
+///
+/// Nulls are rejected upstream in `fit_glm_domain`, so each chunk's value
+/// slice is dense and copies wholesale.
+fn cols_to_vec(cols: &[&Float64Chunked], nrows: usize) -> Vec<f64> {
+    let mut out = vec![0.0; nrows * cols.len()];
     for (j, col) in cols.iter().enumerate() {
-        // Null-aware iteration: `into_no_null_iter` would silently compact
-        // rows past a null, misaligning y/X/w. Nulls are rejected upstream in
-        // fit_glm_domain; any that slip through become 0.0 at the right row.
-        for (i, val) in col.iter().enumerate() {
-            mat[(i, j)] = val.unwrap_or(0.0);
+        let dst = &mut out[j * nrows..(j + 1) * nrows];
+        let mut off = 0usize;
+        for arr in col.downcast_iter() {
+            let vals = arr.values().as_slice();
+            let end = (off + vals.len()).min(nrows);
+            dst[off..end].copy_from_slice(&vals[..end - off]);
+            off = end;
         }
     }
-    mat
+    out
 }
 
-/// Robust group indexing for String/Categorical/Enum/anything-castable-to-string.
-fn index_groups(series: &Series) -> PolarsResult<(Vec<usize>, usize)> {
-    let mut map: HashMap<String, usize> = HashMap::new();
-    let mut indices = Vec::with_capacity(series.len());
-    let mut next_idx = 0;
-
-    match series.dtype() {
-        DataType::String => {
-            let ca = series.str()?;
-            for opt_s in ca.iter() {
-                let s = opt_s.unwrap_or("__NULL__");
-                let idx = *map.entry(s.to_string()).or_insert_with(|| {
-                    let i = next_idx;
-                    next_idx += 1;
-                    i
-                });
-                indices.push(idx);
-            }
+/// Dense 0-based design codes for `strata` (and, when given, PSUs nested
+/// within them), reusing the estimation namespace's factorizers: the Python
+/// layer already hands the kernel integer code columns, and hashing those is
+/// ~10x cheaper than casting to String and hashing `(&str, &str)` per row.
+///
+/// Nulls arrive as `u32::MAX`; they are collected into one extra level so the
+/// code can index a `Vec` directly.
+fn design_codes(
+    strata: Option<&Series>,
+    psu: Option<&Series>,
+    n: usize,
+) -> PolarsResult<(Vec<usize>, usize)> {
+    let (raw, n_levels) = match (strata, psu) {
+        (Some(s), Some(p)) => {
+            design_pair_codes(&s.clone().into_column(), &p.clone().into_column())?
         }
-        DataType::Categorical(_, _) | DataType::Enum(_, _) => {
-            let physical = series.to_physical_repr();
-            let ca = physical.u32()?;
-            let mut phys_map: HashMap<u32, usize> = HashMap::new();
+        (None, Some(p)) => design_col_codes(&p.clone().into_column())?,
+        (Some(s), None) => design_col_codes(&s.clone().into_column())?,
+        (None, None) => return Ok(((0..n).collect(), n)),
+    };
 
-            for opt_v in ca.iter() {
-                let v = opt_v.unwrap_or(u32::MAX);
-                let idx = *phys_map.entry(v).or_insert_with(|| {
-                    let i = next_idx;
-                    next_idx += 1;
-                    i
-                });
-                indices.push(idx);
-            }
-        }
-        _ => {
-            let s_str = series.cast(&DataType::String)?;
-            return index_groups(&s_str);
+    let mut total = n_levels as usize;
+    let mut null_slot: Option<usize> = None;
+    let mut out = Vec::with_capacity(raw.len());
+    for &c in &raw {
+        if c == u32::MAX {
+            let slot = *null_slot.get_or_insert_with(|| {
+                let t = total;
+                total += 1;
+                t
+            });
+            out.push(slot);
+        } else {
+            out.push(c as usize);
         }
     }
-
-    Ok((indices, next_idx))
+    Ok((out, total))
 }
 
-/// Build XtWX and XtWz deterministically from current eta/mu (IRLS step),
-/// mirroring fisherinf: t(D) %*% (w * D / V), D = X * d, d = dmu/deta
+/// Rows per cache block in the cross-product accumulations. The X block of a
+/// 256-row window is k*2 KB, which stays in L1/L2 for every realistic k.
+const XP_BLOCK: usize = 256;
+
+/// Rows per parallel chunk. Fixed rather than derived from the thread count,
+/// so the summation order — and therefore the result — is identical on every
+/// machine and at every core count.
+const XP_CHUNK: usize = 8192;
+
+/// `out[a*k + b] += sum_i w[i] * cols[a*n + i] * cols[b*n + i]`, upper
+/// triangle only, over the rows `[0, n)` of a column-major `cols`.
+///
+/// Columns-outer with the row block innermost: the inner loop is a contiguous
+/// dot product the compiler can vectorize, and `w * cols[a]` is formed once
+/// per (block, a) instead of once per (block, a, b). Blocks are summed in
+/// index order within a chunk and chunks in index order, so the result does
+/// not depend on how rayon schedules them.
+fn accumulate_weighted_crossprod(cols: &[f64], w: &[f64], n: usize, k: usize, out: &mut [f64]) {
+    let chunk_of = |lo: usize, hi: usize| -> Vec<f64> {
+        let mut acc = vec![0.0f64; k * k];
+        let mut wx = [0.0f64; XP_BLOCK];
+        let mut b = lo;
+        while b < hi {
+            let e = (b + XP_BLOCK).min(hi);
+            let len = e - b;
+            let wb = &w[b..e];
+            for a in 0..k {
+                let xa = &cols[a * n + b..a * n + e];
+                let wxa = &mut wx[..len];
+                for t in 0..len {
+                    wxa[t] = wb[t] * xa[t];
+                }
+                for c in a..k {
+                    let xc = &cols[c * n + b..c * n + e];
+                    let mut s = 0.0f64;
+                    for t in 0..len {
+                        s += wxa[t] * xc[t];
+                    }
+                    acc[a * k + c] += s;
+                }
+            }
+            b = e;
+        }
+        acc
+    };
+
+    if n <= XP_CHUNK {
+        let acc = chunk_of(0, n);
+        for t in 0..k * k {
+            out[t] += acc[t];
+        }
+        return;
+    }
+
+    let n_chunks = n.div_ceil(XP_CHUNK);
+    let partials: Vec<Vec<f64>> = (0..n_chunks)
+        .into_par_iter()
+        .map(|c| chunk_of(c * XP_CHUNK, ((c + 1) * XP_CHUNK).min(n)))
+        .collect();
+    for acc in &partials {
+        for t in 0..k * k {
+            out[t] += acc[t];
+        }
+    }
+}
+
+/// Build XtWX and XtWz from the current eta/mu (one IRLS step), mirroring
+/// fisherinf: t(D) %*% (w * D / V), D = X * d, d = dmu/deta.
 ///
 /// When `domain_mask` is `Some`, rows where mask[i] is false contribute 0 to
-/// both XtWX and XtWz (and have w_irls[i] set to 0). When `None`, every row
-/// contributes (original behavior).
+/// both XtWX and XtWz (and have `w_irls[i]` set to 0). When `None`, every row
+/// contributes.
+///
+/// Summation is plain blocked f64, as R's `crossprod` is; Kahan compensation
+/// bought ~1e-16 on a quantity the sandwich is insensitive to and cost the
+/// vectorization of the whole accumulation.
 fn build_irls_normal_eqs(
     family: Family,
     link: Link,
     n: usize,
     k: usize,
-    Y: &Mat<f64>,
-    X: &Mat<f64>,
+    y_vals: &[f64],
+    x: &[f64],
     w_samp: &[f64],
     eta: &[f64],
     mu: &[f64],
     offset: &[f64],
     domain_mask: Option<&[bool]>,
-    Z: &mut Mat<f64>,
+    z: &mut [f64],
     w_irls: &mut [f64],
     XtWX: &mut Mat<f64>,
     XtWz: &mut Mat<f64>,
 ) {
-    // Kahan accumulators
-    let mut acc_wz = vec![Kahan::new(); k];
-    let mut acc_wx = vec![Kahan::new(); k * k];
-
+    // Pass 1 — per-row IRLS weight and working response. O(n), no k factor.
     for i in 0..n {
-        let in_domain = domain_mask.map_or(true, |m| m[i]);
+        let in_domain = domain_mask.is_none_or(|m| m[i]);
         let w_i = w_samp[i];
-
         if !in_domain || w_i <= 0.0 {
             w_irls[i] = 0.0;
-            Z[(i, 0)] = 0.0;
+            z[i] = 0.0;
             continue;
         }
 
-        let y_i = Y[(i, 0)];
         let mu_i = mu[i];
-
         let v = family.variance(mu_i).max(1e-12);
         let d = link.mu_eta(mu_i, eta[i]); // dμ/dη
-
-        // IRLS weight: w * (d^2 / V)
         let wi = w_i * (d * d) / v;
-        w_irls[i] = wi;
 
         let safe_d = if d.abs() < 1e-12 { 1e-12 } else { d };
         // Working response on the X-only scale: the offset is a known part of
         // eta with no parameter, so it comes out here and goes back in wherever
         // eta is rebuilt (R's glm.fit: z <- (eta - offset) + (y - mu)/mu.eta).
-        let z_i = (eta[i] - offset[i]) + (y_i - mu_i) / safe_d;
-        Z[(i, 0)] = z_i;
-
-        if wi.abs() < 1e-18 {
-            continue;
-        }
-
-        for r in 0..k {
-            let x_ir = X[(i, r)];
-            acc_wz[r].add(wi * x_ir * z_i);
-
-            for c in r..k {
-                let x_ic = X[(i, c)];
-                acc_wx[r * k + c].add(wi * x_ir * x_ic);
-            }
-        }
+        z[i] = (eta[i] - offset[i]) + (y_vals[i] - mu_i) / safe_d;
+        w_irls[i] = if wi < 1e-18 { 0.0 } else { wi };
     }
 
-    // XtWz
+    // Pass 2 — XtWX (blocked, columns-outer) and XtWz.
+    let mut acc_wx = vec![0.0f64; k * k];
+    accumulate_weighted_crossprod(x, w_irls, n, k, &mut acc_wx);
+
     for r in 0..k {
-        XtWz[(r, 0)] = acc_wz[r].value();
+        let xr = &x[r * n..(r + 1) * n];
+        let mut total = 0.0f64;
+        let mut b = 0usize;
+        while b < n {
+            let e = (b + XP_BLOCK).min(n);
+            let mut s = 0.0f64;
+            for t in b..e {
+                s += w_irls[t] * xr[t] * z[t];
+            }
+            total += s;
+            b = e;
+        }
+        XtWz[(r, 0)] = total;
     }
 
-    // XtWX symmetric
     for r in 0..k {
         for c in r..k {
-            let v = acc_wx[r * k + c].value();
+            let v = acc_wx[r * k + c];
             XtWX[(r, c)] = v;
             XtWX[(c, r)] = v;
-        }
-    }
-
-    // force symmetry (numerical)
-    for r in 0..k {
-        for c in 0..k {
-            let v = 0.5 * (XtWX[(r, c)] + XtWX[(c, r)]);
-            XtWX[(r, c)] = v;
         }
     }
 }
@@ -477,12 +531,73 @@ fn solve_linear_system(A: MatRef<'_, f64>, b: MatRef<'_, f64>) -> Mat<f64> {
     x2
 }
 
+/// Refuse an aliased design matrix.
+///
+/// A pivot-free Cholesky of XtWX in the model's own column order: column j is
+/// aliased when the variance it still has after projecting out the columns
+/// before it is a vanishing fraction of its own. That is R's "first columns
+/// win" rule, but raising instead of reporting NA coefficients — consistent
+/// with the rest of svy, and better than today's alternative, a fit that
+/// "succeeds" with SE 0 or NaN and an F statistic around 1e30.
+fn check_rank(XtWX: &Mat<f64>, k: usize, cols: &[Series]) -> PolarsResult<()> {
+    // An exactly aliased column leaves ~1e-16 of its own norm; a genuinely
+    // collinear-but-distinct one (R^2 = 0.999999) leaves 1e-6. This separates
+    // them by five orders of magnitude either way.
+    const ALIAS_TOL: f64 = 1e-11;
+
+    let mut l = vec![0.0f64; k * k]; // column-major lower factor
+    let mut aliased: Vec<usize> = Vec::new();
+
+    for j in 0..k {
+        let mut d = XtWX[(j, j)];
+        for p in 0..j {
+            d -= l[p * k + j] * l[p * k + j];
+        }
+        // Negated so a NaN diagonal is aliased rather than accepted.
+        if !(d > ALIAS_TOL * XtWX[(j, j)]) {
+            // Its factor column stays zero, so the columns after it are
+            // measured against the ones that were actually kept.
+            aliased.push(j);
+            continue;
+        }
+        let ljj = d.sqrt();
+        l[j * k + j] = ljj;
+        for i in (j + 1)..k {
+            let mut v = XtWX[(i, j)];
+            for p in 0..j {
+                v -= l[p * k + i] * l[p * k + j];
+            }
+            l[j * k + i] = v / ljj;
+        }
+    }
+
+    if aliased.is_empty() {
+        return Ok(());
+    }
+
+    let listed: Vec<String> = aliased
+        .iter()
+        .map(|&j| format!("'{}'", cols[j].name()))
+        .collect();
+    Err(PolarsError::ComputeError(
+        format!(
+            "GLM design matrix is rank deficient: {} is collinear with the columns \
+             before it. Drop it, or one of the columns it duplicates.",
+            listed.join(", ")
+        )
+        .into(),
+    ))
+}
+
 /// Compute A^{-1} via solving A X = I with same solve strategy.
-fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> Mat<f64> {
+///
+/// Returns an error rather than panicking when even the SVD fails: a single
+/// non-finite entry in the information matrix used to reach `thin_svd().unwrap()`.
+fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> PolarsResult<Mat<f64>> {
     if let Ok(chol) = A.llt(Side::Lower) {
         let mut inv = Mat::<f64>::identity(k, k);
         chol.solve_in_place(inv.as_mut());
-        return inv;
+        return Ok(inv);
     }
 
     let lblt = A.lblt(Side::Lower);
@@ -500,16 +615,23 @@ fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> Mat<f64> {
                 for rr in 0..k {
                     for cc in 0..k {
                         if !inv2[(rr, cc)].is_finite() {
-                            return A.thin_svd().unwrap().pseudoinverse();
+                            return match A.thin_svd() {
+                                Ok(svd) => Ok(svd.pseudoinverse()),
+                                Err(_) => Err(PolarsError::ComputeError(
+                                    "GLM information matrix could not be inverted \
+                                     (degenerate or non-finite fit)"
+                                        .into(),
+                                )),
+                            };
                         }
                     }
                 }
-                return inv2;
+                return Ok(inv2);
             }
         }
     }
 
-    inv
+    Ok(inv)
 }
 
 // ============================================================================
@@ -530,6 +652,8 @@ pub struct GlmResult {
     pub null_deviance: f64,
     pub iterations: u32,
     pub n_obs: usize,
+    /// Whether IRLS met the tolerance rather than exhausting `max_iter`.
+    pub converged: bool,
 }
 
 // ============================================================================
@@ -544,7 +668,7 @@ fn null_deviance_with_offset(
     family: Family,
     link: Link,
     n: usize,
-    Y: &Mat<f64>,
+    y_vals: &[f64],
     w_samp: &[f64],
     offset: &[f64],
     domain_mask: Option<&[bool]>,
@@ -575,7 +699,7 @@ fn null_deviance_with_offset(
                 continue;
             }
             let safe_d = if d.abs() < 1e-12 { 1e-12 } else { d };
-            let z_i = (eta_i - offset[i]) + (Y[(i, 0)] - mu_i) / safe_d;
+            let z_i = (eta_i - offset[i]) + (y_vals[i] - mu_i) / safe_d;
             num.add(wi * z_i);
             den.add(wi);
         }
@@ -592,7 +716,7 @@ fn null_deviance_with_offset(
                 continue;
             }
             let mu_i = link.inverse(b_new + offset[i]);
-            dev_new += w_samp[i] * family.unit_deviance(Y[(i, 0)], mu_i);
+            dev_new += w_samp[i] * family.unit_deviance(y_vals[i], mu_i);
         }
 
         let converged = deviance.is_finite()
@@ -630,6 +754,49 @@ pub fn fit_glm(
 ) -> PolarsResult<GlmResult> {
     fit_glm_domain(
         y, x_cols, weights, strata, psu, fpc, offset, None, family_str, link_str, tol, max_iter,
+        calib,
+    )
+}
+
+/// Single fit restricted to the rows where `mask` is true.
+///
+/// A `where=` clause is one domain, not a by-variable: routing it through
+/// `fit_glm_by` fitted the complement as well and threw it away, doubling the
+/// CPU (rayon only hid it) and turning a degenerate complement into a
+/// swallowed error.
+#[allow(clippy::too_many_arguments)]
+pub fn fit_glm_where(
+    y: &Series,
+    x_cols: Vec<Series>,
+    weights: &Series,
+    strata: Option<&Series>,
+    psu: Option<&Series>,
+    fpc: Option<&Series>,
+    offset: Option<&Series>,
+    mask: &Series,
+    family_str: &str,
+    link_str: &str,
+    tol: f64,
+    max_iter: usize,
+    calib: Option<&CalibSweep>,
+) -> PolarsResult<GlmResult> {
+    let cast = mask.cast(&DataType::Boolean)?;
+    let ca = cast.bool()?;
+    let mask_vec: Vec<bool> = ca.iter().map(|v| v.unwrap_or(false)).collect();
+
+    fit_glm_domain(
+        y,
+        x_cols,
+        weights,
+        strata,
+        psu,
+        fpc,
+        offset,
+        Some(&mask_vec),
+        family_str,
+        link_str,
+        tol,
+        max_iter,
         calib,
     )
 }
@@ -696,11 +863,11 @@ pub fn fit_glm_by(
         })
         .collect();
 
-    // A level that fails to fit (e.g. a complement domain with a constant
-    // binomial response) is dropped rather than failing the whole call —
-    // the caller typically needs only one level. If every level fails,
-    // propagate the first error.
+    // A level that fails to fit used to be dropped silently, so a caller
+    // asking for every level got a short list with no way to tell which one
+    // was missing or why.
     let mut results = Vec::with_capacity(attempts.len());
+    let mut failed: Vec<String> = Vec::new();
     let mut first_err: Option<PolarsError> = None;
     for (level, res) in attempts {
         match res {
@@ -709,13 +876,24 @@ pub fn fit_glm_by(
                 if first_err.is_none() {
                     first_err = Some(e);
                 }
+                failed.push(level);
             }
         }
     }
-    if results.is_empty() {
-        if let Some(e) = first_err {
-            return Err(e);
-        }
+    if !failed.is_empty() {
+        let detail = first_err
+            .map(|e| e.to_string())
+            .unwrap_or_else(|| "unknown error".to_string());
+        return Err(PolarsError::ComputeError(
+            format!(
+                "GLM failed on {} of {} levels of '{}' ({}): {detail}",
+                failed.len(),
+                failed.len() + results.len(),
+                by_col.name(),
+                failed.join(", ")
+            )
+            .into(),
+        ));
     }
     Ok(results)
 }
@@ -780,8 +958,8 @@ fn fit_glm_domain(
         }
     }
 
-    let Y = cols_to_mat(&[y_ca], n);
-    let X = cols_to_mat(&x_ca_list, n);
+    let y_vals = cols_to_vec(&[y_ca], n);
+    let x = cols_to_vec(&x_ca_list, n);
 
     // Known term on the link scale, coefficient fixed at 1. Absent -> all zero,
     // which makes every offset expression below a no-op on the existing path.
@@ -817,6 +995,54 @@ fn fit_glm_domain(
         w_sum = n as f64;
     }
 
+    // Rows that will actually carry the fit. An empty `where` domain or an
+    // all-zero weight column used to return a zero fit as `Ok`: the normal
+    // equations are then the zero matrix, whose SVD pseudoinverse is also
+    // zero, and beta = 0 passes the finite check below.
+    let n_obs = (0..n)
+        .filter(|&i| domain_mask.is_none_or(|m| m[i]) && w_samp[i] > 0.0)
+        .count();
+    if n_obs <= k {
+        return Err(PolarsError::ComputeError(
+            format!("GLM needs more observations than parameters: n_obs={n_obs}, k={k}").into(),
+        ));
+    }
+
+    // Nulls are rejected above; NaN/Inf are not, and Rust's `f64::max` returns
+    // the other operand for a NaN, so `.max(1e-12)` on the variance would hide
+    // one all the way to a NaN beta. Only contributing rows matter: a padded
+    // zero-weight row never enters an accumulation.
+    for i in 0..n {
+        if !(domain_mask.is_none_or(|m| m[i]) && w_samp[i] > 0.0) {
+            continue;
+        }
+        if !y_vals[i].is_finite() {
+            return Err(PolarsError::ComputeError(
+                format!(
+                    "GLM response column '{}' contains a non-finite value at row {i}",
+                    y.name()
+                )
+                .into(),
+            ));
+        }
+        if !offset_vals[i].is_finite() {
+            return Err(PolarsError::ComputeError(
+                format!("GLM offset contains a non-finite value at row {i}").into(),
+            ));
+        }
+        for j in 0..k {
+            if !x[j * n + i].is_finite() {
+                return Err(PolarsError::ComputeError(
+                    format!(
+                        "GLM predictor column '{}' contains a non-finite value at row {i}",
+                        x_cast[j].name()
+                    )
+                    .into(),
+                ));
+            }
+        }
+    }
+
     // 2) IRLS init — only meaningful for in-domain rows; out-of-domain rows
     //    get a neutral placeholder since they won't contribute.
     let mut beta = Mat::<f64>::zeros(k, 1);
@@ -825,7 +1051,7 @@ fn fit_glm_domain(
 
     for i in 0..n {
         let in_domain = domain_mask.map_or(true, |m| m[i]);
-        let y_init = if in_domain { Y[(i, 0)] } else { 0.5 };
+        let y_init = if in_domain { y_vals[i] } else { 0.5 };
         mu[i] = family.initial_mu(y_init);
         // R seeds eta at linkfun(mustart) without the offset; it enters through
         // the working response, and every later eta adds it back explicitly.
@@ -833,74 +1059,74 @@ fn fit_glm_domain(
     }
 
     // work arrays
-    let mut Z = Mat::<f64>::zeros(n, 1);
+    let mut z_work = vec![0.0f64; n];
     let mut w_irls = vec![0.0; n];
     let mut XtWX = Mat::<f64>::zeros(k, k);
     let mut XtWz = Mat::<f64>::zeros(k, 1);
 
     // 3) IRLS loop
+    //
+    // eta/mu enter each pass already evaluated at the current beta — step 4
+    // leaves them there and step 6 commits that beta — so there is no leading
+    // recomputation.
     let mut iter_count = 0;
     let mut deviance = 0.0;
+    let mut converged = false;
 
     for iter in 0..max_iter {
         iter_count += 1;
 
-        // 1) eta/mu from current beta
-        if iter > 0 {
-            for i in 0..n {
-                let mut s = 0.0f64;
-                for j in 0..k {
-                    s += X[(i, j)] * beta[(j, 0)];
-                }
-                s += offset_vals[i];
-                eta[i] = s;
-                mu[i] = link.inverse(s);
-            }
-        }
-
-        // 2) build normal equations at current beta
+        // 1) build normal equations at current beta
         build_irls_normal_eqs(
             family,
             link,
             n,
             k,
-            &Y,
-            &X,
+            &y_vals,
+            &x,
             &w_samp,
             &eta,
             &mu,
             &offset_vals,
             domain_mask,
-            &mut Z,
+            &mut z_work,
             &mut w_irls,
             &mut XtWX,
             &mut XtWz,
         );
 
+        // 2) an aliased column makes every SE that follows meaningless, so
+        //    say so once, at the first information matrix, instead of
+        //    returning a fit built on a pseudoinverse.
+        if iter == 0 {
+            check_rank(&XtWX, k, &x_cast)?;
+        }
+
         // 3) solve for beta_new
         let beta_new = solve_linear_system(XtWX.as_ref(), XtWz.as_ref());
 
-        // 4) recompute eta/mu at beta_new — direct loop, no N×1 Mat alloc
-        let mut dev_new = 0.0;
-        {
+        // 4) eta/mu at beta_new, column-outer: each term is one contiguous
+        //    pass over x, where a row-outer loop strides by n per term.
+        for i in 0..n {
+            eta[i] = offset_vals[i];
+        }
+        for j in 0..k {
+            let bj = beta_new[(j, 0)];
+            if bj == 0.0 {
+                continue;
+            }
+            let xj = &x[j * n..(j + 1) * n];
             for i in 0..n {
-                let mut s = 0.0f64;
-                for j in 0..k {
-                    s += X[(i, j)] * beta_new[(j, 0)];
-                }
-                s += offset_vals[i];
-                let mu_i = link.inverse(s);
-                eta[i] = s;
-                mu[i] = mu_i;
-                let in_domain = domain_mask.map_or(true, |m| m[i]);
-                if !in_domain {
-                    continue;
-                }
-                let w_i = w_samp[i];
-                if w_i > 0.0 {
-                    let y_i = Y[(i, 0)];
-                    dev_new += w_i * family.unit_deviance(y_i, mu_i);
-                }
+                eta[i] += xj[i] * bj;
+            }
+        }
+
+        let mut dev_new = 0.0;
+        for i in 0..n {
+            let mu_i = link.inverse(eta[i]);
+            mu[i] = mu_i;
+            if domain_mask.is_none_or(|m| m[i]) && w_samp[i] > 0.0 {
+                dev_new += w_samp[i] * family.unit_deviance(y_vals[i], mu_i);
             }
         }
 
@@ -924,6 +1150,7 @@ fn fit_glm_domain(
         deviance = dev_new;
 
         if iter > 0 && (rel_dev < tol || max_delta < tol) {
+            converged = true;
             break;
         }
     }
@@ -943,69 +1170,40 @@ fn fit_glm_domain(
     // 4) Sandwich variance (R-alignment: rebuild XtWX at FINAL beta)
     // =========================================================================
 
-    // final eta/mu at converged beta — direct loop
-    for i in 0..n {
-        let mut s = 0.0f64;
-        for j in 0..k {
-            s += X[(i, j)] * beta[(j, 0)];
-        }
-        s += offset_vals[i];
-        eta[i] = s;
-        mu[i] = link.inverse(s);
-    }
-
+    // eta/mu are already at the converged beta (step 4 of the last pass).
     // rebuild XtWX at final beta (bread must match fisherinf)
     build_irls_normal_eqs(
         family,
         link,
         n,
         k,
-        &Y,
-        &X,
+        &y_vals,
+        &x,
         &w_samp,
         &eta,
         &mu,
         &offset_vals,
         domain_mask,
-        &mut Z,
+        &mut z_work,
         &mut w_irls,
         &mut XtWX,
         &mut XtWz,
     );
 
-    // strata/psu indices — FULL design (not affected by domain)
+    // strata/psu indices — FULL design (not affected by domain).
+    //
+    // The Python layer already hands the kernel dense integer code columns
+    // (the PSU code encodes the (stratum, psu) pair), so this reuses the
+    // estimation namespace's factorizers instead of casting to String and
+    // hashing a (&str, &str) per row.
     let (strata_idx, n_strata) = match strata {
-        Some(s) => index_groups(s)?,
+        Some(_) => design_codes(strata, None, n)?,
         None => (vec![0usize; n], 1usize),
     };
 
-    let (psu_idx, _n_psu_levels) = match (strata, psu) {
-        (Some(s), Some(p)) => {
-            // nest PSU within strata: id = (stratum, psu)
-            let s_str = s.cast(&DataType::String)?;
-            let p_str = p.cast(&DataType::String)?;
-            let s_ca = s_str.str()?;
-            let p_ca = p_str.str()?;
-            let s_vals: Vec<&str> = s_ca.iter().map(|v| v.unwrap_or("__NULL__")).collect();
-            let p_vals: Vec<&str> = p_ca.iter().map(|v| v.unwrap_or("__NULL__")).collect();
-
-            let mut map: HashMap<(&str, &str), usize> = HashMap::new();
-            let mut idx = Vec::with_capacity(n);
-            let mut next = 0usize;
-
-            for i in 0..n {
-                let key = (s_vals[i], p_vals[i]);
-                let v = *map.entry(key).or_insert_with(|| {
-                    let t = next;
-                    next += 1;
-                    t
-                });
-                idx.push(v);
-            }
-            (idx, next)
-        }
-        (_, Some(p)) => index_groups(p)?,
-        _ => ((0..n).collect::<Vec<_>>(), n),
+    let (psu_idx, n_psu_levels) = match psu {
+        Some(_) => design_codes(strata, psu, n)?,
+        None => ((0..n).collect::<Vec<_>>(), n),
     };
 
     // Pre-build strata → obs index
@@ -1040,7 +1238,7 @@ fn fit_glm_domain(
         let mu_i = mu[i];
         let d = link.mu_eta(mu_i, eta[i]);
         let v = family.variance(mu_i).max(1e-12);
-        w_i * (Y[(i, 0)] - mu_i) * d / v
+        w_i * (y_vals[i] - mu_i) * d / v
     };
 
     // Calibration-aware variance. R centres the INFLUENCE functions --
@@ -1064,7 +1262,7 @@ fn fit_glm_domain(
             let s_i = score_at(i);
             if s_i != 0.0 {
                 for j in 0..k {
-                    m[j * n + i] = s_i * X[(i, j)];
+                    m[j * n + i] = s_i * x[j * n + i];
                 }
             }
         }
@@ -1075,91 +1273,200 @@ fn fit_glm_domain(
     });
 
     // MEAT = sum_h Var_h( PSU totals ) with svytotal-style centering.
-    let mut meat_acc = vec![Kahan::new(); k * k];
+    let mut meat_flat = vec![0.0f64; k * k]; // upper triangle
 
-    for h in 0..n_strata {
-        let mut local_map: HashMap<usize, usize> = HashMap::new();
-        let mut totals: Vec<Vec<Kahan>> = Vec::new();
+    // Per-stratum with-replacement factor m/(m-1), times the stratum FPC
+    // (1 - f_h). Zero for a stratum that cannot contribute (a single PSU),
+    // which is how those rows are kept out of the accumulation below.
+    let mut scale_h = vec![0.0f64; n_strata];
+    let mut psus_h = vec![0usize; n_strata];
 
-        for &i in &strata_obs[h] {
-            let psu_id = psu_idx[i];
-            let li = *local_map.entry(psu_id).or_insert_with(|| {
-                let new_i = totals.len();
-                totals.push(vec![Kahan::new(); k]);
-                new_i
-            });
-
-            match &ef {
-                Some(m) => {
-                    for j in 0..k {
-                        totals[li][j].add(m[j * n + i]);
-                    }
-                }
-                None => {
-                    if w_samp[i] <= 0.0 || w_irls[i] <= 0.0 {
-                        continue;
-                    }
-                    let s_i = score_at(i);
-                    for j in 0..k {
-                        totals[li][j].add(s_i * X[(i, j)]);
-                    }
+    if psu.is_none() {
+        for h in 0..n_strata {
+            psus_h[h] = strata_obs[h].len();
+        }
+    } else {
+        let mut seen = vec![false; n_psu_levels];
+        for h in 0..n_strata {
+            let mut m = 0usize;
+            for &i in &strata_obs[h] {
+                if !seen[psu_idx[i]] {
+                    seen[psu_idx[i]] = true;
+                    m += 1;
                 }
             }
+            for &i in &strata_obs[h] {
+                seen[psu_idx[i]] = false;
+            }
+            psus_h[h] = m;
         }
-
-        let m = totals.len();
+    }
+    for h in 0..n_strata {
+        let m = psus_h[h];
         if m <= 1 {
             continue;
         }
-
-        // mean-center PSU totals in stratum
-        let mut mean = vec![0.0; k];
-        for t in &totals {
-            for j in 0..k {
-                mean[j] += t[j].value();
-            }
-        }
-        for j in 0..k {
-            mean[j] /= m as f64;
-        }
-
-        // with-replacement factor m/(m-1), times the stratum FPC (1 - f_h)
-        let fpc_h = match &fpc_rows {
+        let f = match &fpc_rows {
             Some(f) => strata_obs[h].first().map(|&i| f[i]).unwrap_or(1.0),
             None => 1.0,
         };
-        let scale_h = fpc_h * (m as f64) / ((m - 1) as f64);
+        scale_h[h] = f * (m as f64) / ((m - 1) as f64);
+    }
 
-        for a in 0..k {
-            for b in 0..k {
-                let mut s = Kahan::new();
-                for t in &totals {
-                    let da = t[a].value() - mean[a];
-                    let db = t[b].value() - mean[b];
-                    s.add(da * db);
+    if psu.is_none() {
+        // Every row is its own PSU, so a PSU total IS that row's score
+        // contribution and the stratum sums telescope:
+        //   sum_i (t_i - tbar)(t_i - tbar)' = sum_i t_i t_i' - m tbar tbar'.
+        // The quadratic half is then one weighted cross-product over all rows
+        // (row weight = the row's stratum scale), and the correction needs
+        // only a k-vector per stratum. Materialising m x k PSU totals -- at
+        // 1e6 rows, a million heap vectors behind a million-entry hash map,
+        // walked k^2 times -- was the entire cost of a weights-only design.
+        //
+        // No cancellation to worry about: the score equations make the total
+        // sum_i s_i x_ij zero at the MLE, and a stratum's share of it is
+        // O(sqrt(m)), so the correction is ~1/m of the quadratic term.
+        let mut row_w = vec![0.0f64; n];
+        let mut sums = vec![0.0f64; n_strata * k];
+
+        match &ef {
+            Some(e) => {
+                for i in 0..n {
+                    row_w[i] = scale_h[strata_idx[i]];
                 }
-                meat_acc[a * k + b].add(scale_h * s.value());
+                for j in 0..k {
+                    let col = &e[j * n..(j + 1) * n];
+                    for i in 0..n {
+                        sums[strata_idx[i] * k + j] += col[i];
+                    }
+                }
+                accumulate_weighted_crossprod(e, &row_w, n, k, &mut meat_flat);
+            }
+            None => {
+                let mut scores = vec![0.0f64; n];
+                for i in 0..n {
+                    scores[i] = score_at(i);
+                }
+                for i in 0..n {
+                    row_w[i] = scale_h[strata_idx[i]] * scores[i] * scores[i];
+                }
+                for j in 0..k {
+                    let col = &x[j * n..(j + 1) * n];
+                    for i in 0..n {
+                        sums[strata_idx[i] * k + j] += scores[i] * col[i];
+                    }
+                }
+                accumulate_weighted_crossprod(&x, &row_w, n, k, &mut meat_flat);
+            }
+        }
+
+        for h in 0..n_strata {
+            let m = psus_h[h];
+            if m <= 1 {
+                continue;
+            }
+            let c = scale_h[h] / (m as f64);
+            for a in 0..k {
+                let sa = sums[h * k + a];
+                for b in a..k {
+                    meat_flat[a * k + b] -= c * sa * sums[h * k + b];
+                }
+            }
+        }
+    } else {
+        // Real PSUs: one flat m x k totals buffer per stratum, addressed
+        // through a dense slot table indexed by the (already 0-based) PSU
+        // code, in place of a per-stratum HashMap and m heap vectors.
+        let mut slot = vec![usize::MAX; n_psu_levels];
+        let mut totals: Vec<f64> = Vec::new();
+        let mut used: Vec<usize> = Vec::new();
+        let mut mean = vec![0.0f64; k];
+        let mut local = vec![0.0f64; k * k];
+
+        for h in 0..n_strata {
+            totals.clear();
+            used.clear();
+
+            for &i in &strata_obs[h] {
+                let pid = psu_idx[i];
+                let li = if slot[pid] == usize::MAX {
+                    let t = used.len();
+                    slot[pid] = t;
+                    used.push(pid);
+                    totals.resize(totals.len() + k, 0.0);
+                    t
+                } else {
+                    slot[pid]
+                };
+
+                let base = li * k;
+                match &ef {
+                    Some(e) => {
+                        for j in 0..k {
+                            totals[base + j] += e[j * n + i];
+                        }
+                    }
+                    None => {
+                        let s_i = score_at(i);
+                        if s_i != 0.0 {
+                            for j in 0..k {
+                                totals[base + j] += s_i * x[j * n + i];
+                            }
+                        }
+                    }
+                }
+            }
+
+            let m = used.len();
+            for &pid in &used {
+                slot[pid] = usize::MAX;
+            }
+            if m <= 1 {
+                continue;
+            }
+
+            // mean-center PSU totals in stratum
+            mean.iter_mut().for_each(|v| *v = 0.0);
+            for li in 0..m {
+                for j in 0..k {
+                    mean[j] += totals[li * k + j];
+                }
+            }
+            for j in 0..k {
+                mean[j] /= m as f64;
+            }
+
+            local.iter_mut().for_each(|v| *v = 0.0);
+            for li in 0..m {
+                let base = li * k;
+                for a in 0..k {
+                    let da = totals[base + a] - mean[a];
+                    for b in a..k {
+                        local[a * k + b] += da * (totals[base + b] - mean[b]);
+                    }
+                }
+            }
+            for a in 0..k {
+                for b in a..k {
+                    meat_flat[a * k + b] += scale_h[h] * local[a * k + b];
+                }
             }
         }
     }
 
-    // materialize meat
+    // materialize meat (symmetric by construction: only the upper triangle
+    // was accumulated)
     let mut meat = Mat::<f64>::zeros(k, k);
     for a in 0..k {
-        for b in 0..k {
-            meat[(a, b)] = meat_acc[a * k + b].value();
-        }
-    }
-    // symmetrize
-    for a in 0..k {
-        for b in 0..k {
-            let v = 0.5 * (meat[(a, b)] + meat[(b, a)]);
+        for b in a..k {
+            let v = meat_flat[a * k + b];
             meat[(a, b)] = v;
+            meat[(b, a)] = v;
         }
     }
 
     // BREAD = (XtWX)^-1 at final beta
-    let bread = invert_matrix(XtWX.as_ref(), k);
+    let bread = invert_matrix(XtWX.as_ref(), k)?;
 
     // Cov = bread * meat * bread
     let tmp = &bread * &meat;
@@ -1213,14 +1520,6 @@ fn fit_glm_domain(
         if n_dom <= 1 { 1.0 } else { (n_dom - 1) as f64 }
     };
 
-    // n_obs: rows actually contributing to the fit — in-domain with
-    // positive weight. Zero-weight rows (e.g. missing-value rows kept for
-    // the design structure) are excluded in both branches.
-    let n_obs = match domain_mask {
-        Some(m) => (0..n).filter(|&i| m[i] && w_samp[i] > 0.0).count(),
-        None => (0..n).filter(|&i| w_samp[i] > 0.0).count(),
-    };
-
     // scale (phi) for gaussian/gamma/invgauss (reporting only).
     // Pearson sum is computed over in-domain rows only.
     let scale = if matches!(
@@ -1239,7 +1538,7 @@ fn fit_glm_domain(
             }
             let mu_i = mu[i];
             let v = family.variance(mu_i).max(1e-12);
-            let y_i = Y[(i, 0)];
+            let y_i = y_vals[i];
             pearson += w_i * (y_i - mu_i).powi(2) / v;
         }
         if df_resid > 0.0 {
@@ -1264,7 +1563,7 @@ fn fit_glm_domain(
             family,
             link,
             n,
-            &Y,
+            &y_vals,
             &w_samp,
             &offset_vals,
             domain_mask,
@@ -1280,7 +1579,7 @@ fn fit_glm_domain(
             if !in_domain || w_samp[i] <= 0.0 {
                 continue;
             }
-            sum_wy += Y[(i, 0)] * w_samp[i];
+            sum_wy += y_vals[i] * w_samp[i];
             sum_w += w_samp[i];
         }
         let y_mean = if sum_w > 0.0 { sum_wy / sum_w } else { 0.0 };
@@ -1295,7 +1594,7 @@ fn fit_glm_domain(
             if w_i <= 0.0 {
                 continue;
             }
-            let y_i = Y[(i, 0)];
+            let y_i = y_vals[i];
             dev0 += w_i * family.unit_deviance(y_i, y_mean);
         }
         dev0
@@ -1325,6 +1624,7 @@ fn fit_glm_domain(
         null_deviance,
         iterations: iter_count as u32,
         n_obs,
+        converged,
     })
 }
 

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -29,6 +29,12 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Fixed
 
+- **`glm.fit()` reported failures as results.** An empty `where=` domain, or an all-zero weight column, returned a fit of all-zero coefficients (or, for gamma and poisson, a `TypeError` from the response check); `x` and `2 * x` "fitted" with SE 0 and an F statistic around 1e30; more parameters than observations came back through a pseudoinverse. Each of these now raises `ModelError` naming what is wrong — the collinear term by name, in the model's own column order.
+
+- **A GLM that ran out of iterations was reported like a converged one.** `fit()` now warns, giving the iteration count and the tolerance, and so does dropping rows for an invalid weight, dropping a `Cat` with fewer than two levels among the fitted rows, and — as a `ModelError` rather than a polars "duplicate output name" — listing the same predictor twice.
+
+- **`where=` fitted the complement domain too** and threw it away. The predicate now reaches the kernel as a Boolean mask instead of a `"true"`/`"false"` by-column, so only the requested domain is fitted (1e6 rows x 20 covariates: 1.22 s → 0.45 s). The estimates are unchanged.
+
 - **`glm.predict()` and `glm.margins()` were wrong on an int, float or bool-coded `Cat`.** Both rebuilt a dummy column by slicing the level out of the coefficient *name* and comparing it to the raw column as a string, which numpy answers all-False without raising: every row got the reference-level prediction (off by up to 0.26 in probability on the test model) and every categorical average marginal effect came back exactly 0.0 with SE 0.0. The fitted coefficients were correct throughout, which is what kept it quiet. The design matrix is now rebuilt from the level values in their fitted dtype, through the same polars expression the fit used — and, as a side effect, in one pass instead of a Python loop over object arrays (predict on 1e6 rows: 0.72 s → 0.12 s; a 10-level categorical AME: 5.9 s → 0.8 s).
 
 - **Prediction data is validated.** A missing predictor column raises `ModelError` naming it (was a raw polars `ColumnNotFoundError` or a bare `KeyError`), and a categorical value the fit never saw — including a null — raises instead of being silently coded as the reference level, in `predict()` and in `margins(at=)` alike.

--- a/packages/svy/benchmarks/baselines/kernel.json
+++ b/packages/svy/benchmarks/baselines/kernel.json
@@ -1,99 +1,111 @@
 {
-  "machine": "Darwin arm64 / py3.14.6",
-  "note": "release build, feat/weighting-cells-standardize; adds calibrated-design cases",
-  "results": {
-    "corr/tot_exp~hhsize": {
-      "1000000": 48.481,
-      "250000": 12.245
-    },
-    "cov/tot_exp~hhsize": {
-      "1000000": 47.782,
-      "250000": 11.998
-    },
-    "kernel/long-labels": {
-      "1000000": 44.651,
-      "250000": 11.167
-    },
-    "kernel/no-design": {
-      "1000000": 7.828,
-      "250000": 1.977
-    },
-    "kernel/short-32chunks": {
-      "1000000": 45.359,
-      "250000": 11.492
-    },
-    "kernel/short-labels": {
-      "1000000": 43.769,
-      "250000": 11.183
-    },
-    "mean/batched(2 vars)": {
-      "1000000": 31.709,
-      "250000": 8.571
-    },
-    "mean/by=sex": {
-      "1000000": 84.508,
-      "250000": 21.597
-    },
-    "mean/calibrated": {
-      "1000000": 30.495,
-      "250000": 8.09
-    },
-    "mean/domain(region==0)": {
-      "1000000": 32.934,
-      "250000": 8.586
-    },
-    "mean/looped(2 vars)": {
-      "1000000": 47.489,
-      "250000": 13.121
-    },
-    "mean/poststratified": {
-      "1000000": 27.462,
-      "250000": 7.435
-    },
-    "mean/poststratified by=sex": {
-      "1000000": 94.335,
-      "250000": 24.3
-    },
-    "mean/raked": {
-      "1000000": 95.745,
-      "250000": 24.429
-    },
-    "mean/replication(R=40)": {
-      "1000000": 13.228,
-      "250000": 4.266
-    },
-    "mean/strat+cluster": {
-      "1000000": 23.947,
-      "250000": 6.536
-    },
-    "median/tot_exp": {
-      "1000000": 97.32,
-      "250000": 22.193
-    },
-    "prop/sex": {
-      "1000000": 70.837,
-      "250000": 18.248
-    },
-    "quantile/tot_exp": {
-      "1000000": 154.481,
-      "250000": 35.964
-    },
-    "ratio/strat+cluster": {
-      "1000000": 37.654,
-      "250000": 9.165
-    },
-    "tabulate/sex": {
-      "1000000": 253.9,
-      "250000": 63.15
-    },
-    "total/poststratified": {
-      "1000000": 32.341,
-      "250000": 8.001
-    },
-    "total/strat+cluster": {
-      "1000000": 27.193,
-      "250000": 7.128
-    }
+ "machine": "Darwin arm64 / py3.14.6",
+ "note": "release build, feat/weighting-cells-standardize; adds calibrated-design cases; adds GLM cases (perf/glm-kernel)",
+ "results": {
+  "corr/tot_exp~hhsize": {
+   "1000000": 48.481,
+   "250000": 12.245
   },
-  "svy_version": "0.26.0"
+  "cov/tot_exp~hhsize": {
+   "1000000": 47.782,
+   "250000": 11.998
+  },
+  "glm/binomial domain": {
+   "1000000": 428.428,
+   "250000": 110.284
+  },
+  "glm/binomial strat+cluster": {
+   "1000000": 505.56,
+   "250000": 123.406
+  },
+  "glm/binomial weights-only": {
+   "1000000": 419.716,
+   "250000": 109.535
+  },
+  "kernel/long-labels": {
+   "1000000": 44.651,
+   "250000": 11.167
+  },
+  "kernel/no-design": {
+   "1000000": 7.828,
+   "250000": 1.977
+  },
+  "kernel/short-32chunks": {
+   "1000000": 45.359,
+   "250000": 11.492
+  },
+  "kernel/short-labels": {
+   "1000000": 43.769,
+   "250000": 11.183
+  },
+  "mean/batched(2 vars)": {
+   "1000000": 31.709,
+   "250000": 8.571
+  },
+  "mean/by=sex": {
+   "1000000": 84.508,
+   "250000": 21.597
+  },
+  "mean/calibrated": {
+   "1000000": 30.495,
+   "250000": 8.09
+  },
+  "mean/domain(region==0)": {
+   "1000000": 32.934,
+   "250000": 8.586
+  },
+  "mean/looped(2 vars)": {
+   "1000000": 47.489,
+   "250000": 13.121
+  },
+  "mean/poststratified": {
+   "1000000": 27.462,
+   "250000": 7.435
+  },
+  "mean/poststratified by=sex": {
+   "1000000": 94.335,
+   "250000": 24.3
+  },
+  "mean/raked": {
+   "1000000": 95.745,
+   "250000": 24.429
+  },
+  "mean/replication(R=40)": {
+   "1000000": 13.228,
+   "250000": 4.266
+  },
+  "mean/strat+cluster": {
+   "1000000": 23.947,
+   "250000": 6.536
+  },
+  "median/tot_exp": {
+   "1000000": 97.32,
+   "250000": 22.193
+  },
+  "prop/sex": {
+   "1000000": 70.837,
+   "250000": 18.248
+  },
+  "quantile/tot_exp": {
+   "1000000": 154.481,
+   "250000": 35.964
+  },
+  "ratio/strat+cluster": {
+   "1000000": 37.654,
+   "250000": 9.165
+  },
+  "tabulate/sex": {
+   "1000000": 253.9,
+   "250000": 63.15
+  },
+  "total/poststratified": {
+   "1000000": 32.341,
+   "250000": 8.001
+  },
+  "total/strat+cluster": {
+   "1000000": 27.193,
+   "250000": 7.128
+  }
+ },
+ "svy_version": "0.26.0"
 }

--- a/packages/svy/benchmarks/bench_kernel.py
+++ b/packages/svy/benchmarks/bench_kernel.py
@@ -212,6 +212,51 @@ def run_end_to_end(n_rows: int, reps: int, n_reps: int) -> None:
     )
 
 
+# ── GLM (IRLS kernel + sandwich) ────────────────────────────────────────────
+
+
+def run_glm(n_rows: int, reps: int) -> None:
+    """The GLM path, which none of the estimation cases touch.
+
+    Binomial logit on 20 continuous covariates, under both design shapes: the
+    normal-equations build dominates a strata+PSU fit, while a weights-only
+    design makes every row its own PSU and shifts the cost into the sandwich
+    meat. A regression in either pass shows up in exactly one of the two.
+    """
+    n_cov = 20
+    rng = np.random.default_rng(11)
+    cols: dict[str, np.ndarray] = {
+        f"x{j}": rng.normal(size=n_rows) for j in range(n_cov)
+    }
+    cols["hhweight"] = rng.uniform(0.5, 2.0, n_rows)
+    cols["geo1"] = rng.integers(0, 10, n_rows).astype("U2")
+    cols["urbrur"] = rng.integers(0, 2, n_rows).astype("U1")
+    cols["ea"] = rng.integers(0, PSU_PER_STRATUM, n_rows).astype("U3")
+    eta = sum(cols[f"x{j}"] for j in range(n_cov)) / np.sqrt(n_cov)
+    cols["y_bin"] = (rng.random(n_rows) < 1.0 / (1.0 + np.exp(-eta))).astype("int8")
+    df = pl.DataFrame(cols)
+
+    x = [f"x{j}" for j in range(n_cov)]
+    clustered = Sample(
+        data=df, design=Design(stratum=("geo1", "urbrur"), psu="ea", wgt="hhweight")
+    )
+    weights_only = Sample(data=df, design=Design(wgt="hhweight"))
+
+    def fit(sample):
+        return lambda: sample.glm.fit(y="y_bin", x=x, family="binomial")
+
+    emit_case("glm/binomial strat+cluster", n_rows, fit(clustered), reps)
+    emit_case("glm/binomial weights-only", n_rows, fit(weights_only), reps)
+    emit_case(
+        "glm/binomial domain",
+        n_rows,
+        lambda: clustered.glm.fit(
+            y="y_bin", x=x, family="binomial", where=svy.col("urbrur") == "1"
+        ),
+        reps,
+    )
+
+
 # ── Direct-kernel probe (isolates Rust kernel + marshalling) ────────────────
 
 
@@ -266,6 +311,9 @@ def main() -> None:
         reps = args.reps_large if n_rows >= 1_000_000 else args.reps
         print(f"# ── {n_rows:,} rows (best of {reps}) ──")
         run_end_to_end(n_rows, reps, args.n_reps)
+        # A 1e6 x 20 binomial fit is seconds, not milliseconds; best-of-3 is
+        # enough to see a real change and keeps the harness usable.
+        run_glm(n_rows, min(reps, 3))
         run_direct_kernel(n_rows, reps)
         print()
 

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import logging
 import math
+import warnings
 
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, Sequence, cast
 
@@ -67,6 +68,44 @@ def _dummy_expr(var: str, level: Any) -> pl.Expr:
     dtype.
     """
     return (pl.col(var) == pl.lit(level)).cast(pl.Float64)
+
+
+# Structural failures the kernel reports as a RuntimeError. They are the
+# user's problem to fix, not an internal error, so they are re-raised as
+# ModelError with the engine's own message — which already names the offending
+# column — plus the remedy.
+_ENGINE_ERRORS: tuple[tuple[str, str, str], ...] = (
+    (
+        "rank deficient",
+        "RANK_DEFICIENT",
+        "Drop the term named above, or the column it duplicates, and refit.",
+    ),
+    (
+        "needs more observations than parameters",
+        "INSUFFICIENT_OBSERVATIONS",
+        "Fit fewer terms, or widen the domain.",
+    ),
+    (
+        "non-finite value",
+        "NON_FINITE_INPUT",
+        "Replace the infinite or NaN entries, or drop those rows.",
+    ),
+)
+
+
+def _as_model_error(exc: Exception) -> ModelError | None:
+    """Recognise an engine failure that the caller can act on."""
+    msg = str(exc)
+    for needle, code, hint in _ENGINE_ERRORS:
+        if needle in msg:
+            return ModelError(
+                title="GLM cannot be fitted",
+                detail=msg,
+                code=code,
+                where="GLM.fit",
+                hint=hint,
+            )
+    return None
 
 
 def _normalize_family(family: FamilyArg) -> str:
@@ -385,35 +424,59 @@ class GLM:
         s_col = prep.strata_col
         p_col = prep.psu_col
 
-        # ── Materialise the where predicate as a boolean by-column ───────
+        # ── Materialise the where predicate as a boolean domain column ───
         # We don't pass `where` to prepare_data because the GLM engine needs
         # the full design rows in the dataframe (the Rust side does the
-        # domain restriction via by_col). Instead, compile the predicate to
-        # a polars expression and add it as a string column ("true"/"false").
-        # The Rust engine receives this as by_col and produces one fit per
-        # level; the Python side then picks the "true" level.
-        by_col_name: str | None = None
+        # domain restriction itself, so the strata/PSU structure and the df
+        # stay those of the full design). The predicate becomes a Boolean
+        # column the engine takes as its domain mask.
+        dom_col: str | None = None
         if where is not None:
-            by_col_name = "__where_domain__"
+            dom_col = "__where_domain__"
             bool_expr = _compile_where_to_pl_expr(where)
-            df = df.with_columns(cast(pl.Expr, bool_expr).cast(pl.Utf8).alias(by_col_name))
+            df = df.with_columns(
+                cast(pl.Expr, bool_expr).fill_null(False).cast(pl.Boolean).alias(dom_col)
+            )
 
         # Drop rows with INVALID weights (null / non-finite / negative) —
         # unconditionally: prepare_data always provides a weight column,
         # synthesizing ones for unweighted designs. Zero-weight rows are
         # KEPT: prepare_data zero-weights missing-value rows so they
         # preserve the design structure while contributing nothing.
-        df = df.filter(
-            pl.col(w_col).is_not_null() & pl.col(w_col).is_finite() & (pl.col(w_col) >= 0)
-        )
+        _valid_w = pl.col(w_col).is_not_null() & pl.col(w_col).is_finite() & (pl.col(w_col) >= 0)
+        _n_before = df.height
+        df = df.filter(_valid_w)
+        if df.height < _n_before:
+            warnings.warn(
+                f"{_n_before - df.height} row(s) dropped: weight column {w_col!r} is "
+                "null, non-finite or negative there.",
+                UserWarning,
+                stacklevel=2,
+            )
 
         # In-domain rows: where == true (when set) and positive weight.
         # Cat level enumeration, reference validation, and response
         # validation all use exactly the rows the fit will use.
         _in_dom_expr = pl.col(w_col) > 0
-        if by_col_name is not None:
-            _in_dom_expr = _in_dom_expr & (pl.col(by_col_name).str.to_lowercase() == "true")
+        if dom_col is not None:
+            _in_dom_expr = _in_dom_expr & pl.col(dom_col)
         level_df = df.filter(_in_dom_expr)
+
+        if level_df.height == 0:
+            raise ModelError(
+                title="No observations to fit",
+                detail=(
+                    "No row has a positive weight"
+                    + (" inside the where clause" if where is not None else "")
+                    + ". Nothing was fitted."
+                ),
+                code="GLM_NO_OBSERVATIONS",
+                where="GLM.fit",
+                hint=(
+                    "Check the where clause and the weight column; rows with a missing "
+                    "predictor are kept with weight zero and do not count here."
+                ),
+            )
 
         # ── Build feature matrix ──────────────────────────────────────────
         feature_exprs: list[pl.Expr] = []
@@ -440,7 +503,12 @@ class GLM:
                 )
 
                 if len(levels) < 2:
-                    log.warning(f"Categorical '{feat.name}' has < 2 levels. Dropped.")
+                    warnings.warn(
+                        f"Categorical {feat.name!r} has fewer than 2 levels among the "
+                        "rows being fitted and was dropped from the model.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
                     return [], []
 
                 if feat.ref is not None and feat.ref not in levels:
@@ -503,6 +571,23 @@ class GLM:
             feature_exprs.extend(exprs)
             feature_names.extend(names)
 
+        # A duplicate engineered name would fail in the select below as a
+        # polars "duplicate output name", which says nothing about the model.
+        _dupes = sorted({nm for nm in feature_names if feature_names.count(nm) > 1})
+        if _dupes:
+            raise ModelError(
+                title="Duplicate model term",
+                detail=(
+                    f"The terms {_dupes!r} are each engineered twice. A repeated "
+                    "predictor, or a Cat level whose dummy name collides with "
+                    "another column, makes the design matrix singular."
+                ),
+                code="DUPLICATE_TERM",
+                where="GLM.fit",
+                got=_dupes,
+                hint="List each predictor once.",
+            )
+
         # ── FPC (single-stage) ───────────────────────────────────────────
         # Per-stratum (1 - f_h) factors matching R svyglm on a design with
         # fpc=. Only the PSU-level factor applies (the sandwich meat is
@@ -537,8 +622,8 @@ class GLM:
             final_selects.append(pl.col(s_col))
         if p_col and p_col in df.columns:
             final_selects.append(pl.col(p_col))
-        if by_col_name and by_col_name in df.columns:
-            final_selects.append(pl.col(by_col_name))
+        if dom_col and dom_col in df.columns:
+            final_selects.append(pl.col(dom_col))
         if fpc_name and fpc_name in df.columns:
             final_selects.append(pl.col(fpc_name))
         if offset and offset in df.columns:
@@ -546,7 +631,7 @@ class GLM:
         for rc in rep_cols:
             if rc in df.columns:
                 final_selects.append(pl.col(rc).cast(pl.Float64))
-        _already = {y, w_col, s_col, p_col, by_col_name, fpc_name}
+        _already = {y, w_col, s_col, p_col, dom_col, fpc_name}
         _already.update(feature_names)
         _already.update(rep_cols)
         for cc in calib_cols:
@@ -582,7 +667,7 @@ class GLM:
                 psu_name=p_col,
                 fpc_name=fpc,
                 offset_name=offset,
-                by_col=by_col_name,
+                where_col=dom_col,
                 family=fam_str,
                 link=link_str,
                 tol=tol,
@@ -592,20 +677,16 @@ class GLM:
             )
             if not res:
                 raise RuntimeError("GLM engine returned no results.")
-            if by_col_name is None:
-                return res[0]
-            true_res = [r for r in res if str(r[0]).lower() == "true"]
-            if not true_res:
-                raise RuntimeError(
-                    "where clause produced no in-domain observations; cannot fit GLM."
-                )
-            return true_res[0]
+            return res[0]
 
         try:
             chosen = _run_engine(w_col, fpc_name)
-        except RuntimeError:
-            raise
         except Exception as e:
+            mapped = _as_model_error(e)
+            if mapped is not None:
+                raise mapped from e
+            if isinstance(e, RuntimeError):
+                raise
             raise RuntimeError(f"Rust GLM engine failed: {e}") from e
 
         (
@@ -619,6 +700,7 @@ class GLM:
             null_dev,
             iters,
             n_obs,
+            converged,
         ) = chosen
 
         # ── Post-process ──────────────────────────────────────────────────
@@ -636,11 +718,8 @@ class GLM:
         # information are linear in that scale; rho converts to R's scale
         # (rho == 1 for full-sample fits with no zero-weight rows).
         w_all = eng_df.get_column(w_col).to_numpy().astype(float)
-        if by_col_name is not None:
-            _dom_arr = (
-                eng_df.get_column(by_col_name).cast(pl.Utf8).str.to_lowercase() == "true"
-            ).to_numpy()
-            in_dom_mask = _dom_arr & (w_all > 0)
+        if dom_col is not None:
+            in_dom_mask = eng_df.get_column(dom_col).to_numpy() & (w_all > 0)
         else:
             in_dom_mask = w_all > 0
         _n_in = int(in_dom_mask.sum())
@@ -726,6 +805,15 @@ class GLM:
         else:
             aic_val = dev + 2.0 * eff_p if eff_p is not None else None
 
+        if not converged:
+            warnings.warn(
+                f"GLM did not converge in {iters} iterations (tol={tol:g}); the "
+                "coefficients and standard errors below are the last iterate. "
+                "Raise max_iter, or check for separation in the response.",
+                UserWarning,
+                stacklevel=2,
+            )
+
         # Statistics
         stats_struct = self._build_stats(
             n,
@@ -789,7 +877,7 @@ class GLM:
         # frame instead of recomputing from the raw sample data.
         self._fit_frame = df
         self._fit_weight_col = w_col
-        self._fit_domain_col = by_col_name
+        self._fit_domain_col = dom_col
 
         self.fitted = fit_obj
         return self

--- a/packages/svy/src/svy/regression/margins.py
+++ b/packages/svy/src/svy/regression/margins.py
@@ -339,7 +339,7 @@ def _fitted_frame(glm: GLM, fit: GLMFit) -> tuple[pl.DataFrame, np.ndarray]:
 
     d_col = glm._fit_domain_col
     if d_col is not None and d_col in frame.columns:
-        frame = frame.filter(pl.col(d_col).str.to_lowercase() == "true").drop(d_col)
+        frame = frame.filter(pl.col(d_col)).drop(d_col)
 
     weights = frame.get_column(w_col).to_numpy().astype(float)
     return frame, weights

--- a/packages/svy/tests/svy/regression/test_glm_kernel_guards.py
+++ b/packages/svy/tests/svy/regression/test_glm_kernel_guards.py
@@ -1,0 +1,131 @@
+# tests/svy/regression/test_glm_kernel_guards.py
+"""
+What the GLM kernel refuses, and what it warns about.
+
+Each case below used to produce a result rather than a complaint: an empty
+domain returned a zero fit as a success, `x` and `2 * x` "fitted" with SE 0 and
+an F around 1e30, k >= n came back through an SVD pseudoinverse, and a model
+that ran out of iterations was reported like a converged one.
+"""
+
+import warnings
+
+from pathlib import Path
+
+import polars as pl
+import pytest
+
+import svy
+
+from svy.core.sample import Design, Sample
+from svy.core.terms import Cat
+from svy.errors.model_errors import ModelError
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
+
+
+@pytest.fixture
+def api():
+    return pl.read_csv(DATA_DIR / "apistrat.csv")
+
+
+def _sample(df: pl.DataFrame) -> Sample:
+    return Sample(df, Design(wgt="pw"))
+
+
+class TestRefusals:
+    def test_collinear_column_is_named(self, api):
+        df = api.with_columns((pl.col("ell") * 2).alias("ell2"))
+
+        with pytest.raises(ModelError, match="ell2"):
+            _sample(df).glm.fit(y="api00", x=["ell", "ell2"])
+
+    def test_collinear_error_points_at_the_later_column(self, api):
+        """R's rule: the columns that came first are the ones that are kept."""
+        df = api.with_columns((pl.col("ell") * 2).alias("ell2"))
+
+        with pytest.raises(ModelError) as exc:
+            _sample(df).glm.fit(y="api00", x=["ell", "ell2"])
+
+        assert "'ell2'" in str(exc.value)
+        assert "'ell'," not in str(exc.value)
+
+    def test_a_duplicated_categorical_is_caught(self, api):
+        """`stype` and a copy of it: the second set of dummies is aliased."""
+        df = api.with_columns(pl.col("stype").alias("stype2"))
+
+        with pytest.raises(ModelError, match="rank deficient"):
+            _sample(df).glm.fit(y="api00", x=[Cat("stype"), Cat("stype2")])
+
+    def test_more_parameters_than_observations(self, api):
+        with pytest.raises(ModelError, match="more observations than parameters"):
+            _sample(api.head(3)).glm.fit(y="api00", x=["ell", "meals", "mobility"])
+
+    def test_empty_where_domain(self, api):
+        with pytest.raises(ModelError, match="No row has a positive weight"):
+            _sample(api).glm.fit(y="api00", x=["ell"], where=svy.col("stype") == "ZZ")
+
+    def test_all_weights_zero(self, api):
+        df = api.with_columns(pl.lit(0.0).alias("pw"))
+
+        with pytest.raises(ModelError, match="No row has a positive weight"):
+            _sample(df).glm.fit(y="api00", x=["ell"])
+
+    def test_repeated_predictor(self, api):
+        with pytest.raises(ModelError, match="engineered twice"):
+            _sample(api).glm.fit(y="api00", x=["ell", "ell"])
+
+    def test_non_finite_predictor_reaching_the_kernel(self):
+        """
+        The Python path never gets here — `prepare_data` treats an infinite
+        covariate as missing and zero-weights the row — so this drives the
+        kernel directly, which is what other callers of `fit_glm_rs` do.
+        """
+        from svy_rs import _internal as rs
+
+        df = pl.DataFrame(
+            {
+                "y": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                "_intercept_": [1.0] * 6,
+                "x": [1.0, 2.0, float("inf"), 4.0, 5.0, 6.0],
+                "w": [1.0] * 6,
+            }
+        )
+
+        with pytest.raises(RuntimeError, match="non-finite value"):
+            rs.fit_glm_rs(
+                y_name="y",
+                x_names=["_intercept_", "x"],
+                weight_name="w",
+                data=df,
+                family="gaussian",
+                link="identity",
+            )
+
+
+class TestWarnings:
+    def test_non_convergence_is_reported(self, api):
+        with pytest.warns(UserWarning, match="did not converge"):
+            _sample(api).glm.fit(y="api00", x=["ell"], family="gamma", link="log", max_iter=1)
+
+    def test_a_converged_fit_is_silent(self, api):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            _sample(api).glm.fit(y="api00", x=["ell", "meals"])
+
+    def test_invalid_weights_are_reported_when_dropped(self, api):
+        df = api.with_columns(
+            pl.when(pl.int_range(pl.len()) == 0).then(-1.0).otherwise(pl.col("pw")).alias("pw")
+        )
+
+        with pytest.warns(UserWarning, match="null, non-finite or negative"):
+            _sample(df).glm.fit(y="api00", x=["ell"])
+
+    def test_single_level_categorical_is_reported_when_dropped(self, api):
+        df = api.with_columns(pl.lit("A").alias("g"))
+
+        with pytest.warns(UserWarning, match="fewer than 2 levels"):
+            model = _sample(df).glm.fit(y="api00", x=["ell", Cat("g")])
+
+        assert [c.term for c in model.fitted.coefs] == ["_intercept_", "ell"]


### PR DESCRIPTION
## Performance

The kernel is ~97% of a GLM fit; Python is the rest.

| 1e6 rows x 20 covariates, binomial logit | before | after |
|---|---|---|
| strata + PSU | 1.60 s | 0.51 s |
| weights only | 5.36 s | 0.42 s |
| `where=` domain | 1.22 s | 0.43 s |

- **`build_irls_normal_eqs`** — the row-outer Kahan loop became columns-outer over 256-row blocks of the column-major X, so the inner loop is a contiguous dot product that vectorizes, with `w * X_a` formed once per (block, column) rather than once per column pair. Blocks group into fixed 8192-row parallel chunks summed in index order, so the answer does not depend on the core count or on how rayon schedules the work. Kahan compensation is gone: R's `crossprod` is plain summation, and blocked f64 is ~1e-14 relative at 1e6 rows.
- **Sandwich meat** — a weights-only design makes every row a PSU, so `totals` was a million heap `Vec<Kahan>` behind a million-entry `HashMap`, walked k² times. With no PSU the centring telescopes (`sum (t-tbar)(t-tbar)' = sum t t' - m tbar tbar'`) into one weighted cross-product over all rows plus a k-vector per stratum. There is no cancellation to worry about: the score equations put `sum_i s_i x_ij` at zero, so a stratum's share of it is O(sqrt(m)) and the correction is ~1/m of the quadratic term. With real PSUs, one flat `m x k` buffer behind a dense slot table keyed on the PSU code.
- **Design codes** — the Python layer already passes dense integer code columns with the PSU code encoding the (stratum, psu) pair; the GLM kernel was casting them back to String and hashing `(&str, &str)` per row, ~0.4 s at 1e6. It now calls the estimation namespace's `design_col_codes` / `design_pair_codes`.
- **Redundant passes** — the loop's own recomputation already leaves eta/mu at the committed beta, so neither the next iteration nor the bread rebuild needs to redo them; the remaining pass is column-outer. `cols_to_vec` copies each chunk's value slice wholesale instead of iterating `Option<f64>` per element.

## Fits that were not fits

| input | before | after |
|---|---|---|
| empty `where` domain, or all-zero weights | all-zero coefficients, returned as a success | `ModelError` |
| `x` and `2 * x` | "fitted", SE 0 / NaN, F ~ 1e30 | `ModelError` naming `'x2'` |
| k >= n | SVD pseudoinverse | `ModelError` with n_obs and k |
| NaN / Inf in y, X or the offset | NaN beta (`f64::max` discards NaN) | error naming the column and row |
| a non-finite information matrix | panic (`thin_svd().unwrap()`) | error |
| a by-level that fails to fit | dropped silently | named |
| ran out of iterations | reported like a converged fit | warns |
| invalid weights dropped, single-level `Cat` dropped | silent | warns |
| the same predictor listed twice | polars "duplicate output name" | `ModelError` |

Rank deficiency is a pivot-free Cholesky of the first information matrix in the model's own column order — R's "the columns that came first are kept" rule, but raising rather than reporting NA coefficients, consistent with the rest of svy. The tolerance separates exact aliasing (~1e-16 of the column's own norm) from a genuinely collinear-but-distinct column (1e-6 at R² = 0.999999) by five orders either way.

## `where=` fits one domain

The predicate reaches the kernel as a Boolean mask through the new `where_col`, instead of a `"true"`/`"false"` by-column that fitted the complement too and threw it away. Estimates unchanged.

## Verification

Every R-parity test in `tests/svy/regression/` passes at its current tolerance, including the probit/cloglog classes at 1e-12. Full suite 3574 passed, 1 skipped. `make bench-check` shows no regression elsewhere; three GLM cases are added to the harness and to the recorded baseline.

Pre-existing and untouched: `benches/kernel_bench.rs` does not compile (a `srs_variance_mean` signature drift), so `cargo clippy --all-targets` fails on it.
