### PR TITLE
fix: pin explode's empty_as_null before polars 2.0 flips it

### DIFF
--- a/packages/svy/CHANGELOG.md
+++ b/packages/svy/CHANGELOG.md
@@ -6,6 +6,14 @@ Companion packages track their own changes: [`svy-io`](../svy-io/CHANGELOG.md) (
 
 ## [Unreleased]
 
+### Fixed
+
+- **`svy.col(...).explode()` will not change behaviour under polars 2.0.** polars 1.44 deprecates the default of its `empty_as_null`, and 2.0 flips it: an empty list would stop yielding a null row and yield no row at all. A row that disappears on a dependency upgrade is one fewer observation in whatever is estimated downstream, so svy passes the argument explicitly and keeps today's behaviour. `explode(empty_as_null=False)` selects the other one.
+
+  This raises the polars floor to **1.36.1**, where `empty_as_null` was added (1.35.1 does not have it). The alternative was a runtime version check, and svy has none anywhere else.
+
+  On polars ≥ 1.44 the deprecation warning is also gone; because the test suite escalates `DeprecationWarning` to an error, `test_explode` had been failing there and passing locally only on the lockfile's pinned 1.39.3.
+
 ## [0.28.0] — 2026-09-08
 
 ### Added

--- a/packages/svy/pyproject.toml
+++ b/packages/svy/pyproject.toml
@@ -26,7 +26,9 @@ dependencies = [
   # Below it, every clone silently skipped the normalization that keeps
   # value labels as ValueLabel pairs (see CHANGELOG, value-label clone fix).
   "msgspec>=0.21.0",
-  "polars[pyarrow]>=1.33.1",
+  # 1.36.1 is where Expr.explode gained empty_as_null, which svy passes
+  # explicitly so polars 2.0 cannot flip it underneath a survey estimate.
+  "polars[pyarrow]>=1.36.1",
   "scipy>=1.13",
   "svy-io>=0.4.0,<0.5.0",
   "svy-rs>=0.17.0,<0.18.0",

--- a/packages/svy/src/svy/core/expr.py
+++ b/packages/svy/src/svy/core/expr.py
@@ -852,9 +852,19 @@ class Expr:
         """Reverse list."""
         return _typing.cast(T, Expr(self._e.list.reverse()))
 
-    def explode(self: T) -> T:
-        """Explode list into rows."""
-        return _typing.cast(T, Expr(self._e.explode()))
+    def explode(self: T, empty_as_null: bool = True) -> T:
+        """
+        Explode a list into rows.
+
+        `empty_as_null` decides what an empty list becomes: `True` (the
+        default) yields one null row, `False` yields no row at all.
+
+        It is passed explicitly rather than left to polars because polars 2.0
+        flips its own default to `False`. A survey estimate should not move
+        because a dependency was upgraded, and a dropped row is one fewer
+        observation — so svy pins the behaviour and lets the caller choose.
+        """
+        return _typing.cast(T, Expr(self._e.explode(empty_as_null=empty_as_null)))
 
     # -------------------------------------------------------------------------
     # Sorting

--- a/packages/svy/tests/svy/core/test_describe.py
+++ b/packages/svy/tests/svy/core/test_describe.py
@@ -163,7 +163,18 @@ def test_describe_str_and_repr_dont_crash(sample: Sample):
     r = repr(res)
     # sanity checks
     assert "Describe" in s
+    assert "DescribeResult(" in r
+
+
+@pytest.mark.optional  # the per-type sections are the Rich rendering
+def test_describe_str_lists_each_column_type(sample: Sample):
+    """Without Rich, __str__ falls back to the header block and stops there."""
+    pytest.importorskip("rich", reason="the per-type sections need Rich")
+
+    res = sample.describe(columns=["income", "sex", "is_urban"], weighted=False, top_k=5)
+
+    s = str(res)
+
     assert "Numeric" in s
     assert "Categorical" in s
     assert "Boolean" in s
-    assert "DescribeResult(" in r

--- a/packages/svy/tests/svy/core/test_expr.py
+++ b/packages/svy/tests/svy/core/test_expr.py
@@ -778,6 +778,27 @@ def test_explode():
     assert out["nums"].to_list() == [1, 2, 3, 4, 5]
 
 
+def test_explode_keeps_an_empty_list_as_a_null_row():
+    """
+    svy pins `empty_as_null=True`; polars 2.0 flips its own default to False.
+    A row that silently disappears on a dependency upgrade is one fewer
+    observation in whatever is estimated downstream.
+    """
+    df = pl.DataFrame({"nums": [[1, 2], [], [3]]})
+
+    out = df.select(col("nums").explode()._e)
+
+    assert out["nums"].to_list() == [1, 2, None, 3]
+
+
+def test_explode_can_drop_empty_lists_instead():
+    df = pl.DataFrame({"nums": [[1, 2], [], [3]]})
+
+    out = df.select(col("nums").explode(empty_as_null=False)._e)
+
+    assert out["nums"].to_list() == [1, 2, 3]
+
+
 # =============================================================================
 # Sorting
 # =============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -2407,7 +2407,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "msgspec", specifier = ">=0.21.0" },
     { name = "numpy", specifier = ">=2.0" },
-    { name = "polars", extras = ["pyarrow"], specifier = ">=1.33.1" },
+    { name = "polars", extras = ["pyarrow"], specifier = ">=1.36.1" },
     { name = "rich", marker = "extra == 'all'", specifier = ">=14.1" },
     { name = "rich", marker = "extra == 'report'", specifier = ">=14.1" },
     { name = "scipy", specifier = ">=1.13" },


### PR DESCRIPTION
Both issues found by the clean-venv check during the 0.28.0 release ([#172](https://github.com/samplics-org/svy/pull/172)). Neither is a regression — a user on polars 1.44 hits the first with 0.27.0 today.

## `explode` and polars 2.0

polars 1.44 deprecates the default of `Expr.explode`'s `empty_as_null`, and **2.0 flips it**: an empty list stops yielding a null row and yields no row at all. A row that disappears because a dependency was upgraded is one fewer observation in whatever is estimated downstream, so svy now passes the argument explicitly and keeps today's behaviour. The parameter is exposed, so `explode(empty_as_null=False)` selects the other one.

### Why the floor moved rather than a version check

`empty_as_null` does not exist at the declared floor — verified directly:

| polars | `Expr.explode` |
|---|---|
| 1.33.1 | `(self)` — passing the kwarg raises `TypeError` |
| 1.34.0 | absent |
| 1.35.1 | absent |
| **1.36.1** | **present** |
| 1.39.3 (lockfile) | present, default `True` |
| 1.44.1 | present, sentinel default + deprecation warning |

So the floor goes to **1.36.1**. The alternative was detecting the parameter at import and dispatching, but svy has no runtime version branching anywhere in `src/` — this would be the only one, for the three superseded releases in 1.33.1–1.35.1.

### The test never covered the semantics

`test_explode` used `[[1, 2], [3, 4, 5]]` — no empty list — so it was failing on polars ≥ 1.44 purely on the warning, and passing locally only because the lockfile pins 1.39.3. Two tests now cover the actual behaviour, one per setting.

## The Rich-dependent describe test

`test_describe_str_and_repr_dont_crash` asserted on `Numeric`/`Categorical`/`Boolean` section headers that only the Rich rendering emits, so it failed in a venv without Rich. Without it, `__str__` falls back to the header block and stops.

The crash check its name promises stays unconditional; the section assertions move to their own test that skips when Rich is absent. That follows the marker-plus-skip pattern already in `tests/svy/errors/test_method_errors.py` — worth noting that `@pytest.mark.optional` alone would not have fixed it, since nothing deselects that marker in CI or the makefile.

## Verified

| environment | result |
|---|---|
| polars 1.36.1 (new floor), no Rich | 3677 passed, 4 skipped |
| polars 1.44.1, no Rich | 3677 passed, 4 skipped — the combination that failed twice before |
| dev environment (polars 1.39.3, Rich present) | 3681 passed, 1 skipped |

`explode` returns `[1, 2, None, 3]` by default and `[1, 2, 3]` with `empty_as_null=False` identically on 1.36.1 and 1.44.1, with no `DeprecationWarning` on either.

## Ordering

#172 has merged, so this lands after 0.28.0 and sits under a fresh
`[Unreleased]`. That means **0.28.0 ships with the old floor and the polars 2.0
behaviour flip still live** — worth a 0.28.1 reasonably soon rather than letting
it ride to the next minor, since the failure mode is silent.

Rebased onto `main` after #172; the conflict was my changelog entry landing where
the `[0.28.0]` heading went, plus the lockfile.
