### PR TITLE
feat(glm): negative binomial, with the joint (beta, theta) design variance

### DIFF
--- a/packages/svy-rs/CHANGELOG.md
+++ b/packages/svy-rs/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 
 ### Added
 
+- **Negative binomial**, whole. `Family::NegativeBinomial(theta)` gives `Var(mu) = mu + mu^2/theta` with MASS's `initialize` (`y + (y == 0)/6`) and `dev.resids`; `regression::negbin` adds what a family arm cannot hold — `theta_ml` (Newton on the weighted profile likelihood, `MASS::theta.ml`), the `MASS::glm.nb` outer loop alternating it with IRLS, and the joint `(beta, theta)` design-based variance, which is R `survey::svymle`'s route. `fit_glm_rs` gains `theta` and returns `(theta, theta_se)`.
+
+- `regression::special` — `lgamma`, `digamma` and `trigamma`, written out because the crate carries no math dependency, the same reason `norm_cdf` is. Each recurs to `x >= 20` and then sums the asymptotic series; all three agree with R to 1e-14 relative over `[0.1, 1000]`, and the tests also check the recurrences across the switchover and trigamma against a numeric derivative of digamma.
+
+- `Link::mu_eta2` — the second derivative of the inverse link, which the negative binomial's joint bread needs. Arms for all nine links.
+
+- `design_vcov_rs` — the design-based variance-covariance of the totals of several already-weighted columns, R survey's `svyrecvar`. The GLM sandwich's meat and the negative binomial's joint variance both run through it.
+
 - `Link::Cauchit` and `Link::Sqrt`, mirroring R's `make.link`: cauchit clamps eta at `-qcauchy(.Machine$double.eps)` and computes `pcauchy` from `atan(1/x)` outside [-1, 1] (the naive `atan(x)/pi + 0.5` loses three and a half digits at x = -1000); sqrt is `eta^2` with `mu_eta = 2*eta`, and needs no `valideta` since the kernel does no step-halving.
 
 - - `converged` on `GlmResult`, and `where_col` on `fit_glm_rs`: a Boolean column marking a subpopulation, fitted as one domain. A `where=` clause used to be routed through `fit_glm_by` on a "true"/"false" string column, which fitted the complement as well and threw it away.
@@ -13,6 +21,8 @@ All notable changes to **svy_rs**, the internal Rust extension powering `svy`'s 
 - `domain_col` on `tabulate_rs`: a Boolean column marking the rows of a subpopulation. Out-of-domain rows keep their design columns and get weight 0 (R's `subset()` on a design), so the PSU structure is intact and `degrees_of_freedom` counts the units with an in-domain row; cells are formed from in-domain keys only (a null key outside the domain is not missing), and the Rao-Scott `n`, strata and PSU counts are taken over in-domain rows. `estimate_proportions`, `estimate_totals` and `count_strata_psus` gain the matching `domain` parameter.
 
 ### Changed
+
+- **`fit_glm_domain` takes `want_variance`.** The negative binomial's theta loop refits beta several times and needs nothing but the coefficients; the sandwich is the most expensive part of a fit. `fit_one` is the new single dispatch point over families.
 
 - **`Family::initial_mu` takes the row's prior weight** and returns R's `family$initialize` starting value: `(w y + 1/2)/(w + 1)` for binomial, `y + 0.1` for poisson, `y` elsewhere. The old binomial seed `(y + 1/2)/2` put IRLS on a different iterate path from R's, which on a flat deviance surface means stopping somewhere else — cloglog on apistrat ended 3e-5 from R's coefficients.
 

--- a/packages/svy-rs/src/lib.rs
+++ b/packages/svy-rs/src/lib.rs
@@ -88,6 +88,7 @@ fn _internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     )?)?;
     // GLM regression
     m.add_function(wrap_pyfunction!(regression::api::fit_glm_rs, m)?)?;
+    m.add_function(wrap_pyfunction!(regression::api::design_vcov_rs, m)?)?;
     // Categorical tests
     m.add_function(wrap_pyfunction!(categorical::api::ttest_rs, m)?)?;
     m.add_function(wrap_pyfunction!(categorical::api::ranktest_rs, m)?)?;

--- a/packages/svy-rs/src/regression/api.rs
+++ b/packages/svy-rs/src/regression/api.rs
@@ -4,7 +4,8 @@
 // The actual fitting logic lives in regression/glm.rs.
 //
 // Return shape: Vec<(level, params, cov_params, naive_cov, scale, df_resid,
-//                    deviance, null_deviance, iterations, n_obs, converged)>.
+//                    deviance, null_deviance, iterations, n_obs, converged,
+//                    (theta, theta_se) | None)>.
 // When neither by_col nor where_col is given, a single-element vec with
 // level="" is returned, so the Python side can treat every case uniformly.
 
@@ -13,7 +14,9 @@ use pyo3::prelude::*;
 use pyo3_polars::PyDataFrame;
 
 use crate::estimation::calib_sweep::{CalibSpec, CalibSweep, build_calib_sweep};
-use crate::regression::glm::{fit_glm, fit_glm_by, fit_glm_where};
+use crate::regression::glm::{
+    design_codes, design_vcov_of_totals, fit_glm, fit_glm_by, fit_glm_where,
+};
 
 type GlmTuple = (
     String,
@@ -27,6 +30,10 @@ type GlmTuple = (
     u32,
     usize,
     bool,
+    // (theta, theta_se) when the family has a dispersion parameter; theta_se
+    // is None when theta was supplied rather than estimated. One element
+    // rather than two because pyo3 only converts tuples up to twelve long.
+    Option<(f64, Option<f64>)>,
 );
 
 fn column_to_series(df: &DataFrame, name: &str) -> PyResult<Series> {
@@ -55,6 +62,7 @@ fn optional_column_to_series(df: &DataFrame, name: &Option<String>) -> PyResult<
     where_col=None,
     family="gaussian".to_string(),
     link="identity".to_string(),
+    theta=None,
     tol=1e-8,
     max_iter=100,
     data=None,
@@ -78,6 +86,7 @@ pub fn fit_glm_rs(
     where_col: Option<String>,
     family: String,
     link: String,
+    theta: Option<f64>,
     tol: f64,
     max_iter: usize,
     data: Option<PyDataFrame>,
@@ -140,6 +149,7 @@ pub fn fit_glm_rs(
                     &mask,
                     &family,
                     &link,
+                    theta,
                     tol,
                     max_iter,
                     calib,
@@ -159,6 +169,7 @@ pub fn fit_glm_rs(
             result.iterations,
             result.n_obs,
             result.converged,
+            result.theta.map(|t| (t, result.theta_se)),
         )]);
     }
 
@@ -177,6 +188,7 @@ pub fn fit_glm_rs(
                     offset.as_ref(),
                     &family,
                     &link,
+                    theta,
                     tol,
                     max_iter,
                     calib,
@@ -196,6 +208,7 @@ pub fn fit_glm_rs(
             result.iterations,
             result.n_obs,
             result.converged,
+            result.theta.map(|t| (t, result.theta_se)),
         )]);
     }
 
@@ -216,6 +229,7 @@ pub fn fit_glm_rs(
                 &by_series,
                 &family,
                 &link,
+                theta,
                 tol,
                 max_iter,
                 calib,
@@ -238,7 +252,99 @@ pub fn fit_glm_rs(
                 r.iterations,
                 r.n_obs,
                 r.converged,
+                r.theta.map(|t| (t, r.theta_se)),
             )
         })
         .collect())
+}
+
+/// Design-based variance-covariance of the totals of several already-weighted
+/// columns — R survey's `svyrecvar`.
+///
+/// Returns the full symmetric `p x p` matrix, row-major. The columns are
+/// influence functions, so the weights are already folded into them; this
+/// computes only the design part (PSU totals centred within stratum, the
+/// with-replacement factor, the stratum FPC).
+///
+/// The GLM sandwich uses the same code internally. It is exposed because the
+/// negative binomial's joint (theta, beta) variance is assembled on the Python
+/// side, where digamma and trigamma live — svy-rs carries no math dependency —
+/// and only this part belongs in the kernel.
+#[pyfunction]
+#[pyo3(signature = (data, value_cols, strata_col=None, psu_col=None, fpc_col=None))]
+pub fn design_vcov_rs(
+    _py: Python,
+    data: PyDataFrame,
+    value_cols: Vec<String>,
+    strata_col: Option<String>,
+    psu_col: Option<String>,
+    fpc_col: Option<String>,
+) -> PyResult<Vec<f64>> {
+    let df: DataFrame = data.into();
+    let n = df.height();
+    let p = value_cols.len();
+    if p == 0 {
+        return Ok(Vec::new());
+    }
+
+    let mut cols = vec![0.0f64; n * p];
+    for (j, name) in value_cols.iter().enumerate() {
+        let s = column_to_series(&df, name)?;
+        let cast = s
+            .cast(&DataType::Float64)
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        let ca = cast
+            .f64()
+            .map_err(|e| PyErr::new::<pyo3::exceptions::PyValueError, _>(e.to_string()))?;
+        for (i, v) in ca.iter().enumerate() {
+            cols[j * n + i] = v.unwrap_or(0.0);
+        }
+    }
+
+    let strata = optional_column_to_series(&df, &strata_col)?;
+    let psu = optional_column_to_series(&df, &psu_col)?;
+    let fpc = optional_column_to_series(&df, &fpc_col)?;
+
+    _py.detach(|| {
+        let (strata_idx, n_strata) = match strata {
+            Some(ref s) => design_codes(Some(s), None, n)?,
+            None => (vec![0usize; n], 1usize),
+        };
+        let (psu_idx, n_psu_levels) = match psu {
+            Some(ref pcol) => design_codes(strata.as_ref(), Some(pcol), n)?,
+            None => ((0..n).collect::<Vec<_>>(), n),
+        };
+
+        let mut strata_obs: Vec<Vec<usize>> = vec![Vec::new(); n_strata];
+        for i in 0..n {
+            strata_obs[strata_idx[i]].push(i);
+        }
+
+        let fpc_rows: Option<Vec<f64>> = match fpc {
+            Some(ref s) => {
+                let cast = s.cast(&DataType::Float64)?;
+                let ca = cast.f64()?;
+                Some(ca.iter().map(|v| v.unwrap_or(1.0)).collect())
+            }
+            None => None,
+        };
+
+        let psu_opt = if psu.is_some() {
+            Some(psu_idx.as_slice())
+        } else {
+            None
+        };
+
+        Ok(design_vcov_of_totals(
+            &cols,
+            n,
+            p,
+            &strata_idx,
+            &strata_obs,
+            psu_opt,
+            n_psu_levels,
+            fpc_rows.as_deref(),
+        ))
+    })
+    .map_err(|e: PolarsError| PyErr::new::<pyo3::exceptions::PyRuntimeError, _>(e.to_string()))
 }

--- a/packages/svy-rs/src/regression/glm.rs
+++ b/packages/svy-rs/src/regression/glm.rs
@@ -40,29 +40,51 @@ pub enum Family {
     Poisson,
     Gamma,
     InverseGaussian,
+    /// Negative binomial with a KNOWN dispersion: Var(mu) = mu + mu^2/theta.
+    ///
+    /// Estimating theta is the Python side's outer loop. It needs digamma and
+    /// trigamma, and this crate carries no math dependency; scipy is already a
+    /// dependency of `svy`, so the profile likelihood lives there and the
+    /// kernel only ever sees a fixed theta.
+    NegativeBinomial(f64),
 }
 
 impl Family {
-    pub fn from_str(s: &str) -> PolarsResult<Self> {
+    pub fn from_str(s: &str, theta: Option<f64>) -> PolarsResult<Self> {
         match s.to_lowercase().as_str() {
             "gaussian" => Ok(Family::Gaussian),
             "binomial" => Ok(Family::Binomial),
             "poisson" => Ok(Family::Poisson),
             "gamma" => Ok(Family::Gamma),
             "inversegaussian" | "inverse_gaussian" => Ok(Family::InverseGaussian),
+            "negativebinomial" | "negative_binomial" => {
+                let th = theta.ok_or_else(|| {
+                    PolarsError::ComputeError(
+                        "negative binomial needs its dispersion: pass theta".into(),
+                    )
+                })?;
+                if !(th.is_finite() && th > 0.0) {
+                    return Err(PolarsError::ComputeError(
+                        format!("negative binomial theta must be finite and positive, got {th}")
+                            .into(),
+                    ));
+                }
+                Ok(Family::NegativeBinomial(th))
+            }
             _ => Err(PolarsError::ComputeError(
                 format!("Unsupported family: {}", s).into(),
             )),
         }
     }
 
-    fn variance(&self, mu: f64) -> f64 {
+    pub(crate) fn variance(&self, mu: f64) -> f64 {
         match self {
             Family::Gaussian => 1.0,
             Family::Binomial => mu * (1.0 - mu),
             Family::Poisson => mu,
             Family::Gamma => mu * mu,
             Family::InverseGaussian => mu * mu * mu,
+            Family::NegativeBinomial(theta) => mu + mu * mu / theta,
         }
     }
 
@@ -80,6 +102,14 @@ impl Family {
             Family::Poisson => y + 0.1,
             Family::Gamma | Family::InverseGaussian => y.max(eps),
             Family::Gaussian => y,
+            // MASS::negative.binomial's initialize: y + (y == 0)/6.
+            Family::NegativeBinomial(_) => {
+                if y == 0.0 {
+                    1.0 / 6.0
+                } else {
+                    y
+                }
+            }
         }
     }
 
@@ -110,6 +140,12 @@ impl Family {
                 2.0 * (-(y_c / mu_c).ln() + (y - mu_c) / mu_c)
             }
             Family::InverseGaussian => (y - mu).powi(2) / (y.max(1e-10) * mu * mu),
+            // MASS::negative.binomial's dev.resids.
+            Family::NegativeBinomial(theta) => {
+                let mu_c = mu.max(1e-10);
+                2.0 * (y * (y.max(1.0) / mu_c).ln()
+                    - (y + theta) * ((y + theta) / (mu_c + theta)).ln())
+            }
         }
     }
 }
@@ -233,7 +269,7 @@ impl Link {
         }
     }
 
-    fn link(&self, mu: f64) -> f64 {
+    pub(crate) fn link(&self, mu: f64) -> f64 {
         match self {
             Link::Identity => mu,
             Link::Logit => (mu / (1.0 - mu)).ln(),
@@ -250,7 +286,7 @@ impl Link {
         }
     }
 
-    fn inverse(&self, eta: f64) -> f64 {
+    pub(crate) fn inverse(&self, eta: f64) -> f64 {
         match self {
             Link::Identity => eta,
             Link::Logit => {
@@ -281,8 +317,30 @@ impl Link {
         }
     }
 
+    /// d2μ/dη2 — only the negative binomial's joint (beta, theta) bread needs
+    /// it, and only for the links that family admits.
+    pub(crate) fn mu_eta2(&self, mu: f64, eta: f64) -> f64 {
+        match self {
+            Link::Identity => 0.0,
+            Link::Logit => mu * (1.0 - mu) * (1.0 - 2.0 * mu),
+            Link::Probit => -eta * norm_pdf(eta),
+            Link::Cauchit => {
+                let d = 1.0 + eta * eta;
+                -2.0 * eta / (std::f64::consts::PI * d * d)
+            }
+            Link::Cloglog => {
+                let e = eta.min(700.0).exp();
+                e * (-e).exp() * (1.0 - e)
+            }
+            Link::Log => mu,
+            Link::Sqrt => 2.0,
+            Link::Inverse => 2.0 * mu * mu * mu,
+            Link::InverseSquared => 0.75 * mu.powi(5),
+        }
+    }
+
     /// dμ/dη. Probit and cloglog are the arms that need eta rather than mu.
-    fn mu_eta(&self, mu: f64, eta: f64) -> f64 {
+    pub(crate) fn mu_eta(&self, mu: f64, eta: f64) -> f64 {
         match self {
             Link::Identity => 1.0,
             Link::Logit => mu * (1.0 - mu),
@@ -338,7 +396,7 @@ impl Kahan {
 ///
 /// Nulls are rejected upstream in `fit_glm_domain`, so each chunk's value
 /// slice is dense and copies wholesale.
-fn cols_to_vec(cols: &[&Float64Chunked], nrows: usize) -> Vec<f64> {
+pub(crate) fn cols_to_vec(cols: &[&Float64Chunked], nrows: usize) -> Vec<f64> {
     let mut out = vec![0.0; nrows * cols.len()];
     for (j, col) in cols.iter().enumerate() {
         let dst = &mut out[j * nrows..(j + 1) * nrows];
@@ -360,7 +418,7 @@ fn cols_to_vec(cols: &[&Float64Chunked], nrows: usize) -> Vec<f64> {
 ///
 /// Nulls arrive as `u32::MAX`; they are collected into one extra level so the
 /// code can index a `Vec` directly.
-fn design_codes(
+pub(crate) fn design_codes(
     strata: Option<&Series>,
     psu: Option<&Series>,
     n: usize,
@@ -575,6 +633,190 @@ fn solve_linear_system(A: MatRef<'_, f64>, b: MatRef<'_, f64>) -> Mat<f64> {
     x2
 }
 
+/// Per-stratum `(1 - f_h) * m/(m-1)`, zero where the stratum cannot contribute
+/// (a single PSU), which is how those rows are kept out of the accumulation.
+///
+/// Returns `(scale_h, psus_h)`.
+pub(crate) fn stratum_scales(
+    strata_obs: &[Vec<usize>],
+    psu_idx: Option<&[usize]>,
+    n_psu_levels: usize,
+    fpc_rows: Option<&[f64]>,
+) -> (Vec<f64>, Vec<usize>) {
+    let n_strata = strata_obs.len();
+    let mut psus_h = vec![0usize; n_strata];
+
+    match psu_idx {
+        // No PSU: every row is its own.
+        None => {
+            for h in 0..n_strata {
+                psus_h[h] = strata_obs[h].len();
+            }
+        }
+        Some(psu) => {
+            let mut seen = vec![false; n_psu_levels];
+            for h in 0..n_strata {
+                let mut m = 0usize;
+                for &i in &strata_obs[h] {
+                    if !seen[psu[i]] {
+                        seen[psu[i]] = true;
+                        m += 1;
+                    }
+                }
+                for &i in &strata_obs[h] {
+                    seen[psu[i]] = false;
+                }
+                psus_h[h] = m;
+            }
+        }
+    }
+
+    let mut scale_h = vec![0.0f64; n_strata];
+    for h in 0..n_strata {
+        let m = psus_h[h];
+        if m <= 1 {
+            continue;
+        }
+        let f = match fpc_rows {
+            Some(f) => strata_obs[h].first().map(|&i| f[i]).unwrap_or(1.0),
+            None => 1.0,
+        };
+        scale_h[h] = f * (m as f64) / ((m - 1) as f64);
+    }
+    (scale_h, psus_h)
+}
+
+/// Design-based variance-covariance of the totals of `p` already-weighted
+/// columns — R survey's `svyrecvar`.
+///
+/// `cols` is column-major, `n * p`. PSU totals are centred within stratum and
+/// scaled by `stratum_scales`. Returns the full symmetric `p * p` matrix,
+/// row-major.
+///
+/// The caller passes influence functions, not raw variables: the weights are
+/// already folded into the columns.
+pub(crate) fn design_vcov_of_totals(
+    cols: &[f64],
+    n: usize,
+    p: usize,
+    strata_idx: &[usize],
+    strata_obs: &[Vec<usize>],
+    psu_idx: Option<&[usize]>,
+    n_psu_levels: usize,
+    fpc_rows: Option<&[f64]>,
+) -> Vec<f64> {
+    let n_strata = strata_obs.len();
+    let (scale_h, psus_h) = stratum_scales(strata_obs, psu_idx, n_psu_levels, fpc_rows);
+    let mut upper = vec![0.0f64; p * p];
+
+    match psu_idx {
+        None => {
+            // Every row is its own PSU, so the stratum sums telescope:
+            //   sum_i (t_i - tbar)(t_i - tbar)' = sum_i t_i t_i' - m tbar tbar'.
+            let mut row_w = vec![0.0f64; n];
+            for i in 0..n {
+                row_w[i] = scale_h[strata_idx[i]];
+            }
+            let mut sums = vec![0.0f64; n_strata * p];
+            for j in 0..p {
+                let col = &cols[j * n..(j + 1) * n];
+                for i in 0..n {
+                    sums[strata_idx[i] * p + j] += col[i];
+                }
+            }
+            accumulate_weighted_crossprod(cols, &row_w, n, p, &mut upper);
+
+            for h in 0..n_strata {
+                let m = psus_h[h];
+                if m <= 1 {
+                    continue;
+                }
+                let c = scale_h[h] / (m as f64);
+                for a in 0..p {
+                    let sa = sums[h * p + a];
+                    for b in a..p {
+                        upper[a * p + b] -= c * sa * sums[h * p + b];
+                    }
+                }
+            }
+        }
+        Some(psu) => {
+            let mut slot = vec![usize::MAX; n_psu_levels];
+            let mut totals: Vec<f64> = Vec::new();
+            let mut used: Vec<usize> = Vec::new();
+            let mut mean = vec![0.0f64; p];
+            let mut local = vec![0.0f64; p * p];
+
+            for h in 0..n_strata {
+                totals.clear();
+                used.clear();
+
+                for &i in &strata_obs[h] {
+                    let pid = psu[i];
+                    let li = if slot[pid] == usize::MAX {
+                        let t = used.len();
+                        slot[pid] = t;
+                        used.push(pid);
+                        totals.resize(totals.len() + p, 0.0);
+                        t
+                    } else {
+                        slot[pid]
+                    };
+                    let base = li * p;
+                    for j in 0..p {
+                        totals[base + j] += cols[j * n + i];
+                    }
+                }
+
+                let m = used.len();
+                for &pid in &used {
+                    slot[pid] = usize::MAX;
+                }
+                if m <= 1 {
+                    continue;
+                }
+
+                mean.iter_mut().for_each(|v| *v = 0.0);
+                for li in 0..m {
+                    for j in 0..p {
+                        mean[j] += totals[li * p + j];
+                    }
+                }
+                for j in 0..p {
+                    mean[j] /= m as f64;
+                }
+
+                local.iter_mut().for_each(|v| *v = 0.0);
+                for li in 0..m {
+                    let base = li * p;
+                    for a in 0..p {
+                        let da = totals[base + a] - mean[a];
+                        for b in a..p {
+                            local[a * p + b] += da * (totals[base + b] - mean[b]);
+                        }
+                    }
+                }
+                for a in 0..p {
+                    for b in a..p {
+                        upper[a * p + b] += scale_h[h] * local[a * p + b];
+                    }
+                }
+            }
+        }
+    }
+
+    // Mirror the upper triangle: symmetric by construction.
+    let mut out = vec![0.0f64; p * p];
+    for a in 0..p {
+        for b in a..p {
+            let v = upper[a * p + b];
+            out[a * p + b] = v;
+            out[b * p + a] = v;
+        }
+    }
+    out
+}
+
 /// Refuse an aliased design matrix.
 ///
 /// A pivot-free Cholesky of XtWX in the model's own column order: column j is
@@ -637,7 +879,7 @@ fn check_rank(XtWX: &Mat<f64>, k: usize, cols: &[Series]) -> PolarsResult<()> {
 ///
 /// Returns an error rather than panicking when even the SVD fails: a single
 /// non-finite entry in the information matrix used to reach `thin_svd().unwrap()`.
-fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> PolarsResult<Mat<f64>> {
+pub(crate) fn invert_matrix(A: MatRef<'_, f64>, k: usize) -> PolarsResult<Mat<f64>> {
     if let Ok(chol) = A.llt(Side::Lower) {
         let mut inv = Mat::<f64>::identity(k, k);
         chol.solve_in_place(inv.as_mut());
@@ -698,6 +940,10 @@ pub struct GlmResult {
     pub n_obs: usize,
     /// Whether IRLS met the tolerance rather than exhausting `max_iter`.
     pub converged: bool,
+    /// Negative binomial dispersion, and its design-based standard error when
+    /// it was estimated rather than supplied. `None` for every other family.
+    pub theta: Option<f64>,
+    pub theta_se: Option<f64>,
 }
 
 // ============================================================================
@@ -719,8 +965,7 @@ fn null_deviance_with_offset(
     tol: f64,
     max_iter: usize,
 ) -> f64 {
-    let contributes =
-        |i: usize| domain_mask.map_or(true, |m| m[i]) && w_samp[i] > 0.0;
+    let contributes = |i: usize| domain_mask.map_or(true, |m| m[i]) && w_samp[i] > 0.0;
 
     let mut b = 0.0f64;
     let mut deviance = f64::INFINITY;
@@ -778,6 +1023,68 @@ fn null_deviance_with_offset(
     if deviance.is_finite() { deviance } else { 0.0 }
 }
 
+/// One fit, dispatching on the family.
+///
+/// Only the negative binomial has anything to do before IRLS: unless its
+/// dispersion was supplied it has to be estimated, and the variance then spans
+/// (beta, theta) rather than beta alone. Everything else goes straight to the
+/// IRLS solve.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fit_one(
+    y: &Series,
+    x_cols: Vec<Series>,
+    weights: &Series,
+    strata: Option<&Series>,
+    psu: Option<&Series>,
+    fpc: Option<&Series>,
+    offset: Option<&Series>,
+    domain_mask: Option<&[bool]>,
+    family_str: &str,
+    link_str: &str,
+    theta: Option<f64>,
+    tol: f64,
+    max_iter: usize,
+    calib: Option<&CalibSweep>,
+) -> PolarsResult<GlmResult> {
+    if matches!(
+        family_str.to_lowercase().as_str(),
+        "negativebinomial" | "negative_binomial"
+    ) {
+        return crate::regression::negbin::fit_negbin(
+            y,
+            x_cols,
+            weights,
+            strata,
+            psu,
+            fpc,
+            offset,
+            domain_mask,
+            link_str,
+            theta,
+            tol,
+            max_iter,
+            calib,
+        );
+    }
+    fit_glm_domain(
+        y,
+        x_cols,
+        weights,
+        strata,
+        psu,
+        fpc,
+        offset,
+        domain_mask,
+        family_str,
+        link_str,
+        theta,
+        tol,
+        max_iter,
+        calib,
+        true,
+    )
+}
+
 /// Full-sample GLM fit (no domain restriction).
 ///
 /// Equivalent to `fit_glm_domain(..., domain_mask=None)`. Kept as a thin
@@ -792,13 +1099,14 @@ pub fn fit_glm(
     offset: Option<&Series>,
     family_str: &str,
     link_str: &str,
+    theta: Option<f64>,
     tol: f64,
     max_iter: usize,
     calib: Option<&CalibSweep>,
 ) -> PolarsResult<GlmResult> {
-    fit_glm_domain(
-        y, x_cols, weights, strata, psu, fpc, offset, None, family_str, link_str, tol, max_iter,
-        calib,
+    fit_one(
+        y, x_cols, weights, strata, psu, fpc, offset, None, family_str, link_str, theta, tol,
+        max_iter, calib,
     )
 }
 
@@ -820,6 +1128,7 @@ pub fn fit_glm_where(
     mask: &Series,
     family_str: &str,
     link_str: &str,
+    theta: Option<f64>,
     tol: f64,
     max_iter: usize,
     calib: Option<&CalibSweep>,
@@ -828,7 +1137,7 @@ pub fn fit_glm_where(
     let ca = cast.bool()?;
     let mask_vec: Vec<bool> = ca.iter().map(|v| v.unwrap_or(false)).collect();
 
-    fit_glm_domain(
+    fit_one(
         y,
         x_cols,
         weights,
@@ -839,6 +1148,7 @@ pub fn fit_glm_where(
         Some(&mask_vec),
         family_str,
         link_str,
+        theta,
         tol,
         max_iter,
         calib,
@@ -863,6 +1173,7 @@ pub fn fit_glm_by(
     by_col: &Series,
     family_str: &str,
     link_str: &str,
+    theta: Option<f64>,
     tol: f64,
     max_iter: usize,
     calib: Option<&CalibSweep>,
@@ -888,7 +1199,7 @@ pub fn fit_glm_by(
             // are cheap reference-counted handles in polars; the clone copies
             // only the Vec, not the underlying data.
             let xs = x_cols.iter().cloned().collect();
-            let res = fit_glm_domain(
+            let res = fit_one(
                 y,
                 xs,
                 weights,
@@ -899,6 +1210,7 @@ pub fn fit_glm_by(
                 Some(&mask_vec),
                 family_str,
                 link_str,
+                theta,
                 tol,
                 max_iter,
                 calib,
@@ -946,7 +1258,7 @@ pub fn fit_glm_by(
 /// the original `fit_glm`. When `Some`, out-of-domain rows contribute 0 to
 /// both the IRLS loop and the sandwich meat, while the strata/PSU
 /// enumeration remains based on the full design.
-fn fit_glm_domain(
+pub(crate) fn fit_glm_domain(
     y: &Series,
     x_cols: Vec<Series>,
     weights: &Series,
@@ -957,11 +1269,13 @@ fn fit_glm_domain(
     domain_mask: Option<&[bool]>,
     family_str: &str,
     link_str: &str,
+    theta: Option<f64>,
     tol: f64,
     max_iter: usize,
     calib: Option<&CalibSweep>,
+    want_variance: bool,
 ) -> PolarsResult<GlmResult> {
-    let family = Family::from_str(family_str)?;
+    let family = Family::from_str(family_str, theta)?;
     let link = Link::from_str(link_str)?;
 
     // 1) Data prep
@@ -991,7 +1305,11 @@ fn fit_glm_domain(
     }
     if w_ca.null_count() > 0 {
         return Err(PolarsError::ComputeError(
-            format!("GLM weight column '{}' contains null values", weights.name()).into(),
+            format!(
+                "GLM weight column '{}' contains null values",
+                weights.name()
+            )
+            .into(),
         ));
     }
     for s in &x_cast {
@@ -1212,10 +1530,28 @@ fn fit_glm_domain(
     for j in 0..k {
         if !beta[(j, 0)].is_finite() {
             return Err(PolarsError::ComputeError(
-                "GLM did not produce finite coefficients (degenerate or non-convergent fit)"
-                    .into(),
+                "GLM did not produce finite coefficients (degenerate or non-convergent fit)".into(),
             ));
         }
+    }
+
+    // The negative binomial's theta loop refits beta several times and needs
+    // nothing else; the sandwich below is the most expensive part of a fit.
+    if !want_variance {
+        return Ok(GlmResult {
+            params: (0..k).map(|i| beta[(i, 0)]).collect(),
+            cov_params: Vec::new(),
+            naive_cov: Vec::new(),
+            scale: 1.0,
+            df_resid: 1.0,
+            deviance,
+            null_deviance: 0.0,
+            iterations: iter_count as u32,
+            n_obs,
+            converged,
+            theta: None,
+            theta_se: None,
+        });
     }
 
     // =========================================================================
@@ -1325,195 +1661,151 @@ fn fit_glm_domain(
     });
 
     // MEAT = sum_h Var_h( PSU totals ) with svytotal-style centering.
-    let mut meat_flat = vec![0.0f64; k * k]; // upper triangle
-
-    // Per-stratum with-replacement factor m/(m-1), times the stratum FPC
-    // (1 - f_h). Zero for a stratum that cannot contribute (a single PSU),
-    // which is how those rows are kept out of the accumulation below.
-    let mut scale_h = vec![0.0f64; n_strata];
-    let mut psus_h = vec![0usize; n_strata];
-
-    if psu.is_none() {
-        for h in 0..n_strata {
-            psus_h[h] = strata_obs[h].len();
-        }
+    //
+    // The calibrated path already has the influence functions materialised, so
+    // it hands them straight to the shared svyrecvar. The uncalibrated path
+    // does not materialise them: at 1e6 x 20 an n x k score matrix is 160 MB,
+    // and the PSU total of row i is just score_at(i) times its X row, so the
+    // same accumulation runs off X with the score folded into the row weight.
+    let psu_opt = if psu.is_some() {
+        Some(psu_idx.as_slice())
     } else {
-        let mut seen = vec![false; n_psu_levels];
-        for h in 0..n_strata {
-            let mut m = 0usize;
-            for &i in &strata_obs[h] {
-                if !seen[psu_idx[i]] {
-                    seen[psu_idx[i]] = true;
-                    m += 1;
-                }
-            }
-            for &i in &strata_obs[h] {
-                seen[psu_idx[i]] = false;
-            }
-            psus_h[h] = m;
-        }
-    }
-    for h in 0..n_strata {
-        let m = psus_h[h];
-        if m <= 1 {
-            continue;
-        }
-        let f = match &fpc_rows {
-            Some(f) => strata_obs[h].first().map(|&i| f[i]).unwrap_or(1.0),
-            None => 1.0,
-        };
-        scale_h[h] = f * (m as f64) / ((m - 1) as f64);
-    }
+        None
+    };
 
-    if psu.is_none() {
-        // Every row is its own PSU, so a PSU total IS that row's score
-        // contribution and the stratum sums telescope:
-        //   sum_i (t_i - tbar)(t_i - tbar)' = sum_i t_i t_i' - m tbar tbar'.
-        // The quadratic half is then one weighted cross-product over all rows
-        // (row weight = the row's stratum scale), and the correction needs
-        // only a k-vector per stratum. Materialising m x k PSU totals -- at
-        // 1e6 rows, a million heap vectors behind a million-entry hash map,
-        // walked k^2 times -- was the entire cost of a weights-only design.
-        //
-        // No cancellation to worry about: the score equations make the total
-        // sum_i s_i x_ij zero at the MLE, and a stratum's share of it is
-        // O(sqrt(m)), so the correction is ~1/m of the quadratic term.
-        let mut row_w = vec![0.0f64; n];
-        let mut sums = vec![0.0f64; n_strata * k];
-
-        match &ef {
-            Some(e) => {
-                for i in 0..n {
-                    row_w[i] = scale_h[strata_idx[i]];
-                }
-                for j in 0..k {
-                    let col = &e[j * n..(j + 1) * n];
-                    for i in 0..n {
-                        sums[strata_idx[i] * k + j] += col[i];
-                    }
-                }
-                accumulate_weighted_crossprod(e, &row_w, n, k, &mut meat_flat);
+    let meat_flat = match &ef {
+        Some(e) => design_vcov_of_totals(
+            e,
+            n,
+            k,
+            &strata_idx,
+            &strata_obs,
+            psu_opt,
+            n_psu_levels,
+            fpc_rows.as_deref(),
+        ),
+        None => {
+            let mut scores = vec![0.0f64; n];
+            for i in 0..n {
+                scores[i] = score_at(i);
             }
-            None => {
-                let mut scores = vec![0.0f64; n];
-                for i in 0..n {
-                    scores[i] = score_at(i);
-                }
+            let (scale_h, psus_h) =
+                stratum_scales(&strata_obs, psu_opt, n_psu_levels, fpc_rows.as_deref());
+            let mut upper = vec![0.0f64; k * k];
+
+            if psu.is_none() {
+                // Every row is its own PSU: the centred cross-product
+                // telescopes into one weighted pass over all rows plus a
+                // k-vector per stratum.
+                let mut row_w = vec![0.0f64; n];
                 for i in 0..n {
                     row_w[i] = scale_h[strata_idx[i]] * scores[i] * scores[i];
                 }
+                let mut sums = vec![0.0f64; n_strata * k];
                 for j in 0..k {
                     let col = &x[j * n..(j + 1) * n];
                     for i in 0..n {
                         sums[strata_idx[i] * k + j] += scores[i] * col[i];
                     }
                 }
-                accumulate_weighted_crossprod(&x, &row_w, n, k, &mut meat_flat);
-            }
-        }
+                accumulate_weighted_crossprod(&x, &row_w, n, k, &mut upper);
 
-        for h in 0..n_strata {
-            let m = psus_h[h];
-            if m <= 1 {
-                continue;
-            }
-            let c = scale_h[h] / (m as f64);
-            for a in 0..k {
-                let sa = sums[h * k + a];
-                for b in a..k {
-                    meat_flat[a * k + b] -= c * sa * sums[h * k + b];
-                }
-            }
-        }
-    } else {
-        // Real PSUs: one flat m x k totals buffer per stratum, addressed
-        // through a dense slot table indexed by the (already 0-based) PSU
-        // code, in place of a per-stratum HashMap and m heap vectors.
-        let mut slot = vec![usize::MAX; n_psu_levels];
-        let mut totals: Vec<f64> = Vec::new();
-        let mut used: Vec<usize> = Vec::new();
-        let mut mean = vec![0.0f64; k];
-        let mut local = vec![0.0f64; k * k];
-
-        for h in 0..n_strata {
-            totals.clear();
-            used.clear();
-
-            for &i in &strata_obs[h] {
-                let pid = psu_idx[i];
-                let li = if slot[pid] == usize::MAX {
-                    let t = used.len();
-                    slot[pid] = t;
-                    used.push(pid);
-                    totals.resize(totals.len() + k, 0.0);
-                    t
-                } else {
-                    slot[pid]
-                };
-
-                let base = li * k;
-                match &ef {
-                    Some(e) => {
-                        for j in 0..k {
-                            totals[base + j] += e[j * n + i];
+                for h in 0..n_strata {
+                    let m = psus_h[h];
+                    if m <= 1 {
+                        continue;
+                    }
+                    let c = scale_h[h] / (m as f64);
+                    for a in 0..k {
+                        let sa = sums[h * k + a];
+                        for b in a..k {
+                            upper[a * k + b] -= c * sa * sums[h * k + b];
                         }
                     }
-                    None => {
-                        let s_i = score_at(i);
+                }
+            } else {
+                let mut slot = vec![usize::MAX; n_psu_levels];
+                let mut totals: Vec<f64> = Vec::new();
+                let mut used: Vec<usize> = Vec::new();
+                let mut mean = vec![0.0f64; k];
+                let mut local = vec![0.0f64; k * k];
+
+                for h in 0..n_strata {
+                    totals.clear();
+                    used.clear();
+
+                    for &i in &strata_obs[h] {
+                        let pid = psu_idx[i];
+                        let li = if slot[pid] == usize::MAX {
+                            let t = used.len();
+                            slot[pid] = t;
+                            used.push(pid);
+                            totals.resize(totals.len() + k, 0.0);
+                            t
+                        } else {
+                            slot[pid]
+                        };
+                        let s_i = scores[i];
                         if s_i != 0.0 {
+                            let base = li * k;
                             for j in 0..k {
                                 totals[base + j] += s_i * x[j * n + i];
                             }
                         }
                     }
-                }
-            }
 
-            let m = used.len();
-            for &pid in &used {
-                slot[pid] = usize::MAX;
-            }
-            if m <= 1 {
-                continue;
-            }
+                    let m = used.len();
+                    for &pid in &used {
+                        slot[pid] = usize::MAX;
+                    }
+                    if m <= 1 {
+                        continue;
+                    }
 
-            // mean-center PSU totals in stratum
-            mean.iter_mut().for_each(|v| *v = 0.0);
-            for li in 0..m {
-                for j in 0..k {
-                    mean[j] += totals[li * k + j];
-                }
-            }
-            for j in 0..k {
-                mean[j] /= m as f64;
-            }
+                    mean.iter_mut().for_each(|v| *v = 0.0);
+                    for li in 0..m {
+                        for j in 0..k {
+                            mean[j] += totals[li * k + j];
+                        }
+                    }
+                    for j in 0..k {
+                        mean[j] /= m as f64;
+                    }
 
-            local.iter_mut().for_each(|v| *v = 0.0);
-            for li in 0..m {
-                let base = li * k;
-                for a in 0..k {
-                    let da = totals[base + a] - mean[a];
-                    for b in a..k {
-                        local[a * k + b] += da * (totals[base + b] - mean[b]);
+                    local.iter_mut().for_each(|v| *v = 0.0);
+                    for li in 0..m {
+                        let base = li * k;
+                        for a in 0..k {
+                            let da = totals[base + a] - mean[a];
+                            for b in a..k {
+                                local[a * k + b] += da * (totals[base + b] - mean[b]);
+                            }
+                        }
+                    }
+                    for a in 0..k {
+                        for b in a..k {
+                            upper[a * k + b] += scale_h[h] * local[a * k + b];
+                        }
                     }
                 }
             }
+
+            let mut out = vec![0.0f64; k * k];
             for a in 0..k {
                 for b in a..k {
-                    meat_flat[a * k + b] += scale_h[h] * local[a * k + b];
+                    let v = upper[a * k + b];
+                    out[a * k + b] = v;
+                    out[b * k + a] = v;
                 }
             }
+            out
         }
-    }
+    };
 
-    // materialize meat (symmetric by construction: only the upper triangle
-    // was accumulated)
     let mut meat = Mat::<f64>::zeros(k, k);
     for a in 0..k {
-        for b in a..k {
-            let v = meat_flat[a * k + b];
-            meat[(a, b)] = v;
-            meat[(b, a)] = v;
+        for b in 0..k {
+            meat[(a, b)] = meat_flat[a * k + b];
         }
     }
 
@@ -1669,6 +1961,8 @@ fn fit_glm_domain(
         iterations: iter_count as u32,
         n_obs,
         converged,
+        theta: None,
+        theta_se: None,
     })
 }
 

--- a/packages/svy-rs/src/regression/mod.rs
+++ b/packages/svy-rs/src/regression/mod.rs
@@ -1,4 +1,6 @@
 // src/regression/mod.rs
 pub mod api;
 pub mod glm;
+pub mod negbin;
+pub mod special;
 pub mod wols;

--- a/packages/svy-rs/src/regression/negbin.rs
+++ b/packages/svy-rs/src/regression/negbin.rs
@@ -1,0 +1,452 @@
+// src/regression/negbin.rs
+//
+// The negative binomial's dispersion, and the joint (beta, theta) variance.
+//
+// The family arm in glm.rs fits beta by IRLS at a KNOWN theta, which is all a
+// family can do — theta is a second parameter, not a property of the mean.
+// This module adds the two things that need:
+//
+//   * `theta_ml`, Newton on the weighted profile likelihood (MASS::theta.ml),
+//     driven by an outer loop that alternates with the IRLS the way
+//     MASS::glm.nb does. The pair it converges to is the joint MLE.
+//
+//   * the design-based variance over BOTH parameters, which is R survey's
+//     `svymle` route — the method Lumley gives for this model in *Complex
+//     Surveys* (Appendix E) and what `sjstats::svyglm.nb` implements.
+//     Conditioning on theta-hat instead is the cheaper composition of
+//     `glm.nb` with `svyglm`, and it is a different number: on apistrat the
+//     two run from 25% under to 13% over each other. The orthogonality that
+//     makes them agree asymptotically is a property of the model, and a
+//     design-based sandwich is the thing that declines to assume it.
+//
+// The log-likelihood, dropping terms free of (mu, theta):
+//
+//   l = lgamma(theta + y) - lgamma(theta) - lgamma(y + 1)
+//       + theta log theta + y log mu - (theta + y) log(theta + mu)
+
+use faer::Mat;
+use polars::prelude::*;
+
+use crate::estimation::calib_sweep::CalibSweep;
+use crate::regression::glm::{
+    GlmResult, Link, design_codes, design_vcov_of_totals, fit_glm_domain, invert_matrix,
+};
+use crate::regression::special::{digamma, lgamma, trigamma};
+
+/// The identity and sqrt links can push mu to zero, and y/mu is the first
+/// thing the score does.
+const MU_FLOOR: f64 = 1e-10;
+
+fn contributing(w: f64) -> bool {
+    w > 0.0
+}
+
+/// The weighted log-likelihood.
+fn loglik(y: &[f64], mu: &[f64], theta: f64, w: &[f64]) -> f64 {
+    let mut total = 0.0;
+    for i in 0..y.len() {
+        if !contributing(w[i]) {
+            continue;
+        }
+        let m = mu[i].max(MU_FLOOR);
+        let yi = y[i];
+        total += w[i]
+            * (lgamma(theta + yi) - lgamma(theta) - lgamma(yi + 1.0)
+                + theta * theta.ln()
+                + yi * (m + if yi == 0.0 { 1.0 } else { 0.0 }).ln()
+                - (theta + yi) * (theta + m).ln());
+    }
+    total
+}
+
+/// (score, observed information) of the profile likelihood in theta.
+fn theta_score_info(y: &[f64], mu: &[f64], theta: f64, w: &[f64]) -> (f64, f64) {
+    let dg_theta = digamma(theta);
+    let tg_theta = trigamma(theta);
+    let mut score = 0.0;
+    let mut info = 0.0;
+    for i in 0..y.len() {
+        if !contributing(w[i]) {
+            continue;
+        }
+        let m = mu[i].max(MU_FLOOR);
+        let yi = y[i];
+        let tm = theta + m;
+        score += w[i]
+            * (digamma(theta + yi) - dg_theta + theta.ln() + 1.0 - tm.ln() - (yi + theta) / tm);
+        info += w[i]
+            * (-trigamma(theta + yi) + tg_theta - 1.0 / theta + 2.0 / tm
+                - (yi + theta) / (tm * tm));
+    }
+    (score, info)
+}
+
+/// Maximum-likelihood theta at fixed mu — `MASS::theta.ml`.
+///
+/// Newton from the method-of-moments start `sum(w) / sum(w (y/mu - 1)^2)`.
+/// Scale-invariant in the weights: a global factor cancels out of the root.
+fn theta_ml(y: &[f64], mu: &[f64], w: &[f64], eps: f64, limit: usize) -> PolarsResult<f64> {
+    let mut w_sum = 0.0;
+    let mut denom = 0.0;
+    for i in 0..y.len() {
+        if !contributing(w[i]) {
+            continue;
+        }
+        let r = y[i] / mu[i].max(MU_FLOOR) - 1.0;
+        w_sum += w[i];
+        denom += w[i] * r * r;
+    }
+    if !(denom > 0.0) {
+        return Err(PolarsError::ComputeError(
+            "negative binomial: the Pearson statistic is zero, so theta has no \
+             moment estimate — the response does not vary around the fitted mean"
+                .into(),
+        ));
+    }
+
+    let mut t = w_sum / denom;
+    let mut delta: f64 = 1.0;
+    for _ in 0..limit {
+        if delta.abs() <= eps {
+            break;
+        }
+        t = t.abs();
+        let (score, info) = theta_score_info(y, mu, t, w);
+        if info == 0.0 || !info.is_finite() {
+            break;
+        }
+        delta = score / info;
+        t += delta;
+    }
+
+    if !(t.is_finite() && t > 0.0) {
+        return Err(PolarsError::ComputeError(
+            format!(
+                "negative binomial: the profile likelihood in theta reached {t}. \
+                 The counts are probably not overdispersed — fit family='poisson', \
+                 or pass theta to fit at a known value."
+            )
+            .into(),
+        ));
+    }
+    Ok(t)
+}
+
+/// Fit the negative binomial, estimating theta unless it is given.
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn fit_negbin(
+    y: &Series,
+    x_cols: Vec<Series>,
+    weights: &Series,
+    strata: Option<&Series>,
+    psu: Option<&Series>,
+    fpc: Option<&Series>,
+    offset: Option<&Series>,
+    domain_mask: Option<&[bool]>,
+    link_str: &str,
+    theta: Option<f64>,
+    tol: f64,
+    max_iter: usize,
+    calib: Option<&CalibSweep>,
+) -> PolarsResult<GlmResult> {
+    let fit_at = |family: &str, th: Option<f64>, want_variance: bool| {
+        fit_glm_domain(
+            y,
+            x_cols.clone(),
+            weights,
+            strata,
+            psu,
+            fpc,
+            offset,
+            domain_mask,
+            family,
+            link_str,
+            th,
+            tol,
+            max_iter,
+            calib,
+            want_variance,
+        )
+    };
+
+    // A theta the caller knows is not a parameter: the ordinary sandwich,
+    // which holds it fixed, is the right variance and there is no row to
+    // report a standard error for.
+    if let Some(th) = theta {
+        let mut result = fit_at("negativebinomial", Some(th), true)?;
+        result.theta = Some(th);
+        return Ok(result);
+    }
+
+    let link = Link::from_str(link_str)?;
+    let n = y.len();
+    let k = x_cols.len();
+
+    // The same materialisation fit_glm_domain does, needed again here for the
+    // profile likelihood and the joint bread.
+    let (y_vals, x, w, offset_vals) = materialise(y, &x_cols, weights, offset, domain_mask, n, k)?;
+
+    let eps = tol.max(1e-14);
+    let mu_of = |beta: &[f64]| -> Vec<f64> {
+        let mut mu = vec![0.0; n];
+        for i in 0..n {
+            let mut eta = offset_vals[i];
+            for (j, &b) in beta.iter().enumerate() {
+                eta += x[j * n + i] * b;
+            }
+            mu[i] = link.inverse(eta);
+        }
+        mu
+    };
+
+    // R seeds theta from a Poisson fit, the theta -> infinity limit.
+    let mut mu = mu_of(&fit_at("poisson", None, false)?.params);
+    let mut theta = theta_ml(&y_vals, &mu, &w, eps, max_iter)?;
+
+    // MASS::glm.nb's alternation, with its convergence test made relative —
+    // the weighted log-likelihood here is O(1e4), so its own rounding is
+    // ~1e-10 and an absolute test could never reach a tol of 1e-12 however
+    // converged theta is.
+    let mut delta: f64 = 1.0;
+    let mut ll = loglik(&y_vals, &mu, theta, &w);
+    let mut ll_prev = ll + 2.0 * ll.abs().max(1.0);
+    let mut settled = false;
+
+    for _ in 0..max_iter {
+        if (ll_prev - ll).abs() / (0.1 + ll.abs()) + delta.abs() / (0.1 + theta.abs()) <= tol {
+            settled = true;
+            break;
+        }
+        mu = mu_of(&fit_at("negativebinomial", Some(theta), false)?.params);
+        let prev = theta;
+        theta = theta_ml(&y_vals, &mu, &w, eps, max_iter)?;
+        delta = prev - theta;
+        ll_prev = ll;
+        ll = loglik(&y_vals, &mu, theta, &w);
+    }
+
+    let mut result = fit_at("negativebinomial", Some(theta), true)?;
+
+    let (cov, theta_se) = joint_vcov(
+        &y_vals,
+        &x,
+        &w,
+        &offset_vals,
+        &result.params,
+        theta,
+        link,
+        n,
+        k,
+        strata,
+        psu,
+        fpc,
+    )?;
+
+    // The kernel's own sandwich conditions on theta; this one does not.
+    result.cov_params = cov;
+    result.theta = Some(theta);
+    result.theta_se = Some(theta_se);
+    result.converged = result.converged && settled;
+    Ok(result)
+}
+
+/// y, X (column-major), the contributing-row weights, and the offset.
+fn materialise(
+    y: &Series,
+    x_cols: &[Series],
+    weights: &Series,
+    offset: Option<&Series>,
+    domain_mask: Option<&[bool]>,
+    n: usize,
+    k: usize,
+) -> PolarsResult<(Vec<f64>, Vec<f64>, Vec<f64>, Vec<f64>)> {
+    let y_cast = y.cast(&DataType::Float64)?;
+    let y_vals: Vec<f64> = y_cast.f64()?.iter().map(|v| v.unwrap_or(0.0)).collect();
+
+    let mut x = vec![0.0; n * k];
+    for (j, s) in x_cols.iter().enumerate() {
+        let cast = s.cast(&DataType::Float64)?;
+        for (i, v) in cast.f64()?.iter().enumerate() {
+            x[j * n + i] = v.unwrap_or(0.0);
+        }
+    }
+
+    // Out-of-domain and non-positive-weight rows carry no information, but
+    // stay in the frame: the design structure is the full design's.
+    let w_cast = weights.cast(&DataType::Float64)?;
+    let w: Vec<f64> = w_cast
+        .f64()?
+        .iter()
+        .enumerate()
+        .map(|(i, v)| {
+            let wi = v.unwrap_or(0.0);
+            if domain_mask.is_none_or(|m| m[i]) && wi > 0.0 {
+                wi
+            } else {
+                0.0
+            }
+        })
+        .collect();
+
+    let offset_vals = match offset {
+        Some(s) => {
+            let cast = s.cast(&DataType::Float64)?;
+            cast.f64()?.iter().map(|v| v.unwrap_or(0.0)).collect()
+        }
+        None => vec![0.0; n],
+    };
+
+    Ok((y_vals, x, w, offset_vals))
+}
+
+/// The joint (beta, theta) design variance: `svyrecvar(scores %*% -H^-1)`.
+///
+/// Returns the beta block, row-major k*k, and the standard error of theta.
+#[allow(clippy::too_many_arguments)]
+fn joint_vcov(
+    y: &[f64],
+    x: &[f64],
+    w: &[f64],
+    offset_vals: &[f64],
+    beta: &[f64],
+    theta: f64,
+    link: Link,
+    n: usize,
+    k: usize,
+    strata: Option<&Series>,
+    psu: Option<&Series>,
+    fpc: Option<&Series>,
+) -> PolarsResult<(Vec<f64>, f64)> {
+    let p = k + 1;
+    let dg_theta = digamma(theta);
+    let tg_theta = trigamma(theta);
+
+    // Per-row score and second-derivative pieces.
+    let mut s_eta = vec![0.0; n]; // w dl/deta
+    let mut s_theta = vec![0.0; n]; // w dl/dtheta
+    let mut h_eta = vec![0.0; n]; // w d2l/deta2
+    let mut h_cross = vec![0.0; n]; // w d2l/deta dtheta
+    let mut h_theta = 0.0; // sum w d2l/dtheta2
+
+    for i in 0..n {
+        if !contributing(w[i]) {
+            continue;
+        }
+        let mut eta = offset_vals[i];
+        for (j, &b) in beta.iter().enumerate() {
+            eta += x[j * n + i] * b;
+        }
+        let mu = link.inverse(eta).max(MU_FLOOR);
+        let yi = y[i];
+        let tm = theta + mu;
+        let ty = theta + yi;
+
+        let dl_dmu = yi / mu - ty / tm;
+        let d2l_dmu2 = -yi / (mu * mu) + ty / (tm * tm);
+        let d2l_dmu_dtheta = (yi - mu) / (tm * tm);
+
+        let mu_eta = link.mu_eta(mu, eta);
+        let mu_eta2 = link.mu_eta2(mu, eta);
+
+        s_eta[i] = w[i] * dl_dmu * mu_eta;
+        s_theta[i] = w[i] * (digamma(ty) - dg_theta + theta.ln() + 1.0 - tm.ln() - ty / tm);
+        h_eta[i] = w[i] * (d2l_dmu2 * mu_eta * mu_eta + dl_dmu * mu_eta2);
+        h_cross[i] = w[i] * d2l_dmu_dtheta * mu_eta;
+
+        let d2l_dtheta2 = trigamma(ty) - tg_theta + 1.0 / theta - 2.0 / tm + ty / (tm * tm);
+        if d2l_dtheta2.is_finite() {
+            h_theta += w[i] * d2l_dtheta2;
+        }
+    }
+
+    // Bread = -H of the weighted log-likelihood, ordered [beta..., theta].
+    let mut bread = Mat::<f64>::zeros(p, p);
+    for a in 0..k {
+        let xa = &x[a * n..(a + 1) * n];
+        for b in a..k {
+            let xb = &x[b * n..(b + 1) * n];
+            let mut acc = 0.0;
+            for i in 0..n {
+                acc += h_eta[i] * xa[i] * xb[i];
+            }
+            bread[(a, b)] = -acc;
+            bread[(b, a)] = -acc;
+        }
+        let mut cross = 0.0;
+        for i in 0..n {
+            cross += h_cross[i] * xa[i];
+        }
+        bread[(a, k)] = -cross;
+        bread[(k, a)] = -cross;
+    }
+    bread[(k, k)] = -h_theta;
+
+    let a_inv = invert_matrix(bread.as_ref(), p)?;
+
+    // Influence functions, column-major n x p.
+    let mut influence = vec![0.0; n * p];
+    for col in 0..p {
+        let dst_off = col * n;
+        for a in 0..k {
+            let coef = a_inv[(a, col)];
+            if coef == 0.0 {
+                continue;
+            }
+            let xa = &x[a * n..(a + 1) * n];
+            for i in 0..n {
+                influence[dst_off + i] += s_eta[i] * xa[i] * coef;
+            }
+        }
+        let coef = a_inv[(k, col)];
+        if coef != 0.0 {
+            for i in 0..n {
+                influence[dst_off + i] += s_theta[i] * coef;
+            }
+        }
+    }
+
+    // Design variance of the column totals.
+    let (strata_idx, n_strata) = match strata {
+        Some(_) => design_codes(strata, None, n)?,
+        None => (vec![0usize; n], 1usize),
+    };
+    let (psu_idx, n_psu_levels) = match psu {
+        Some(_) => design_codes(strata, psu, n)?,
+        None => ((0..n).collect::<Vec<_>>(), n),
+    };
+    let mut strata_obs: Vec<Vec<usize>> = vec![Vec::new(); n_strata];
+    for i in 0..n {
+        strata_obs[strata_idx[i]].push(i);
+    }
+    let fpc_rows: Option<Vec<f64>> = match fpc {
+        Some(s) => {
+            let cast = s.cast(&DataType::Float64)?;
+            Some(cast.f64()?.iter().map(|v| v.unwrap_or(1.0)).collect())
+        }
+        None => None,
+    };
+    let psu_opt = if psu.is_some() {
+        Some(psu_idx.as_slice())
+    } else {
+        None
+    };
+
+    let vcov = design_vcov_of_totals(
+        &influence,
+        n,
+        p,
+        &strata_idx,
+        &strata_obs,
+        psu_opt,
+        n_psu_levels,
+        fpc_rows.as_deref(),
+    );
+
+    let mut beta_block = vec![0.0; k * k];
+    for a in 0..k {
+        for b in 0..k {
+            beta_block[a * k + b] = vcov[a * p + b];
+        }
+    }
+    Ok((beta_block, vcov[k * p + k].max(0.0).sqrt()))
+}

--- a/packages/svy-rs/src/regression/special.rs
+++ b/packages/svy-rs/src/regression/special.rs
@@ -1,0 +1,213 @@
+// src/regression/special.rs
+//
+// lgamma, digamma and trigamma.
+//
+// The crate carries no math dependency on purpose, so these are written out
+// the way `norm_cdf` is in regression/glm.rs — and, like it, are checked
+// against R to ~1e-14 relative in the tests below. The negative binomial needs
+// all three: the profile likelihood in theta is digamma, its information is
+// trigamma, and the log-likelihood itself is lgamma.
+//
+// Each uses the same shape: recur up to where the asymptotic series is good,
+// then sum it.
+
+use std::f64::consts::PI;
+
+/// Where digamma and trigamma switch from the recurrence to the asymptotic
+/// series. High enough that the first dropped term is below f64 resolution;
+/// the recurrence costs at most twenty divisions.
+const ASYMPTOTIC_FROM: f64 = 20.0;
+
+/// Lanczos coefficients, g = 7, n = 9 — the usual set, good to ~1e-15.
+const LANCZOS: [f64; 9] = [
+    0.999_999_999_999_809_93,
+    676.520_368_121_885_1,
+    -1259.139_216_722_402_8,
+    771.323_428_777_653_13,
+    -176.615_029_162_140_6,
+    12.507_343_278_686_905,
+    -0.138_571_095_265_720_12,
+    9.984_369_578_019_572e-6,
+    1.505_632_735_149_311_6e-7,
+];
+
+/// log |Gamma(x)|, for x > 0.
+pub fn lgamma(x: f64) -> f64 {
+    if x < 0.5 {
+        // Reflection: Gamma(x) Gamma(1-x) = pi / sin(pi x).
+        return (PI / (PI * x).sin()).abs().ln() - lgamma(1.0 - x);
+    }
+    let x = x - 1.0;
+    let mut a = LANCZOS[0];
+    let t = x + 7.5;
+    for (i, &c) in LANCZOS.iter().enumerate().skip(1) {
+        a += c / (x + i as f64);
+    }
+    0.5 * (2.0 * PI).ln() + (x + 0.5) * t.ln() - t + a.ln()
+}
+
+/// The digamma function, psi(x) = d/dx log Gamma(x), for x > 0.
+pub fn digamma(mut x: f64) -> f64 {
+    let mut result = 0.0;
+
+    // Recur up to the threshold with psi(x) = psi(x+1) - 1/x. At x >= 20 the
+    // first term the series below drops is ~5e-18 relative, which is what
+    // buys the 1e-14 agreement with R asserted in the tests.
+    while x < ASYMPTOTIC_FROM {
+        result -= 1.0 / x;
+        x += 1.0;
+    }
+
+    // psi(x) ~ ln x - 1/(2x) - sum_n B_2n / (2n x^2n)
+    let inv = 1.0 / x;
+    let inv2 = inv * inv;
+    result += x.ln() - 0.5 * inv;
+    result -= inv2
+        * (1.0 / 12.0
+            - inv2
+                * (1.0 / 120.0
+                    - inv2
+                        * (1.0 / 252.0
+                            - inv2
+                                * (1.0 / 240.0
+                                    - inv2 * (1.0 / 132.0 - inv2 * (691.0 / 32760.0))))));
+    result
+}
+
+/// The trigamma function, psi'(x), for x > 0.
+pub fn trigamma(mut x: f64) -> f64 {
+    let mut result = 0.0;
+
+    // psi'(x) = psi'(x+1) + 1/x^2.
+    while x < ASYMPTOTIC_FROM {
+        result += 1.0 / (x * x);
+        x += 1.0;
+    }
+
+    // psi'(x) ~ 1/x + 1/(2x^2) + sum_n B_2n / x^(2n+1)
+    let inv = 1.0 / x;
+    let inv2 = inv * inv;
+    result += inv
+        * (1.0
+            + 0.5 * inv
+            + inv2
+                * (1.0 / 6.0
+                    - inv2
+                        * (1.0 / 30.0
+                            - inv2 * (1.0 / 42.0 - inv2 * (1.0 / 30.0 - inv2 * (5.0 / 66.0))))));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// R, at 17 significant digits.
+    const DIGAMMA: [(f64, f64); 14] = [
+        (0.1, -10.423754940411076),
+        (0.5, -1.9635100260214231),
+        (1.0, -0.57721566490153231),
+        (1.5, 0.036489973978576895),
+        (2.0, 0.42278433509846747),
+        (2.5, 0.70315664064524341),
+        (3.0, 0.92278433509846747),
+        (5.0, 1.5061176684318007),
+        (6.0, 1.7061176684318007),
+        (7.0, 1.8727843350984674),
+        (10.0, 2.2517525890667214),
+        (50.0, 3.901989673427892),
+        (200.0, 5.2958152832199117),
+        (1000.0, 6.907255195648812),
+    ];
+
+    const TRIGAMMA: [(f64, f64); 14] = [
+        (0.1, 101.43329915079275),
+        (0.5, 4.934802200544679),
+        (1.0, 1.6449340668482264),
+        (1.5, 0.93480220054467933),
+        (2.0, 0.64493406684822641),
+        (2.5, 0.49035775610023491),
+        (3.0, 0.39493406684822635),
+        (5.0, 0.22132295573711527),
+        (6.0, 0.18132295573711527),
+        (7.0, 0.1535451779593375),
+        (10.0, 0.10516633568168572),
+        (50.0, 0.020201333226697128),
+        (200.0, 0.00501252083322917),
+        (1000.0, 0.0010005001666666335),
+    ];
+
+    const LGAMMA: [(f64, f64); 14] = [
+        (0.1, 2.252712651734206),
+        (0.5, 0.57236494292470008),
+        (1.0, 0.0),
+        (1.5, -0.12078223763524518),
+        (2.0, 0.0),
+        (2.5, 0.28468287047291918),
+        (3.0, 0.69314718055994529),
+        (5.0, 3.1780538303479458),
+        (6.0, 4.7874917427820458),
+        (7.0, 6.5792512120101012),
+        (10.0, 12.801827480081469),
+        (50.0, 144.56574394634487),
+        (200.0, 857.93366982585746),
+        (1000.0, 5905.2204232091808),
+    ];
+
+    fn check(name: &str, cases: &[(f64, f64)], f: impl Fn(f64) -> f64, tol: f64) {
+        for &(x, want) in cases {
+            let got = f(x);
+            let err = (got - want).abs() / want.abs().max(1e-300);
+            assert!(
+                err <= tol || (got - want).abs() < 1e-15,
+                "{name}({x}): got {got:.17e}, want {want:.17e} (rel {err:.2e})"
+            );
+        }
+    }
+
+    #[test]
+    fn digamma_matches_r() {
+        check("digamma", &DIGAMMA, digamma, 1e-14);
+    }
+
+    #[test]
+    fn trigamma_matches_r() {
+        check("trigamma", &TRIGAMMA, trigamma, 1e-14);
+    }
+
+    #[test]
+    fn lgamma_matches_r() {
+        check("lgamma", &LGAMMA, lgamma, 1e-14);
+    }
+
+    /// psi(x+1) - psi(x) = 1/x, and psi'(x) - psi'(x+1) = 1/x^2, across the
+    /// recurrence boundary the implementations use.
+    #[test]
+    fn recurrences_hold_across_the_boundary() {
+        for x in [0.3, 1.0, 2.7, 5.5, 5.999, 6.0, 6.001, 9.0, 40.0] {
+            assert!(
+                (digamma(x + 1.0) - digamma(x) - 1.0 / x).abs() < 1e-13,
+                "digamma recurrence at {x}"
+            );
+            assert!(
+                (trigamma(x) - trigamma(x + 1.0) - 1.0 / (x * x)).abs() < 1e-13,
+                "trigamma recurrence at {x}"
+            );
+            assert!(
+                (lgamma(x + 1.0) - lgamma(x) - x.ln()).abs() < 1e-12,
+                "lgamma recurrence at {x}"
+            );
+        }
+    }
+
+    /// trigamma is the derivative of digamma.
+    #[test]
+    fn trigamma_matches_a_numeric_derivative_of_digamma() {
+        let h = 1e-6;
+        for x in [1.0, 2.0, 4.0, 8.0, 20.0] {
+            let numeric = (digamma(x + h) - digamma(x - h)) / (2.0 * h);
+            let rel = (trigamma(x) - numeric).abs() / trigamma(x);
+            assert!(rel < 1e-7, "trigamma at {x}: {} vs {numeric}", trigamma(x));
+        }
+    }
+}

--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -8,6 +8,21 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ### Added
 
+- **Negative binomial**, for counts a Poisson cannot hold. `family="negative_binomial"` (or `"nb"`), with `Var(mu) = mu + mu^2/theta` and R's `okLinks` — `log`, `identity`, `sqrt`.
+
+  ```python
+  m = sample.glm.fit(y="visits", x=["age", svy.Cat("region")], family="nb")
+  m.fitted.stats.theta, m.fitted.stats.theta_se
+  ```
+
+  Left to itself, theta is estimated by maximum likelihood alongside the coefficients and the standard errors come from the **joint `(coefficients, theta)` design-based sandwich** — `survey::svymle` over the negative binomial likelihood, the method in Lumley's *Complex Surveys* (Appendix E) and what `sjstats::svyglm.nb` implements. `stats.theta_se` is the design-based standard error of the dispersion itself.
+
+  Pass `theta=` and it is treated as known: no row for it, and the variance conditions on it, matching `svyglm(family = MASS::negative.binomial(theta))`. These are different numbers, not two routes to one — on `apistrat` the joint standard errors run from 25% under to 13% over the conditional ones, and on Lumley's own NHANES example 2% under to 12% over. The orthogonality that makes them agree asymptotically is a property of the model, and a design-based sandwich is the thing that declines to assume it.
+
+  On a replicate-weight design an estimated theta raises: the spread of the refits would only mean something if every replicate re-estimated it. Pass `theta=` there.
+
+  All of it is in the kernel, like every other family — the dispersion loop and the joint variance included. That needed digamma, trigamma and lgamma written out in `svy-rs`, for the same reason `norm_cdf` already was.
+
 - **`cauchit` and `sqrt` links.** Binomial gains `cauchit` — the inverse Cauchy CDF, the heavy-tailed alternative to probit, so a few observations far out on the linear predictor cannot dominate the fit — and Poisson gains `sqrt`, the variance-stabilising link for counts. `FAMILY_LINKS` is now exactly R's `okLinks` for every family, with no links R has that svy does not. Both refuse `exponentiate=`: exp(β) is not a ratio on either.
 
   ```python

--- a/packages/svy/scripts/gen_r_reference.R
+++ b/packages/svy/scripts/gen_r_reference.R
@@ -53,3 +53,69 @@ emit("binomial cauchit", quasibinomial("cauchit"), y_bin ~ ell + meals + mobilit
 emit("binomial cloglog", quasibinomial("cloglog"), y_bin ~ ell + meals + mobility)
 emit("poisson sqrt", quasipoisson("sqrt"), enroll ~ ell + meals + mobility)
 emit("inversegaussian 1/mu^2", inverse.gaussian(link = "1/mu^2"), y_pos ~ ell + meals + mobility)
+
+# ---------------------------------------------------------------------------
+# Negative binomial.
+#
+# There is no negative binomial in survey itself. The design-based fit is
+# survey::svymle over the joint (theta, beta) likelihood — the method Lumley
+# gives in *Complex Surveys* (Appendix E, p254ff) and what sjstats::svyglm.nb
+# implements. The four functions below are sjstats', reproduced so this script
+# needs only survey and MASS.
+# ---------------------------------------------------------------------------
+
+nb_loglik <- function(y, theta, eta) {
+  mu <- exp(eta)
+  lgamma(theta + y) - lgamma(theta) - lgamma(y + 1) + theta * log(theta) +
+    y * log(mu + (y == 0)) - (theta + y) * log(theta + mu)
+}
+nb_deta <- function(y, theta, eta) {
+  mu <- exp(eta)
+  (y / mu - (theta + y) / (theta + mu)) * mu
+}
+nb_dtheta <- function(y, theta, eta) {
+  mu <- exp(eta)
+  digamma(theta + y) - digamma(theta) + log(theta) + 1 - log(theta + mu) -
+    (y + theta) / (mu + theta)
+}
+nb_score <- function(y, theta, eta) {
+  cbind(nb_dtheta(y, theta, eta), nb_deta(y, theta, eta))
+}
+
+emit_nb <- function(form) {
+  for (nm in names(designs)) {
+    des <- designs[[nm]]
+    dw <- weights(des)
+    des <- update(des, scaled.weights = dw / mean(dw, na.rm = TRUE))
+    m <- MASS::glm.nb(form, data = model.frame(des), weights = scaled.weights,
+                      control = glm.control(epsilon = 1e-12, maxit = 100))
+    f <- svymle(loglike = nb_loglik, grad = nb_score, design = des,
+                formulas = list(theta = ~1, eta = form),
+                start = c(m$theta, coef(m)), na.action = "na.omit")
+    est <- coef(f)
+    se <- sqrt(diag(vcov(f)))
+    cat(sprintf("## negative binomial log / %s\n", nm))
+    cat("theta   ", sprintf("%.17g", est[1]), "\n")
+    cat("theta_se", sprintf("%.17g", se[1]), "\n")
+    cat("beta ", vec(est[-1]), "\n")
+    cat("se   ", vec(se[-1]), "\n\n")
+  }
+}
+
+emit_nb(enroll ~ ell + meals + mobility)
+
+# Fixed theta: an ordinary svyglm with MASS's family object, so the variance
+# conditions on theta rather than carrying a row for it.
+emit_nb_fixed <- function(form, theta) {
+  for (nm in names(designs)) {
+    f <- svyglm(form, designs[[nm]], family = MASS::negative.binomial(theta),
+                control = glm.control(epsilon = 1e-12, maxit = 100))
+    s <- summary(f)$coefficients
+    cat(sprintf("## negative binomial fixed theta=%g / %s\n", theta, nm))
+    cat("beta ", vec(coef(f)), "\n")
+    cat("se   ", vec(s[, 2]), "\n")
+    cat(sprintf("df    %d\n\n", df.residual(f)))
+  }
+}
+
+emit_nb_fixed(enroll ~ ell + meals + mobility, 2.5)

--- a/packages/svy/src/svy/core/enumerations.py
+++ b/packages/svy/src/svy/core/enumerations.py
@@ -19,8 +19,8 @@ class DistFamily(StrEnum):
     POISSON = "Poisson"
     GAMMA = "Gamma"
     INVERSE_GAUSSIAN = "InverseGaussian"
+    NEGATIVE_BINOMIAL = "NegativeBinomial"
     # Phase 2:
-    # NEG_BINOMIAL = "Negative Binomial"
     # BETA = "Beta"
 
 

--- a/packages/svy/src/svy/regression/base.py
+++ b/packages/svy/src/svy/regression/base.py
@@ -48,7 +48,16 @@ log = logging.getLogger(__name__)
 # spelled out in the Literal — the union is what keeps the two arguments
 # symmetric for a type checker.
 FamilyArg = (
-    Literal["gaussian", "binomial", "poisson", "gamma", "inversegaussian", "inverse_gaussian"]
+    Literal[
+        "gaussian",
+        "binomial",
+        "poisson",
+        "gamma",
+        "inversegaussian",
+        "inverse_gaussian",
+        "negativebinomial",
+        "negative_binomial",
+    ]
     | DistFamily
 )
 LinkArg = (
@@ -66,7 +75,9 @@ LinkArg = (
     | LinkFunction
 )
 
-_FAMILY_NAMES = "'gaussian', 'binomial', 'poisson', 'gamma', or 'inverse_gaussian'"
+_FAMILY_NAMES = (
+    "'gaussian', 'binomial', 'poisson', 'gamma', 'inverse_gaussian', or 'negative_binomial'"
+)
 _LINK_NAMES = (
     "'identity', 'logit', 'probit', 'cauchit', 'cloglog', 'log', 'sqrt', "
     "'inverse', or 'inverse_squared'"
@@ -104,6 +115,21 @@ _ENGINE_ERRORS: tuple[tuple[str, str, str], ...] = (
         "NON_FINITE_INPUT",
         "Replace the infinite or NaN entries, or drop those rows.",
     ),
+    (
+        "theta must be finite and positive",
+        "NB_THETA_INVALID",
+        "Omit theta= to estimate the dispersion from the data.",
+    ),
+    (
+        "Pearson statistic is zero",
+        "NB_THETA_UNDEFINED",
+        "Check the response, or pass theta= to fit at a known value.",
+    ),
+    (
+        "profile likelihood in theta",
+        "NB_THETA_DIVERGED",
+        "Fit family='poisson', or pass theta= to fit at a known value.",
+    ),
 )
 
 
@@ -132,6 +158,7 @@ def _normalize_family(family: FamilyArg) -> str:
       - "poisson"
       - "gamma"
       - "inverse_gaussian" / "inversegaussian"
+      - "negative_binomial" / "negativebinomial" / "nb"
     """
     _MAP = {
         "gaussian": "gaussian",
@@ -140,6 +167,9 @@ def _normalize_family(family: FamilyArg) -> str:
         "gamma": "gamma",
         "inversegaussian": "inversegaussian",
         "inverse_gaussian": "inversegaussian",
+        "negativebinomial": "negativebinomial",
+        "negative_binomial": "negativebinomial",
+        "nb": "negativebinomial",
     }
     if not isinstance(family, str):
         raise TypeError(
@@ -315,6 +345,7 @@ class GLM:
         intercept: bool = True,
         family: FamilyArg = "gaussian",
         link: LinkArg | None = None,
+        theta: float | None = None,
         offset: str | None = None,
         where: WhereArg = None,
         drop_nulls: bool = True,
@@ -335,7 +366,7 @@ class GLM:
             Include intercept term.
         family : str
             Distribution family: ``'gaussian'``, ``'binomial'``, ``'poisson'``,
-            ``'gamma'``, or ``'inverse_gaussian'``.
+            ``'gamma'``, ``'inverse_gaussian'``, or ``'negative_binomial'``.
         link : str, optional
             Link function: ``'identity'``, ``'logit'``, ``'probit'``,
             ``'cauchit'``, ``'cloglog'``, ``'log'``, ``'sqrt'``, ``'inverse'``,
@@ -343,6 +374,22 @@ class GLM:
             family. Each family admits exactly the links R's family objects do,
             so an unusable pairing raises rather than fitting (see
             ``FAMILY_LINKS``).
+        theta : float, optional
+            Negative binomial dispersion, ``Var(mu) = mu + mu^2/theta``. Only
+            meaningful for ``family='negative_binomial'``.
+
+            Left out, theta is estimated by maximum likelihood alongside the
+            coefficients, and the reported standard errors come from the joint
+            ``(coefficients, theta)`` design-based sandwich — R
+            ``survey::svymle`` over the negative binomial likelihood, the
+            method in Lumley's *Complex Surveys* (Appendix E). ``stats.theta``
+            and ``stats.theta_se`` carry the estimate.
+
+            Supplied, theta is treated as known: there is no row for it, the
+            variance conditions on it (matching
+            ``svyglm(family = MASS::negative.binomial(theta))``), and
+            ``stats.theta_se`` is None. The two are materially different
+            numbers, not two routes to the same one.
         offset : str, optional
             Column holding a known term on the *link* scale, entered with its
             coefficient fixed at 1. The usual use is a rate model: Poisson
@@ -671,7 +718,13 @@ class GLM:
         # ── Call Rust ─────────────────────────────────────────────────────
         # Always returns Vec<(level, ...)> with one entry per by-level, or a
         # single entry with level="" when by_col is None.
-        def _run_engine(weight_name: str, fpc: str | None):
+        def _run_engine(
+            weight_name: str,
+            fpc: str | None,
+            *,
+            family_name: str | None = None,
+            theta_val: float | None = None,
+        ):
             res = rs.fit_glm_rs(
                 y_name=y,
                 x_names=feature_names,
@@ -681,8 +734,9 @@ class GLM:
                 fpc_name=fpc,
                 offset_name=offset,
                 where_col=dom_col,
-                family=fam_str,
+                family=family_name or fam_str,
                 link=link_str,
+                theta=theta_val if theta_val is not None else theta,
                 tol=tol,
                 max_iter=max_iter,
                 data=eng_df,
@@ -698,7 +752,10 @@ class GLM:
             mapped = _as_model_error(e)
             if mapped is not None:
                 raise mapped from e
-            if isinstance(e, RuntimeError):
+            # A ModelError from the negative binomial path is already the
+            # message the caller needs; only an unrecognised failure gets
+            # wrapped.
+            if isinstance(e, (RuntimeError, ModelError)):
                 raise
             raise RuntimeError(f"Rust GLM engine failed: {e}") from e
 
@@ -714,6 +771,7 @@ class GLM:
             iters,
             n_obs,
             converged,
+            dispersion,
         ) = chosen
 
         # ── Post-process ──────────────────────────────────────────────────
@@ -769,6 +827,19 @@ class GLM:
         # with the method's coefficients (previously the replicate design
         # silently fell back to Taylor SEs).
         rep_wgts = design0.rep_wgts
+        if rep_wgts is not None and rep_cols and dispersion is not None and theta is None:
+            raise ModelError(
+                title="Replicate variance needs a known dispersion",
+                detail=(
+                    "On a replicate-weight design the negative binomial's theta "
+                    "would have to be re-estimated inside every replicate for the "
+                    "spread of the refits to mean anything, and it is not. Pass "
+                    "theta= to fit every replicate at a known dispersion."
+                ),
+                code="NB_REPLICATE_THETA",
+                where="GLM.fit",
+                hint="Estimate theta once on the full sample, then pass it.",
+            )
         if rep_wgts is not None and rep_cols:
             rep_betas = []
             for rc in rep_cols:
@@ -844,6 +915,11 @@ class GLM:
             cov_mat,
             aic_val,
         )
+        if dispersion is not None:
+            theta_hat, theta_se = dispersion
+            stats_struct = msgspec.structs.replace(
+                stats_struct, theta=theta_hat, theta_se=theta_se
+            )
 
         # Coefficients
         t_crit = stats.t.ppf(1 - alpha / 2, df_design)
@@ -1133,7 +1209,7 @@ class GLM:
             raise ModelError.domain_violation(
                 where="GLM.fit", family=family, violation="Non-positive values"
             )
-        elif family == "poisson" and y_data.min() < 0:  # type: ignore[operator]
+        elif family in ("poisson", "negativebinomial") and y_data.min() < 0:  # type: ignore[operator]
             raise ModelError.domain_violation(
                 where="GLM.fit", family=family, violation="Negative values"
             )

--- a/packages/svy/src/svy/regression/glm.py
+++ b/packages/svy/src/svy/regression/glm.py
@@ -101,6 +101,10 @@ class GLMStats(msgspec.Struct, frozen=True):
     r_squared: float | None = None
     r_squared_adj: float | None = None
     iterations: int | None = None
+    #: Negative binomial dispersion: Var(mu) = mu + mu^2/theta. `theta_se` is
+    #: design-based, from the joint (coefficients, theta) sandwich.
+    theta: float | None = None
+    theta_se: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         return msgspec.to_builtins(self)
@@ -300,6 +304,10 @@ class GLMFit(msgspec.Struct, frozen=True):
             ("DF Residuals", str(df_resid), "BIC", _fmt_smart(st.bic)),
             ("Deviance", _fmt_smart(st.deviance), "Scale", _fmt_smart(st.scale)),
         ]
+        if st.theta is not None:
+            stats_rows.append(
+                ("Theta", _fmt_smart(st.theta), "SE(theta)", _fmt_smart(st.theta_se))
+            )
         if st.r_squared is not None:
             stats_rows.append(
                 (
@@ -413,6 +421,8 @@ class GLMFit(msgspec.Struct, frozen=True):
             _row("Deviance", _fmt_smart(st.deviance), "Scale", _fmt_smart(st.scale)),
             _row("AIC", _fmt_smart(st.aic), "BIC", _fmt_smart(st.bic)),
         ]
+        if st.theta is not None:
+            lines.append(_row("Theta", _fmt_smart(st.theta), "SE(theta)", _fmt_smart(st.theta_se)))
         if st.r_squared is not None:
             lines.append(
                 _row(

--- a/packages/svy/src/svy/regression/links.py
+++ b/packages/svy/src/svy/regression/links.py
@@ -164,6 +164,7 @@ DEFAULT_LINKS: dict[str, str] = {
     "poisson": "log",
     "gamma": "inverse",
     "inversegaussian": "inverse_squared",
+    "negativebinomial": "log",
 }
 
 
@@ -175,6 +176,7 @@ FAMILY_LABELS: dict[str, str] = {
     "poisson": "Poisson",
     "gamma": "Gamma",
     "inversegaussian": "InverseGaussian",
+    "negativebinomial": "NegativeBinomial",
 }
 
 
@@ -192,6 +194,8 @@ FAMILY_LINKS: dict[str, frozenset[str]] = {
     "poisson": frozenset({"log", "identity", "sqrt"}),
     "gamma": frozenset({"inverse", "identity", "log"}),
     "inversegaussian": frozenset({"inverse_squared", "inverse", "identity", "log"}),
+    # MASS::negative.binomial's okLinks.
+    "negativebinomial": frozenset({"log", "identity", "sqrt"}),
 }
 
 

--- a/packages/svy/tests/svy/regression/test_glm_against_rsurvey.py
+++ b/packages/svy/tests/svy/regression/test_glm_against_rsurvey.py
@@ -1009,6 +1009,8 @@ class TestFamilyLinkCompatibility:
         "poisson": {"log", "identity", "sqrt"},
         "gamma": {"inverse", "log", "identity"},
         "inversegaussian": {"inverse", "log", "identity", "inverse_squared"},
+        # MASS::negative.binomial's okLinks.
+        "negativebinomial": {"log", "identity", "sqrt"},
     }
 
     def test_table_matches_r(self):

--- a/packages/svy/tests/svy/regression/test_glm_negative_binomial.py
+++ b/packages/svy/tests/svy/regression/test_glm_negative_binomial.py
@@ -1,0 +1,374 @@
+# tests/svy/regression/test_glm_negative_binomial.py
+"""
+Negative binomial, against R.
+
+There is no negative binomial in `survey` itself, so the reference depends on
+whether the dispersion is estimated or known — and so does what svy computes.
+
+* **theta estimated.** theta is a parameter, so the variance is the joint
+  (coefficients, theta) sandwich: `survey::svymle` over the negative binomial
+  likelihood, which is the method Lumley gives in *Complex Surveys*
+  (Appendix E, p254ff) and what `sjstats::svyglm.nb` implements. svy reports a
+  design-based standard error for theta alongside.
+
+* **theta supplied.** theta is known, not estimated, so there is no row for it
+  and the variance conditions on it — an ordinary
+  `svyglm(family = MASS::negative.binomial(theta))`, and `stats.theta_se` is
+  None.
+
+The two are not interchangeable. On the model below the joint standard errors
+run from 25% under to 13% over the conditional ones.
+
+All references come from survey 4.5 / MASS 7.3-65 at `epsilon = 1e-12`, via
+scripts/gen_r_reference.R.
+"""
+
+from pathlib import Path
+
+import numpy as np
+import polars as pl
+import pytest
+
+import svy
+
+from svy.core.sample import Design, RepWeights, Sample
+from svy.errors.model_errors import ModelError
+
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "test_data"
+
+X_COLS = ["ell", "meals", "mobility"]
+Y = "enroll"
+TOL_TIGHT = 1e-12
+
+# Both sides converge to the joint optimum to ~1e-8; `svymle` polishes with
+# optim, svy with coordinate ascent, and the log-likelihoods at the two points
+# differ by 1.2e-14 relative. Same bar as the rest of the R-parity suite.
+RTOL = 1e-6
+ATOL = 1e-6
+
+
+@pytest.fixture
+def api():
+    return pl.read_csv(DATA_DIR / "apistrat.csv")
+
+
+DESIGNS = {
+    "weights_only": Design(wgt="pw"),
+    "psu_only": Design(wgt="pw", psu="dnum"),
+    "stratified": Design(wgt="pw", stratum="stype"),
+    "psu_stratified": Design(wgt="pw", stratum="stype", psu="dnum"),
+}
+
+# ---------------------------------------------------------------------------
+# theta estimated: survey::svymle over (theta, beta)
+# ---------------------------------------------------------------------------
+
+JOINT_BETA = np.array(
+    [
+        6.4104037649499466,
+        0.0020814251367638681,
+        -0.0019666487480131138,
+        0.0014604152986345562,
+    ]
+)
+JOINT_THETA = 2.7135545330416027
+
+# design -> (theta_se, se, df)
+JOINT = {
+    "weights_only": (
+        0.2399070291580481,
+        [
+            0.093016749035377044,
+            0.0030115602630177256,
+            0.0024071298974609212,
+            0.0029125103645788273,
+        ],
+        196,
+    ),
+    "psu_only": (
+        0.26724295802662734,
+        [
+            0.092906788671465609,
+            0.0026490554271487382,
+            0.0022991311056829813,
+            0.0029953033257325095,
+        ],
+        131,
+    ),
+    "stratified": (
+        0.21524208287373212,
+        [
+            0.079782145946012087,
+            0.003013177317689057,
+            0.0023962885351251914,
+            0.0029221725287920742,
+        ],
+        194,
+    ),
+    "psu_stratified": (
+        0.24371486363874204,
+        [
+            0.090228493595899392,
+            0.0032049080839025388,
+            0.0025383731623479827,
+            0.0029094560930737019,
+        ],
+        156,
+    ),
+}
+
+
+class TestJointAgainstSvymle:
+    @pytest.mark.parametrize("design", sorted(JOINT))
+    def test_matches_r(self, api, design):
+        res = Sample(api, DESIGNS[design]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT, max_iter=100
+        )
+        theta_se_r, se_r, df_r = JOINT[design]
+
+        np.testing.assert_allclose([c.est for c in res.coefs], JOINT_BETA, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose([c.se for c in res.coefs], se_r, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(res.stats.theta, JOINT_THETA, rtol=RTOL, atol=ATOL)
+        np.testing.assert_allclose(res.stats.theta_se, theta_se_r, rtol=RTOL, atol=ATOL)
+        assert res.coefs[0].wald.df == df_r
+
+    def test_theta_matches_mass_glm_nb(self, api):
+        """`MASS::glm.nb` on the same rows, prior weights pw/mean(pw)."""
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT, max_iter=100
+        )
+
+        # glm.nb stops at theta.ml's default eps, which leaves theta good to
+        # ~1e-8; svymle polishes it to the value asserted above.
+        np.testing.assert_allclose(res.stats.theta, 2.71355451164479, rtol=1e-7)
+
+    def test_the_dispersion_is_reported(self, api):
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT
+        )
+
+        assert res.stats.theta is not None
+        assert res.stats.theta_se is not None
+        assert res.stats.theta_se > 0
+
+
+# ---------------------------------------------------------------------------
+# theta known: svyglm(family = MASS::negative.binomial(2.5))
+# ---------------------------------------------------------------------------
+
+FIXED_THETA = 2.5
+FIXED_BETA = np.array(
+    [
+        6.4104046222622895,
+        0.0020815048969284886,
+        -0.0019666695801718597,
+        0.0014603179082650361,
+    ]
+)
+FIXED_SE = {
+    "weights_only": [
+        0.10030019390752351,
+        0.002654244057929734,
+        0.0023823643448716222,
+        0.0039050028379986491,
+    ],
+    "psu_only": [
+        0.098661407131972009,
+        0.002306713511613111,
+        0.0023429762220112016,
+        0.0040170333938916126,
+    ],
+    "stratified": [
+        0.08742494248860623,
+        0.0026557857696118499,
+        0.0023702494903620362,
+        0.0039176480495443531,
+    ],
+    "psu_stratified": [
+        0.098348957568028375,
+        0.0028293803444440096,
+        0.0025004248132958415,
+        0.003898654058209639,
+    ],
+}
+
+
+class TestFixedThetaAgainstSvyglm:
+    @pytest.mark.parametrize("design", sorted(FIXED_SE))
+    def test_matches_r(self, api, design):
+        res = Sample(api, DESIGNS[design]).glm.fit(
+            y=Y,
+            x=X_COLS,
+            family="negative_binomial",
+            theta=FIXED_THETA,
+            tol=TOL_TIGHT,
+            max_iter=100,
+        )
+
+        np.testing.assert_allclose([c.est for c in res.coefs], FIXED_BETA, rtol=1e-9, atol=1e-9)
+        np.testing.assert_allclose(
+            [c.se for c in res.coefs], FIXED_SE[design], rtol=1e-8, atol=1e-8
+        )
+
+    def test_a_known_theta_has_no_standard_error(self, api):
+        """It is not estimated, so there is nothing to put an interval on."""
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", theta=FIXED_THETA, tol=TOL_TIGHT
+        )
+
+        assert res.stats.theta == FIXED_THETA
+        assert res.stats.theta_se is None
+
+    def test_the_two_routes_disagree_materially(self, api):
+        """
+        The whole reason svy carries the joint sandwich: conditioning on
+        theta-hat is not a cheaper way to get the same answer.
+        """
+        sample = Sample(api, DESIGNS["weights_only"])
+        joint = sample.glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT, max_iter=100
+        )
+        conditional = sample.glm.fit(
+            y=Y,
+            x=X_COLS,
+            family="negative_binomial",
+            theta=joint.stats.theta,
+            tol=TOL_TIGHT,
+        )
+
+        ratio = np.array([c.se for c in joint.coefs]) / np.array([c.se for c in conditional.coefs])
+        np.testing.assert_allclose(
+            [c.est for c in joint.coefs], [c.est for c in conditional.coefs], rtol=1e-9
+        )
+        assert ratio.min() < 0.8, ratio
+        assert ratio.max() > 1.1, ratio
+
+
+# ---------------------------------------------------------------------------
+# Behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestOverdispersion:
+    def test_wider_intervals_than_poisson(self, api):
+        """Poisson pins the dispersion at 1; these counts are nowhere near it."""
+        sample = Sample(api, DESIGNS["weights_only"])
+        nb = sample.glm.fit(y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT)
+        pois = sample.glm.fit(y=Y, x=X_COLS, family="poisson", tol=TOL_TIGHT)
+
+        assert pois.stats.scale > 100
+        assert nb.stats.scale < 5
+        assert nb.stats.theta < 10
+
+    def test_the_dispersion_is_near_one_on_its_own_scale(self, api):
+        """Pearson/(n-k) under V(mu) = mu + mu^2/theta, so ~1 when NB fits."""
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT
+        )
+
+        assert 0.5 < res.stats.scale < 2.0
+
+
+class TestApi:
+    def test_family_aliases(self, api):
+        sample = Sample(api, DESIGNS["weights_only"])
+        thetas = [
+            sample.glm.fit(y=Y, x=X_COLS, family=name, tol=TOL_TIGHT).stats.theta
+            for name in ("negative_binomial", "negativebinomial", "nb")
+        ]
+
+        assert thetas[0] == thetas[1] == thetas[2]
+
+    @pytest.mark.parametrize("link", ["log", "identity", "sqrt"])
+    def test_admitted_links(self, api, link):
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", link=link, tol=1e-10
+        )
+
+        assert res.fitted.link == link
+
+    def test_refuses_a_link_r_does_not(self, api):
+        with pytest.raises(ValueError, match="does not admit"):
+            Sample(api, DESIGNS["weights_only"]).glm.fit(
+                y=Y, x=X_COLS, family="negative_binomial", link="logit"
+            )
+
+    def test_exponentiated_coefficients_are_rate_ratios(self, api):
+        res = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT
+        )
+
+        assert "rate_ratio" in res.fitted.to_polars(exponentiate=True).columns
+
+
+class TestRefusals:
+    def test_negative_counts(self, api):
+        df = api.with_columns((pl.col("enroll") - 500).alias("bad"))
+
+        with pytest.raises(ModelError, match="Negative values"):
+            Sample(df, DESIGNS["weights_only"]).glm.fit(
+                y="bad", x=X_COLS, family="negative_binomial"
+            )
+
+    @pytest.mark.parametrize("bad", [0.0, -1.0, float("inf"), float("nan")])
+    def test_invalid_theta(self, api, bad):
+        with pytest.raises(ModelError, match="finite and positive"):
+            Sample(api, DESIGNS["weights_only"]).glm.fit(
+                y=Y, x=X_COLS, family="negative_binomial", theta=bad
+            )
+
+    def test_replicate_weights_need_a_known_theta(self, api):
+        """
+        The spread of replicate refits only means something if each replicate
+        re-estimates theta, and none of them does.
+        """
+        df = api.with_columns(
+            [(pl.col("pw") * (1.0 + 0.01 * i)).alias(f"rep_{i}") for i in range(1, 21)]
+        )
+        design = Design(
+            wgt="pw",
+            stratum="stype",
+            psu="dnum",
+            rep_wgts=RepWeights(method="Bootstrap", prefix="rep_", n_reps=20),
+        )
+
+        with pytest.raises(ModelError, match="known dispersion"):
+            Sample(df, design).glm.fit(y=Y, x=X_COLS, family="negative_binomial")
+
+    def test_replicate_weights_are_fine_with_a_known_theta(self, api):
+        df = api.with_columns(
+            [(pl.col("pw") * (1.0 + 0.01 * i)).alias(f"rep_{i}") for i in range(1, 21)]
+        )
+        design = Design(
+            wgt="pw",
+            stratum="stype",
+            psu="dnum",
+            rep_wgts=RepWeights(method="Bootstrap", prefix="rep_", n_reps=20),
+        )
+
+        res = Sample(df, design).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", theta=2.5, tol=1e-10
+        )
+
+        assert all(c.se > 0 for c in res.coefs)
+
+
+class TestDomain:
+    def test_where_restricts_the_fit(self, api):
+        """A domain fit equals the same model on the filtered frame."""
+        domain = Sample(api, DESIGNS["weights_only"]).glm.fit(
+            y=Y,
+            x=X_COLS,
+            family="negative_binomial",
+            where=svy.col("stype") == "E",
+            tol=TOL_TIGHT,
+        )
+        filtered = Sample(api.filter(pl.col("stype") == "E"), DESIGNS["weights_only"]).glm.fit(
+            y=Y, x=X_COLS, family="negative_binomial", tol=TOL_TIGHT
+        )
+
+        np.testing.assert_allclose(
+            [c.est for c in domain.coefs], [c.est for c in filtered.coefs], rtol=1e-7
+        )
+        np.testing.assert_allclose(domain.stats.theta, filtered.stats.theta, rtol=1e-7)


### PR DESCRIPTION
Closes the last open item on the regression roadmap.

`family="negative_binomial"` (or `"nb"`), `Var(μ) = μ + μ²/θ`, with R's `okLinks`: `log`, `identity`, `sqrt`.

```python
m = sample.glm.fit(y="visits", x=["age", svy.Cat("region")], family="nb")
m.fitted.stats.theta, m.fitted.stats.theta_se
```

## The variance

There is no negative binomial in `survey` itself, so which reference applies depends on whether θ is estimated — and so does what svy computes.

**θ estimated** (the default). θ is a parameter, so the variance spans it: the joint `(β, θ)` sandwich, which is `survey::svymle`'s route — Lumley's method for this model in *Complex Surveys* (Appendix E, p254ff), and what `sjstats::svyglm.nb` implements. `stats.theta_se` is the design-based standard error of the dispersion itself.

**θ supplied.** Then it is known, not estimated: no row for it, the variance conditions on it (matching `svyglm(family = MASS::negative.binomial(theta))`), and `stats.theta_se` is `None`.

These are not two routes to one number. β̂ is identical to ~1e-8 either way — the NB IRLS score `θ(y−μ)/(θ+μ)` *is* the joint ML score w.r.t. η — but the standard errors differ:

| | conditional | joint | ratio |
|---|---|---|---|
| apistrat, `enroll ~ ell+meals+mobility` — intercept | 0.100300 | 0.093017 | 0.93 |
| — ell | 0.0026542 | 0.0030116 | 1.13 |
| — mobility | 0.0039050 | 0.0029125 | **0.75** |
| Lumley's NHANES example — intercept | 0.096912 | 0.107268 | 1.11 |
| — log(age) | 0.125573 | 0.141258 | **1.12** |

The orthogonality that makes the two agree asymptotically (`∂/∂θ E[score_β] = 0`) is a property of the *model*, and a design-based sandwich is precisely the thing that declines to assume it.

On a replicate-weight design an estimated θ raises: the spread of the refits would only mean something if each replicate re-estimated it. Pass `theta=` there.

## All of it is in the kernel

Same as every other family — the dispersion loop and the joint variance included. That needed the special functions written out, for the same reason `norm_cdf` already was:

- **`regression::special`** — `lgamma`, `digamma`, `trigamma`. Each recurs to `x ≥ 20` then sums the asymptotic series; all three agree with R to 1e-14 relative over `[0.1, 1000]`, and the tests also check the recurrences across the switchover and trigamma against a numeric derivative of digamma.
- **`regression::negbin`** — `theta_ml` (`MASS::theta.ml`), the `MASS::glm.nb` outer loop alternating it with IRLS, and the joint variance. Its convergence test is R's made relative: the weighted log-likelihood is O(1e4), so an absolute test could never reach a `tol` of 1e-12 however converged θ is.
- **`fit_glm_domain` gains `want_variance`** — the θ loop refits β several times and wants nothing else, and the sandwich is the costly part of a fit. `fit_one` is the new single dispatch point over families.
- **`design_vcov_rs`** exposes `svyrecvar`; the GLM sandwich's own meat now runs through it too.
- **`Link::mu_eta2`**, for the joint bread. Arms for all nine links.

1e6 × 20 counts: 3.0 s with θ estimated, 0.55 s at a known θ, against 0.68 s for Poisson. An earlier Python/scipy version of the same thing took 6.9 s and put the variance outside the kernel; this replaces it.

## Verification

Four designs against `svymle` (SEs to 1e-6, θ to 8e-9, SE(θ) to 2e-8) and against `svyglm` at fixed θ (to 1e-8). References generated by `scripts/gen_r_reference.R`, which now emits both. 28 new tests; full suite 3678 passed, 1 skipped. `make bench-check` clean.

Docs: `docs/tutorials/glm.qmd` in the docs repo gains the family, the links and an "Overdispersed counts" section — uncommitted there.
